### PR TITLE
docs: add note about required Jest version

### DIFF
--- a/docs/js.md
+++ b/docs/js.md
@@ -74,6 +74,8 @@ jobs:
 | `NODE_VERSION`        | 16                                                 | Node version with which the unit tests are to be executed |
 | `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                           |
 
+**Note**: The default `github-actions` reporter requires Jest 28 or higher.
+
 #### Secrets
 
 | Name                 | Description                                 |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update


**What is the current behavior?** (You can also link to an open issue here)
When the JavaScript unit tests (Jest) are run with an outdated Jest version (<28), they will fail with this error:
```
Error: Could not resolve a module for a custom reporter.
  Module name: github-actions
```


**What is the new behavior (if this is a feature change)?**
Add a note in the documentation about the required Jest version 28+.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
Source: https://jestjs.io/blog/2022/04/25/jest-28#github-actions-reporter
Closes #14