### PR TITLE
docs: add note about missing PHP matrix support

### DIFF
--- a/docs/php.md
+++ b/docs/php.md
@@ -48,7 +48,7 @@ jobs:
       PHPCS_ARGS: '--report=summary'
 ```
 
-**Note**: Coding standards analysis can only be performed with a specific PHP version and not in a PHP matrix, as it should always be tested with the highest PHP version in use. To check the compatibility of the code with multiple PHP versions, use the [Lint PHP](#lint-php) workflow.
+**Note**: Coding standards analysis can only be performed with a specific PHP version and not in a PHP matrix, as it should always be tested with the highest PHP version in use. To check compatibility with multiple PHP versions, use the [Lint PHP](#lint-php) workflow.
 
 
 ## Static code analysis
@@ -98,7 +98,7 @@ jobs:
       PSALM_ARGS: '--threads=3'
 ```
 
-**Note**: Static code analysis can only be performed with a specific PHP version and not in a PHP matrix, as it should always be tested with the highest PHP version in use. To check the compatibility of the code with multiple PHP versions, use the [Lint PHP](#lint-php) workflow.
+**Note**: Static code analysis can only be performed with a specific PHP version and not in a PHP matrix, as it should always be tested with the highest PHP version in use. To check compatibility with multiple PHP versions, use the [Lint PHP](#lint-php) workflow.
 
 ## Unit tests PHP
 

--- a/docs/php.md
+++ b/docs/php.md
@@ -48,6 +48,9 @@ jobs:
       PHPCS_ARGS: '--report=summary'
 ```
 
+**Note**: Coding standards analysis can only be performed with a specific PHP version and not in a PHP matrix, as it should always be tested with the highest PHP version in use. To check the compatibility of the code with multiple PHP versions, use the [Lint PHP](#lint-php) workflow.
+
+
 ## Static code analysis
 
 This workflow runs [Psalm](https://psalm.dev/). It does so by executing the binary in
@@ -94,6 +97,8 @@ jobs:
     with:
       PSALM_ARGS: '--threads=3'
 ```
+
+**Note**: Static code analysis can only be performed with a specific PHP version and not in a PHP matrix, as it should always be tested with the highest PHP version in use. To check the compatibility of the code with multiple PHP versions, use the [Lint PHP](#lint-php) workflow.
 
 ## Unit tests PHP
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update


**What is the current behavior?** (You can also link to an open issue here)
There have been several requests to extend coding standards analysis and/or static code analysis to support a PHP matrix. However, this does not make sense and the [Lint PHP](https://github.com/inpsyde/reusable-workflows/blob/main/docs/php.md#lint-php) workflow should be used instead.


**What is the new behavior (if this is a feature change)?**
Add a note in the documentation about why we don't support the PHP matrix in these workflows with a link to the Lint PHP section.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Closes #15.