### PR TITLE
Add source code syntax check

### DIFF
--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -55,6 +55,9 @@ jobs:
               .parse(process.env.ENV_VARS)
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
+      - name: Check source code syntax
+        run: find . -type f -name '*.php' -print0 | xargs -0 -L 1 -P 4 -- php -l
+
       - name: Set up problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 


### PR DESCRIPTION
Adds a basic source code syntax check via `php -l` for all `.php` files in repo.
This can detect that e.g. PHP 8 syntax is used in a project that must support PHP 7.

At first I thought that it needs a parameter for excluding dirs like `vendor` (via `-name 'MYDIR' -prune -o`), but actually it is probably not needed if running at the beginning before installing deps.