### PR TITLE
Add support to configure the PHP version for the build-assets-compilation workflow

### DIFF
--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -23,6 +23,11 @@ on:
         default: '-v --env=root'
         required: false
         type: string
+      PHP_VERSION:
+        description: PHP version with which the coding standard analysis is to be executed.
+        default: 7.4
+        required: false
+        type: string
     secrets:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
@@ -51,7 +56,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: ${{ inputs.PHP_VERSION }}
           tools: composer
 
       - name: Install Composer dependencies

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -3,6 +3,11 @@ name: Assets compilation
 on:
   workflow_call:
     inputs:
+      PHP_VERSION:
+        description: PHP version with which the coding standard analysis is to be executed.
+        default: 7.4
+        required: false
+        type: string
       NPM_REGISTRY_DOMAIN:
         description: Domain of the private npm registry.
         default: https://npm.pkg.github.com/
@@ -21,11 +26,6 @@ on:
       COMPILE_ASSETS_ARGS:
         description: Set of arguments passed to Composer Asset Compiler.
         default: '-v --env=root'
-        required: false
-        type: string
-      PHP_VERSION:
-        description: PHP version with which the coding standard analysis is to be executed.
-        default: 7.4
         required: false
         type: string
     secrets:

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -20,12 +20,13 @@ jobs:
 
 #### Inputs
 
-| Name                  | Default                       | Description                                         |
-|-----------------------|-------------------------------|-----------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                  |
-| `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled |
-| `COMPOSER_ARGS`       | `'--prefer-dist'`             | Set of arguments passed to Composer                 |
-| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`             | Set of arguments passed to Composer Asset Compiler  |
+| Name                  | Default                       | Description                                                           |
+|-----------------------|-------------------------------|-----------------------------------------------------------------------|
+| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                    |
+| `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled                   |
+| `COMPOSER_ARGS`       | `'--prefer-dist'`             | Set of arguments passed to Composer                                   |
+| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`             | Set of arguments passed to Composer Asset Compiler                    |
+| `PHP_VERSION`         | 7.4                           | PHP version with which the coding standard analysis is to be executed |
 
 #### Secrets
 


### PR DESCRIPTION
Add support to configure the PHP version for the build-assets-compilation workflow.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

**What is the current behavior?** (You can also link to an open issue here)

There is no way to configure the PHP version for the assets-compilation workflow. 


**What is the new behavior (if this is a feature change)?**

Add a new input variable, `PHP_VERSION` to define a different version than the default one


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

**Other information**:
