### PR TITLE
Add support for SSH config for Git

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -49,7 +49,7 @@ on:
         description: Github Username used in "git config".
         required: true
       GITHUB_USER_SSH_KEY:
-        description: Private SSH key associated to the GitHub user in "GITHUB_USER_NAME".
+        description: Private SSH key associated to the GitHub user in Github Username.
         required: false
 
 jobs:

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -85,7 +85,7 @@ jobs:
           echo "TAG_NAME=$(echo ${GITHUB_REF#refs/*/})" >> $GITHUB_ENV
           echo "COMPILE_SCRIPT=${{ inputs.COMPILE_SCRIPT_PROD }}" >> $GITHUB_ENV
 
-      - name: Setup SSH
+      - name: Set up SSH
         if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
         uses: webfactory/ssh-agent@v0.5.4
         with:

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -48,9 +48,10 @@ on:
       GITHUB_USER_NAME:
         description: Github Username used in "git config".
         required: true
-      GH_TOKEN:
-        description: Github Api Token to access third party packages.
+      GITHUB_USER_SSH_KEY:
+        description: Private SSH key associated to the GitHub user in "GITHUB_USER_NAME".
         required: false
+
 jobs:
   compile-assets:
     timeout-minutes: 10
@@ -83,6 +84,12 @@ jobs:
         run: |
           echo "TAG_NAME=$(echo ${GITHUB_REF#refs/*/})" >> $GITHUB_ENV
           echo "COMPILE_SCRIPT=${{ inputs.COMPILE_SCRIPT_PROD }}" >> $GITHUB_ENV
+
+      - name: Setup SSH
+        if: ${{ secrets.GITHUB_USER_SSH_KEY }}
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Setup Git
         run: |

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -49,7 +49,7 @@ on:
         description: Github Username used in "git config".
         required: true
       GITHUB_USER_SSH_KEY:
-        description: Private SSH key associated to the GitHub user in Github Username.
+        description: Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`
         required: false
 
 jobs:

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
       COMPILE_SCRIPT: ${{ inputs.COMPILE_SCRIPT_DEV }} # we'll override if the push is for tag
       TAG_NAME: ''                                     # we'll override if the push is for tag
       TAG_BRANCH_NAME: ''                              # we'll override if the push is for tag
@@ -85,7 +86,7 @@ jobs:
           echo "COMPILE_SCRIPT=${{ inputs.COMPILE_SCRIPT_PROD }}" >> $GITHUB_ENV
 
       - name: Setup SSH
-        if: ${{ secrets.GITHUB_USER_SSH_KEY }}
+        if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -57,7 +57,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       COMPILE_SCRIPT: ${{ inputs.COMPILE_SCRIPT_DEV }} # we'll override if the push is for tag
       TAG_NAME: ''                                     # we'll override if the push is for tag

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -48,14 +48,15 @@ on:
       GITHUB_USER_NAME:
         description: Github Username used in "git config".
         required: true
-      GITHUB_TOKEN:
+      GH_TOKEN:
         description: Github Api Token to access third party packages.
-        required: true  
+        required: false
 jobs:
   compile-assets:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       COMPILE_SCRIPT: ${{ inputs.COMPILE_SCRIPT_DEV }} # we'll override if the push is for tag
       TAG_NAME: ''                                     # we'll override if the push is for tag
@@ -107,7 +108,7 @@ jobs:
           [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "LOCK_FILE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
           [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "LOCK_FILE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
           [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "LOCK_FILE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
-          
+
       - name: Warning for fallback package manager
         if: ${{ (inputs.PACKAGE_MANAGER == 'auto') && (env.LOCK_FILE == '') }}
         run: echo "::warning::PACKAGE_MANAGER input not defined, and no lock file found, using Yarn as default."

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -48,6 +48,9 @@ on:
       GITHUB_USER_NAME:
         description: Github Username used in "git config".
         required: true
+      GITHUB_TOKEN:
+        description: Github Api Token to access third party packages.
+        required: true  
 jobs:
   compile-assets:
     timeout-minutes: 10

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -186,3 +186,15 @@ If the release is created for an existing tag, the only care you need is waiting
 Unfortunately, creating a release via GitHub UI for a non-existing tag is **incompatible** with this workflow. GitHub in that case would first create a tag and then associate the release with it. However, that tag creation would not trigger the workflow. Hence, the release will point to a tag that does not contain assets. And even if the workflow is configured to run on release publishing, the workflow will fail because there's no "current branch" on release, so the workflow would try to push a commit made in a "detached HEAD" status, failing.
 
 In theory, it is possible to make the workflow 100% compliant with a release via UI. However (as of now), the complexity needed has been judged not worthwhile the effort.
+
+---
+
+
+
+> *I use `git+ssh` requirements in my `package.json`, how do I make those work with this workflow?*
+
+The workflow supports a private SSH key to be passed via the `GITHUB_USER_SSH_KEY` secret.
+
+By passing a key that is associated with the GitHub user defined in the required `GITHUB_USER_NAME`, the workflow will be able to install those packages.
+
+Please consider that in such cases it is a good practice to do not use a "personal" GitHub user, but an _ad-hoc_ "bot" user, with an _ad-hoc_ private SSH key only used for the scope.

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -86,12 +86,12 @@ This is not the "simplest" possible example, but it showcases all the recommenda
 
 ## Secrets
 
-| Name                  | Description                                                          |
-|-----------------------|----------------------------------------------------------------------|
-| `NPM_REGISTRY_TOKEN`  | Authentication for the private npm registry.                         |
-| `GITHUB_USER_EMAIL`   | GitHub User email used in `git config`.                              |
-| `GITHUB_USER_NAME`    | GitHub User name used in `git config`.                               |
-| `GITHUB_USER_SSH_KEY` | Private SSH key associated to the GitHub user in "GITHUB_USER_NAME". |
+| Name                  | Description                                                                   |
+|-----------------------|-------------------------------------------------------------------------------|
+| `NPM_REGISTRY_TOKEN`  | Authentication for the private npm registry.                                  |
+| `GITHUB_USER_EMAIL`   | GitHub User email used in `git config`.                                       |
+| `GITHUB_USER_NAME`    | GitHub User name used in `git config`.                                        |
+| `GITHUB_USER_SSH_KEY` | Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`. |
 
 
 
