### PR TITLE
php-unit-tests // set custom environment variables via secrets

### DIFF
--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -22,6 +22,9 @@ on:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
         required: false
+      ENV_VARS:
+        description: Allows to inject ENV variables as JSON string with name and value as keys.
+        required: false
 
 jobs:
   tests-unit-php:
@@ -40,6 +43,17 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+
+      - name: Set up custom environment variables
+        env:
+          ENV_VARS: ${{ secrets.ENV_VARS }}
+        if: ${{ env.ENV_VARS }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            JSON
+              .parse(process.env.ENV_VARS)
+              .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -23,7 +23,7 @@ on:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
         required: false
       ENV_VARS:
-        description: Allows to inject ENV variables as JSON string with name and value as keys.
+        description: Additional environment variables as a JSON formatted object.
         required: false
 
 jobs:

--- a/docs/php.md
+++ b/docs/php.md
@@ -126,6 +126,7 @@ jobs:
 | Name                 | Description                                                                              |
 |----------------------|------------------------------------------------------------------------------------------|
 | `COMPOSER_AUTH_JSON` | Authentication for privately hosted packages and repositories as a JSON formatted object |
+| `ENV_VARS`           | Additional environment variables as a JSON formatted object                              |
 
 **Example with configuration parameters:**
 
@@ -142,4 +143,6 @@ jobs:
       PHP_MATRIX: >-
         ["7.4", "8.0", "8.1"]
       PHPUNIT_ARGS: '--coverage-text --debug'
+      ENV_VARS: >-
+        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}, {"name":"EXAMPLE_TOKEN", "value":"${{ secrets.EXAMPLE_TOKEN }}"}]
 ```


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

----
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This feature introduces a new secrets into our reusable workflow tests-unit-php.yml called `ENV_VARS`. This variable allows to set a JSON string with following schema:

```json
{
	"title": "ENV_VARS",
	"description": "Configuration of custom enviornment variables for reusable workflows.",
	"type": "array",
	"items": {
		"type": "object",
		"properties": {
			"name": {
				"type": "string",
			},
			"value": {
				"type": "string",
			}
		}
	}
}
```

----

**What is the current behavior?** (You can also link to an open issue here)

Currently it is not possible to set custom environments variables into reusable workflows since those are running isolated and do not have access to the enviornment variables of the "executing workflow".

**What is the new behavior (if this is a feature change)?**

With this Pull Request we're now able to set a JSON string as `secrets.ENV_VARS` to inject this into reusable workflows on PHP Unit Tests.

Example 1: Default behavior does not change:

```yaml
test-no-env-vars:
  uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@main
  secrets:
    COMPOSER_AUTH_JSON: ${{secrets.PACKAGIST_AUTH_JSON}}
```

Example 2: Invalid ENV_VAR input will fail:

```yaml
test-invalid-json:
  uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@main
  secrets:
    COMPOSER_AUTH_JSON: ${{secrets.PACKAGIST_AUTH_JSON}}
    ENV_VARS: 'foo'
```

Example 3: Valid input with `secrets.{NAME}` injected as environment variable into reusable workflow:

```yaml
## Multiple values with secrets
test-valid-json:
  uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@main
  secrets:
    COMPOSER_AUTH_JSON: ${{secrets.PACKAGIST_AUTH_JSON}}
    ENV_VARS: >-
       [{"name":"random_string", "value":"actually i am static."}, {"name":"the_secret", "value":"${{secrets.I_AM_A_SECRET}}"}]
```

----

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:
