### PR TITLE
Fix build and push assets create tag

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -150,5 +150,5 @@ jobs:
         if: ${{ always() && (env.TAG_BRANCH_NAME != '' && env.NO_CHANGES != 'yes') }}
         run: |
           git checkout --detach
-          git branch -d {{ env.TAG_BRANCH_NAME }}
-          git push origin --delete {{ env.TAG_BRANCH_NAME }}
+          git branch -d ${{ env.TAG_BRANCH_NAME }}
+          git push origin --delete ${{ env.TAG_BRANCH_NAME }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           # when current push is a tag, we check out the tag's SHA, we'll create a new branch later
           ref: ${{ ((github.ref_type == 'tag') && github.sha) || github.ref }}
 

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -147,7 +147,7 @@ jobs:
           git push origin --tags
 
       - name: Delete tag branch
-        if: ${{ env.TAG_BRANCH_NAME != '' && env.NO_CHANGES != 'yes' }}
+        if: ${{ always() && (env.TAG_BRANCH_NAME != '' && env.NO_CHANGES != 'yes') }}
         run: |
           git checkout --detach
           git branch -d {{ env.TAG_BRANCH_NAME }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Docs have been added/updated (for bug fixes/features)

----

## What is the current behavior? (You can also link to an open issue here)

Currently, when creating a tag the reusable workflow `build-and-push-assets` fails in the "Move tag" step with the following:

```cli
Run git tag -d {tag name}
error: tag ' {tag name}' not found.
Error: Process completed with exit code 1.
```

This is caused by `actions/checkout@v3` where the `fetch-depth` defaults to `1` so it only fetches the latest (current) commit. 

Additionally, the "Delete tag branch" step is never executed which causes more and more branches to be created for compiled assets that are never being deleted.

----

## What is the new behavior (if this is a feature change)?

This PR introduces the following 2 fixes:

**1. Delete tag branch on failure**

The "Delete tag branch" step now contains an `always()` expression in the `if` condition to be executed always if we're currently working on a tag push.

**2. Fix "Move tag"**

The `actions/checkout@v3` uses by default `fetch-depth: 1` which misses tags and branches and only checkouts the current commit. This causes a failure when trying to run `git tag -d {tag name}` because the current tag is not locally available.

By setting the `fetch-depth` to `0` we ensure that the complete git history is checked out.

----

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes, because the action will not work ;) 

----

## Other information:

May we live to learn well
and learn to live well.