@@ -197,4 +197,4 @@ The workflow supports a private SSH key to be passed via the `GITHUB_USER_SSH_KE
 
 By passing a key that is associated with the GitHub user defined in the required `GITHUB_USER_NAME`, the workflow will be able to install those packages.
 
-Please consider that in such cases it is a good practice to do not use a "personal" GitHub user, but an _ad-hoc_ "bot" user, with an _ad-hoc_ private SSH key only used for the scope.
+Please consider that in such cases it is a good practice to not use a "personal" GitHub user, but an _ad-hoc_ "bot" user, with an _ad-hoc_ private SSH key only used for the scope.

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -86,11 +86,12 @@ This is not the "simplest" possible example, but it showcases all the recommenda
 
 ## Secrets
 
-| Name                 | Description                                  |
-| -------------------- | -------------------------------------------- |
-| `NPM_REGISTRY_TOKEN` | Authentication for the private npm registry. |
-| `GITHUB_USER_EMAIL`  | GitHub User email used in `git config`.      |
-| `GITHUB_USER_NAME`   | GitHub User name used in `git config`.       |
+| Name                  | Description                                                          |
+|-----------------------|----------------------------------------------------------------------|
+| `NPM_REGISTRY_TOKEN`  | Authentication for the private npm registry.                         |
+| `GITHUB_USER_EMAIL`   | GitHub User email used in `git config`.                              |
+| `GITHUB_USER_NAME`    | GitHub User name used in `git config`.                               |
+| `GITHUB_USER_SSH_KEY` | Private SSH key associated to the GitHub user in "GITHUB_USER_NAME". |
 
 
 


### PR DESCRIPTION
# Context

Both Yarn and NPM support having in `package.json` [direct Git URLs](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#git-urls-as-dependencies).

When using the `git+ssh` protocol in such requirements (which is pretty common) a private SSH key needs to be set up.

Of course, the SSH key should be treated as a secret.


# How to

This PR introduces a new secret that should contain a private SSH key. The key, if provided, is "forwarded" to the workflow system by the means of the ready-made, pretty popular [`webfactory/ssh-agent`](https://github.com/webfactory/ssh-agent) action.