### PR TITLE
workflows // set "coverage: none" 

### DIFF
--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           tools: composer
+          coverage: none
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v1

--- a/.github/workflows/coding-standards-php.yml
+++ b/.github/workflows/coding-standards-php.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           tools: composer, cs2pr
+          coverage: none
 
       - name: Validate composer.json and composer.lock
         run: composer validate

--- a/.github/workflows/static-analysis-php.yml
+++ b/.github/workflows/static-analysis-php.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           tools: composer, cs2pr
+          coverage: none
 
       - name: Validate composer.json and composer.lock
         run: composer validate


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

**What is the current behavior?** (You can also link to an open issue here)
`shivammathur/setup-php` is used without any code coverage settings while it is not required for static analysis and coding standards or assets building. Only `tests-unit-php.yml` with PHPUnit makes use of the php-code-coverage. 

**What is the new behavior (if this is a feature change)?**
Remove coverage when not needed. This can/will improve run times. See https://github.com/marketplace/actions/setup-php-action#disable-coverage

**Additonal information**
Fixes #7