### PR TITLE
Allow customizing package manager

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: string
       PACKAGE_MANAGER:
-        description: Package manager. Supported are "yarn" and "npm".
+        description: Package manager with which the dependencies should be installed (`npm` or yarn`).
         type: string
         default: "auto"
         required: false
@@ -124,7 +124,7 @@ jobs:
         if: ${{ (env.LOCK_FILE == 'npm') || (inputs.PACKAGE_MANAGER == 'npm') }}
         run: echo "PACKAGE_MANAGER=npm" >> $GITHUB_ENV
 
-      - name: Cache npm/Yarn dependencies
+      - name: Cache dependencies
         uses: actions/cache@v3
         with:
           path: ~/.deps_cache

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -135,10 +135,10 @@ jobs:
 
       - name: Install dependencies
         if: ${{ inputs.DEPS_INSTALL }}
-        run: ${{ ((env.PACKAGE_MANAGER == 'npm') && 'npm install') || 'yarn' }}
+        run: ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
 
       - name: Compile assets
-        run: ${{ ((env.PACKAGE_MANAGER == 'npm') && 'npm run') || 'yarn' }} ${{ env.COMPILE_SCRIPT }}
+        run: ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm run' }} ${{ env.COMPILE_SCRIPT }}
 
       - name: Git add, commit, push
         run: |

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -73,12 +73,6 @@ jobs:
           # when current push is a tag, we check out the tag's SHA, we'll create a new branch later
           ref: ${{ ((github.ref_type == 'tag') && github.sha) || github.ref }}
 
-      - name: Set up node
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ inputs.NODE_VERSION }}
-          registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-
       - name: Set production environment variables
         if: ${{ contains(github.ref, 'refs/tags/') }}
         run: |
@@ -124,17 +118,16 @@ jobs:
         if: ${{ (env.LOCK_FILE == 'npm') || (inputs.PACKAGE_MANAGER == 'npm') }}
         run: echo "PACKAGE_MANAGER=npm" >> $GITHUB_ENV
 
-      - name: Cache dependencies
-        uses: actions/cache@v3
+      - name: Set up node
+        uses: actions/setup-node@v3
         with:
-          path: ~/.deps_cache
-          key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ env.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
+          node-version: ${{ inputs.NODE_VERSION }}
+          registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
+          cache: ${{ env.PACKAGE_MANAGER }}
 
       - name: Install dependencies
         if: ${{ ! startsWith( 'no', inputs.DEPS_INSTALL ) }}
-        run: |
-          ${{ ((env.PACKAGE_MANAGER == 'npm') && 'npm config set cache ~/.deps_cache --global') || 'yarn config set cache-folder ~/.deps_cache' }}
-          ${{ ((env.PACKAGE_MANAGER == 'npm') && 'npm install') || 'yarn' }}
+        run: ${{ ((env.PACKAGE_MANAGER == 'npm') && 'npm install') || 'yarn' }}
 
       - name: Compile assets
         run: ${{ ((env.PACKAGE_MANAGER == 'npm') && 'npm run') || 'yarn' }} ${{ env.COMPILE_SCRIPT }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
       PACKAGE_MANAGER:
-        description: Package manager with which the dependencies should be installed (`npm` or yarn`).
+        description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
         type: string
         default: 'auto'
         required: false

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -3,39 +3,39 @@ name: Build and push assets
 on:
   workflow_call:
     inputs:
+      NPM_REGISTRY_DOMAIN:
+        description: Domain of the private npm registry.
+        default: https://npm.pkg.github.com/
+        required: false
+        type: string
       NODE_VERSION:
         description: Node version with which the assets will be compiled.
         default: 16
         required: false
         type: string
-      NPM_REGISTRY_DOMAIN:
-        description: Domain of the private npm registry.
-        default: "https://npm.pkg.github.com/"
-        required: false
-        type: string
       PACKAGE_MANAGER:
         description: Package manager with which the dependencies should be installed (`npm` or yarn`).
         type: string
-        default: "auto"
+        default: 'auto'
         required: false
       DEPS_INSTALL:
         description: Install dependencies before compiling?
         type: string
-        default: "yes"
+        default: 'yes'
         required: false
       COMPILE_SCRIPT_PROD:
         description: Script added to "npm run" or "yarn" to build production assets.
         type: string
-        default: "encore prod"
+        default: 'encore prod'
         required: false
       COMPILE_SCRIPT_DEV:
         description: Script added to "npm run" or "yarn" to build development assets.
         type: string
-        default: "encore dev"
+        default: 'encore dev'
         required: false
       ASSETS_TARGET_PATHS:
         description: Target path(s) for compiled assets.
-        default: "./assets"
+        default: './assets'
         required: false
         type: string
     secrets:
@@ -63,8 +63,8 @@ jobs:
       TAG_NAME: ''                                     # we'll override if the push is for tag
       TAG_BRANCH_NAME: ''                              # we'll override if the push is for tag
       LOCK_FILE: ''                                    # we'll override after checking files
-      PACKAGE_MANAGER: "yarn"                          # we'll override based on env/inputs
-      NO_CHANGES: ""                                   # we'll override if no changes to commit
+      PACKAGE_MANAGER: 'yarn'                          # we'll override based on env/inputs
+      NO_CHANGES: ''                                   # we'll override if no changes to commit
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -73,7 +73,7 @@ jobs:
           # when current push is a tag, we check out the tag's SHA, we'll create a new branch later
           ref: ${{ ((github.ref_type == 'tag') && github.sha) || github.ref }}
 
-      - name: Set up Node.js
+      - name: Set up node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.NODE_VERSION }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -3,9 +3,9 @@ name: Build and push assets
 on:
   workflow_call:
     inputs:
-      WORKING_DIRECTORY:
-        description: Working directory path.
-        default: './'
+      NPM_REGISTRY_DOMAIN:
+        description: Domain of the private npm registry.
+        default: https://npm.pkg.github.com/
         required: false
         type: string
       NODE_VERSION:
@@ -13,9 +13,9 @@ on:
         default: 16
         required: false
         type: string
-      NPM_REGISTRY_DOMAIN:
-        description: Domain of the private npm registry.
-        default: https://npm.pkg.github.com/
+      WORKING_DIRECTORY:
+        description: Working directory path.
+        default: './'
         required: false
         type: string
       PACKAGE_MANAGER:

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -43,17 +43,10 @@ jobs:
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.deps_cache
-          key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ inputs.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
+          cache: ${{ inputs.PACKAGE_MANAGER }}
 
       - name: Install dependencies
-        run: |
-          ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn config set cache-folder ~/.deps_cache') || 'npm config set cache ~/.deps_cache --global' }}
-          ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
+        run: ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
 
       - name: Run ESLint
         run: ./node_modules/.bin/eslint ${{ inputs.ESLINT_ARGS }}

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -20,7 +20,7 @@ on:
         type: string
       PACKAGE_MANAGER:
         description: Package manager with which the dependencies should be installed (`npm` or yarn`).
-        default: "npm"
+        default: 'npm'
         required: false
         type: string
     secrets:

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -18,6 +18,11 @@ on:
         default: '-o eslint_report.json -f json --ext .js,.jsx,.ts,.tsx ./resources'
         required: false
         type: string
+      PACKAGE_MANAGER:
+        description: Package manager. Supported are "yarn" and "npm".
+        default: "npm"
+        required: false
+        type: string
     secrets:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
@@ -39,16 +44,16 @@ jobs:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
 
-      - name: Cache npm dependencies
+      - name: Cache npm/Yarn dependencies
         uses: actions/cache@v3
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: ~/.deps_cache
+          key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ env.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
 
-      - name: Install npm dependencies
-        run: npm install
+      - name: Install dependencies
+        run: |
+          ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn config set cache-folder ~/.deps_cache') || 'npm config set cache ~/.deps_cache --global' }}
+          ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
 
       - name: Run ESLint
         run: ./node_modules/.bin/eslint ${{ inputs.ESLINT_ARGS }}

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -19,8 +19,8 @@ on:
         required: false
         type: string
       PACKAGE_MANAGER:
-        description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
-        default: 'npm'
+        description: Package manager with which the dependencies should be installed (`npm` or `yarn` (default)).
+        default: 'yarn'
         required: false
         type: string
     secrets:

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
       PACKAGE_MANAGER:
-        description: Package manager. Supported are "yarn" and "npm".
+        description: Package manager with which the dependencies should be installed (`npm` or yarn`).
         default: "npm"
         required: false
         type: string
@@ -44,7 +44,7 @@ jobs:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
 
-      - name: Cache npm/Yarn dependencies
+      - name: Cache dependencies
         uses: actions/cache@v3
         with:
           path: ~/.deps_cache

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -48,12 +48,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.deps_cache
-          key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ env.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
+          key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ inputs.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
 
       - name: Install dependencies
         run: |
-          ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn config set cache-folder ~/.deps_cache') || 'npm config set cache ~/.deps_cache --global' }}
-          ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
+          ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn config set cache-folder ~/.deps_cache') || 'npm config set cache ~/.deps_cache --global' }}
+          ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
 
       - name: Run ESLint
         run: ./node_modules/.bin/eslint ${{ inputs.ESLINT_ARGS }}

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
       PACKAGE_MANAGER:
-        description: Package manager with which the dependencies should be installed (`npm` or `yarn` (default)).
+        description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
         default: 'yarn'
         required: false
         type: string

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
       PACKAGE_MANAGER:
-        description: Package manager with which the dependencies should be installed (`npm` or yarn`).
+        description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
         default: 'npm'
         required: false
         type: string

--- a/.github/workflows/static-analysis-sass.yml
+++ b/.github/workflows/static-analysis-sass.yml
@@ -43,20 +43,13 @@ jobs:
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
+          cache: ${{ inputs.PACKAGE_MANAGER }}
 
       - name: Set up problem matchers for Stylelint
         uses: xt0rted/stylelint-problem-matcher@v1
 
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.deps_cache
-          key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ inputs.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
-
       - name: Install dependencies
-        run: |
-          ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn config set cache-folder ~/.deps_cache') || 'npm config set cache ~/.deps_cache --global' }}
-          ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
+        run: ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
 
       - name: Run Stylelint
         run: ./node_modules/.bin/stylelint ${{ inputs.STYLELINT_ARGS }}

--- a/.github/workflows/static-analysis-sass.yml
+++ b/.github/workflows/static-analysis-sass.yml
@@ -51,12 +51,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.deps_cache
-          key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ env.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
+          key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ inputs.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
 
       - name: Install dependencies
         run: |
-          ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn config set cache-folder ~/.deps_cache') || 'npm config set cache ~/.deps_cache --global' }}
-          ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
+          ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn config set cache-folder ~/.deps_cache') || 'npm config set cache ~/.deps_cache --global' }}
+          ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
 
       - name: Run Stylelint
         run: ./node_modules/.bin/stylelint ${{ inputs.STYLELINT_ARGS }}

--- a/.github/workflows/static-analysis-sass.yml
+++ b/.github/workflows/static-analysis-sass.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
       PACKAGE_MANAGER:
-        description: Package manager. Supported are "yarn" and "npm".
+        description: Package manager with which the dependencies should be installed (`npm` or yarn`).
         default: "npm"
         required: false
         type: string
@@ -47,7 +47,7 @@ jobs:
       - name: Set up problem matchers for Stylelint
         uses: xt0rted/stylelint-problem-matcher@v1
 
-      - name: Cache npm/Yarn dependencies
+      - name: Cache dependencies
         uses: actions/cache@v3
         with:
           path: ~/.deps_cache

--- a/.github/workflows/static-analysis-sass.yml
+++ b/.github/workflows/static-analysis-sass.yml
@@ -20,7 +20,7 @@ on:
         type: string
       PACKAGE_MANAGER:
         description: Package manager with which the dependencies should be installed (`npm` or yarn`).
-        default: "npm"
+        default: 'npm'
         required: false
         type: string
     secrets:

--- a/.github/workflows/static-analysis-sass.yml
+++ b/.github/workflows/static-analysis-sass.yml
@@ -18,6 +18,11 @@ on:
         default: './resources/**/*.scss'
         required: false
         type: string
+      PACKAGE_MANAGER:
+        description: Package manager. Supported are "yarn" and "npm".
+        default: "npm"
+        required: false
+        type: string
     secrets:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
@@ -42,16 +47,16 @@ jobs:
       - name: Set up problem matchers for Stylelint
         uses: xt0rted/stylelint-problem-matcher@v1
 
-      - name: Cache npm dependencies
+      - name: Cache npm/Yarn dependencies
         uses: actions/cache@v3
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: ~/.deps_cache
+          key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ env.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
 
-      - name: Install npm dependencies
-        run: npm install
+      - name: Install dependencies
+        run: |
+          ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn config set cache-folder ~/.deps_cache') || 'npm config set cache ~/.deps_cache --global' }}
+          ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
 
       - name: Run Stylelint
         run: ./node_modules/.bin/stylelint ${{ inputs.STYLELINT_ARGS }}

--- a/.github/workflows/static-analysis-sass.yml
+++ b/.github/workflows/static-analysis-sass.yml
@@ -20,7 +20,7 @@ on:
         type: string
       PACKAGE_MANAGER:
         description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
-        default: 'npm'
+        default: 'yarn'
         required: false
         type: string
     secrets:

--- a/.github/workflows/static-analysis-sass.yml
+++ b/.github/workflows/static-analysis-sass.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
       PACKAGE_MANAGER:
-        description: Package manager with which the dependencies should be installed (`npm` or yarn`).
+        description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
         default: 'npm'
         required: false
         type: string

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -18,6 +18,11 @@ on:
         default: '--reporters=default --reporters=github-actions'
         required: false
         type: string
+      PACKAGE_MANAGER:
+        description: Package manager. Supported are "yarn" and "npm".
+        default: "npm"
+        required: false
+        type: string
     secrets:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
@@ -39,16 +44,16 @@ jobs:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
 
-      - name: Cache npm dependencies
+      - name: Cache npm/Yarn dependencies
         uses: actions/cache@v3
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: ~/.deps_cache
+          key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ env.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
 
-      - name: Install npm dependencies
-        run: npm install
+      - name: Install dependencies
+        run: |
+          ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn config set cache-folder ~/.deps_cache') || 'npm config set cache ~/.deps_cache --global' }}
+          ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
 
       - name: Run Jest
         run: ./node_modules/.bin/jest ${{ inputs.JEST_ARGS }}

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -43,17 +43,10 @@ jobs:
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.deps_cache
-          key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ inputs.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
+          cache: ${{ inputs.PACKAGE_MANAGER }}
 
       - name: Install dependencies
-        run: |
-          ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn config set cache-folder ~/.deps_cache') || 'npm config set cache ~/.deps_cache --global' }}
-          ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
+        run: ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
 
       - name: Run Jest
         run: ./node_modules/.bin/jest ${{ inputs.JEST_ARGS }}

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -20,7 +20,7 @@ on:
         type: string
       PACKAGE_MANAGER:
         description: Package manager with which the dependencies should be installed (`npm` or yarn`).
-        default: "npm"
+        default: 'npm'
         required: false
         type: string
     secrets:

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -19,8 +19,8 @@ on:
         required: false
         type: string
       PACKAGE_MANAGER:
-        description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
-        default: 'npm'
+        description: Package manager with which the dependencies should be installed (`npm` or `yarn` (default)).
+        default: 'yarn'
         required: false
         type: string
     secrets:

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
       PACKAGE_MANAGER:
-        description: Package manager. Supported are "yarn" and "npm".
+        description: Package manager with which the dependencies should be installed (`npm` or yarn`).
         default: "npm"
         required: false
         type: string
@@ -44,7 +44,7 @@ jobs:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
 
-      - name: Cache npm/Yarn dependencies
+      - name: Cache dependencies
         uses: actions/cache@v3
         with:
           path: ~/.deps_cache

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
       PACKAGE_MANAGER:
-        description: Package manager with which the dependencies should be installed (`npm` or `yarn` (default)).
+        description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
         default: 'yarn'
         required: false
         type: string

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
       PACKAGE_MANAGER:
-        description: Package manager with which the dependencies should be installed (`npm` or yarn`).
+        description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
         default: 'npm'
         required: false
         type: string

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -48,12 +48,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.deps_cache
-          key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ env.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
+          key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ inputs.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
 
       - name: Install dependencies
         run: |
-          ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn config set cache-folder ~/.deps_cache') || 'npm config set cache ~/.deps_cache --global' }}
-          ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
+          ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn config set cache-folder ~/.deps_cache') || 'npm config set cache ~/.deps_cache --global' }}
+          ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
 
       - name: Run Jest
         run: ./node_modules/.bin/jest ${{ inputs.JEST_ARGS }}

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -72,15 +72,15 @@ This is not the simplest possible example, but it showcases all the recommendati
 
 ### Inputs
 
-| Name                  | Default                         | Description                                                                            |
-|-----------------------|---------------------------------|----------------------------------------------------------------------------------------|
-| `NODE_VERSION`        | `16`                            | Node version with which the assets will be compiled                                    |
-| `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"` | Domain of the private npm registry                                                     |
-| `PACKAGE_MANAGER`     | `"auto"` <sup>**^1**</sup>      | Package manager with which the dependencies should be installed (`npm` or yarn`). Required if no lock file is available |
-| `DEPS_INSTALL`        | `"yes"`                         | Install dependencies before compiling? Options: `"yes"` (default) `"no"`               |
-| `COMPILE_SCRIPT_PROD` | `"encore prod"`                 | Script added to `npm run` or `yarn` to build production assets                         |
-| `COMPILE_SCRIPT_DEV`  | `"encore dev"`                  | Script added to `npm run` or `yarn` to build development assets                        |
-| `ASSETS_TARGET_PATHS` | `"./assets"`                    | Target path(s) for compiled assets                                                     |
+| Name                  | Default                         | Description                                                                                                             |
+|-----------------------|---------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `NODE_VERSION`        | `16`                            | Node version with which the assets will be compiled                                                                     |
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                                                      |
+| `PACKAGE_MANAGER`     | `'auto'` <sup>**^1**</sup>      | Package manager with which the dependencies should be installed (`npm` or yarn`). Required if no lock file is available |
+| `DEPS_INSTALL`        | `'yes'`                         | Install dependencies before compiling? Options: `'yes'` (default) `'no'`                                                |
+| `COMPILE_SCRIPT_PROD` | `'encore prod'`                 | Script added to `npm run` or `yarn` to build production assets                                                          |
+| `COMPILE_SCRIPT_DEV`  | `'encore dev'`                  | Script added to `npm run` or `yarn` to build development assets                                                         |
+| `ASSETS_TARGET_PATHS` | `'./assets'`                    | Target path(s) for compiled assets                                                                                      |
 
 <sup>**^1**</sup> `PACKAGE_MANAGER` defaults to "auto" because it tries to determine the package
 manager by looking at lock file (e.g. presence of `yarn.lock` means _Yarn_, `npm-shrinkwrap.json`

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -72,16 +72,16 @@ This is not the simplest possible example, but it showcases all the recommendati
 
 ### Inputs
 
-| Name                  | Default                         | Description                                                                            |
-|-----------------------|---------------------------------|----------------------------------------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                     |
-| `NODE_VERSION`        | `16`                            | Node version with which the assets will be compiled                                    |
-| `WORKING_DIRECTORY`   | `'./'`                          | Working directory path                                                                 |
-| `PACKAGE_MANAGER`     | `'auto'` <sup>**^1**</sup>      | Package manager. Supported are "yarn" and "npm". Required if no lock file is available |
-| `DEPS_INSTALL`        | `true`                          | Whether or not to install dependencies before compiling                                |
-| `COMPILE_SCRIPT_PROD` | `'encore prod'`                 | Script added to `npm run` or `yarn` to build production assets                         |
-| `COMPILE_SCRIPT_DEV`  | `'encore dev'`                  | Script added to `npm run` or `yarn` to build development assets                        |
-| `ASSETS_TARGET_PATHS` | `'./assets'`                    | Target path(s) for compiled assets                                                     |
+| Name                  | Default                       | Description                                                                            |
+|-----------------------|-------------------------------|----------------------------------------------------------------------------------------|
+| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                     |
+| `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled                                    |
+| `WORKING_DIRECTORY`   | `'./'`                        | Working directory path                                                                 |
+| `PACKAGE_MANAGER`     | `'auto'` <sup>**^1**</sup>    | Package manager. Supported are "yarn" and "npm". Required if no lock file is available |
+| `DEPS_INSTALL`        | `true`                        | Whether or not to install dependencies before compiling                                |
+| `COMPILE_SCRIPT_PROD` | `'encore prod'`               | Script added to `npm run` or `yarn` to build production assets                         |
+| `COMPILE_SCRIPT_DEV`  | `'encore dev'`                | Script added to `npm run` or `yarn` to build development assets                        |
+| `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                     |
 
 <sup>**^1**</sup> `PACKAGE_MANAGER` defaults to "auto" because it tries to determine the package
 manager by looking at lock file (e.g. presence of `yarn.lock` means _Yarn_, `npm-shrinkwrap.json`

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -74,9 +74,9 @@ This is not the simplest possible example, but it showcases all the recommendati
 
 | Name                  | Default                         | Description                                                                            |
 |-----------------------|---------------------------------|----------------------------------------------------------------------------------------|
-| `WORKING_DIRECTORY`   | `'./'`                          | Working directory path                                                                 |
-| `NODE_VERSION`        | `16`                            | Node version with which the assets will be compiled                                    |
 | `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                     |
+| `NODE_VERSION`        | `16`                            | Node version with which the assets will be compiled                                    |
+| `WORKING_DIRECTORY`   | `'./'`                          | Working directory path                                                                 |
 | `PACKAGE_MANAGER`     | `'auto'` <sup>**^1**</sup>      | Package manager. Supported are "yarn" and "npm". Required if no lock file is available |
 | `DEPS_INSTALL`        | `true`                          | Whether or not to install dependencies before compiling                                |
 | `COMPILE_SCRIPT_PROD` | `'encore prod'`                 | Script added to `npm run` or `yarn` to build production assets                         |

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -76,7 +76,7 @@ This is not the simplest possible example, but it showcases all the recommendati
 |-----------------------|---------------------------------|----------------------------------------------------------------------------------------|
 | `NODE_VERSION`        | `16`                            | Node version with which the assets will be compiled                                    |
 | `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"` | Domain of the private npm registry                                                     |
-| `PACKAGE_MANAGER`     | `"auto"` <sup>**^1**</sup>      | Package manager. Supported are "yarn" and "npm". Required if no lock file is available |
+| `PACKAGE_MANAGER`     | `"auto"` <sup>**^1**</sup>      | Package manager with which the dependencies should be installed (`npm` or yarn`). Required if no lock file is available |
 | `DEPS_INSTALL`        | `"yes"`                         | Install dependencies before compiling? Options: `"yes"` (default) `"no"`               |
 | `COMPILE_SCRIPT_PROD` | `"encore prod"`                 | Script added to `npm run` or `yarn` to build production assets                         |
 | `COMPILE_SCRIPT_DEV`  | `"encore dev"`                  | Script added to `npm run` or `yarn` to build development assets                        |

--- a/docs/js.md
+++ b/docs/js.md
@@ -20,12 +20,12 @@ jobs:
 
 #### Inputs
 
-| Name                  | Default                                                               | Description                                                                       |
-|-----------------------|-----------------------------------------------------------------------|-----------------------------------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                                       | Domain of the private npm registry                                                |
-| `NODE_VERSION`        | 16                                                                    | Node version with which the assets will be compiled                               |
-| `ESLINT_ARGS`         | `'-o eslint_report.json -f json --ext .js,.jsx,.ts,.tsx ./resources'` | Set of arguments passed to ESLint                                                 |
-| `PACKAGE_MANAGER`     | `npm`                                                                 | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
+| Name                  | Default                                                               | Description                                                                                 |
+|-----------------------|-----------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                                       | Domain of the private npm registry                                                          |
+| `NODE_VERSION`        | 16                                                                    | Node version with which the assets will be compiled                                         |
+| `ESLINT_ARGS`         | `'-o eslint_report.json -f json --ext .js,.jsx,.ts,.tsx ./resources'` | Set of arguments passed to ESLint                                                           |
+| `PACKAGE_MANAGER`     | `yarn`                                                                | Package manager with which the dependencies should be installed (`npm` or `yarn` (default)) |
 
 #### Secrets
 
@@ -69,12 +69,12 @@ jobs:
 
 #### Inputs
 
-| Name                  | Default                                            | Description                                                                       |
-|-----------------------|----------------------------------------------------|-----------------------------------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                    | Domain of the private npm registry                                                |
-| `NODE_VERSION`        | 16                                                 | Node version with which the unit tests are to be executed                         |
-| `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                                                   |
-| `PACKAGE_MANAGER`     | `npm`                                              | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
+| Name                  | Default                                            | Description                                                                                 |
+|-----------------------|----------------------------------------------------|---------------------------------------------------------------------------------------------|
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                    | Domain of the private npm registry                                                          |
+| `NODE_VERSION`        | 16                                                 | Node version with which the unit tests are to be executed                                   |
+| `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                                                             |
+| `PACKAGE_MANAGER`     | `yarn`                                             | Package manager with which the dependencies should be installed (`npm` or `yarn` (default)) |
 
 **Note**: The default `github-actions` reporter requires Jest 28 or higher.
 

--- a/docs/js.md
+++ b/docs/js.md
@@ -25,7 +25,7 @@ jobs:
 | `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                                       | Domain of the private npm registry                  |
 | `NODE_VERSION`        | 16                                                                    | Node version with which the assets will be compiled |
 | `ESLINT_ARGS`         | `'-o eslint_report.json -f json --ext .js,.jsx,.ts,.tsx ./resources'` | Set of arguments passed to ESLint                   |
-| `PACKAGE_MANAGER`     | `npm`                                                                 | Package manager. Supported are "yarn" and "npm".    |
+| `PACKAGE_MANAGER`     | `npm`                                                                 | Package manager with which the dependencies should be installed (`npm` or yarn`).    |
 
 #### Secrets
 
@@ -74,7 +74,7 @@ jobs:
 | `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                    | Domain of the private npm registry                        |
 | `NODE_VERSION`        | 16                                                 | Node version with which the unit tests are to be executed |
 | `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                           |
-| `PACKAGE_MANAGER`     | `npm`                                              | Package manager. Supported are "yarn" and "npm".          |
+| `PACKAGE_MANAGER`     | `npm`                                              | Package manager with which the dependencies should be installed (`npm` or yarn`).          |
 
 **Note**: The default `github-actions` reporter requires Jest 28 or higher.
 

--- a/docs/js.md
+++ b/docs/js.md
@@ -20,12 +20,12 @@ jobs:
 
 #### Inputs
 
-| Name                  | Default                                                               | Description                                                                                 |
-|-----------------------|-----------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/`                                         | Domain of the private npm registry                                                          |
-| `NODE_VERSION`        | 16                                                                    | Node version with which the assets will be compiled                                         |
-| `ESLINT_ARGS`         | `'-o eslint_report.json -f json --ext .js,.jsx,.ts,.tsx ./resources'` | Set of arguments passed to ESLint                                                           |
-| `PACKAGE_MANAGER`     | `yarn`                                                                | Package manager with which the dependencies should be installed (`npm` or `yarn` (default)) |
+| Name                  | Default                                                               | Description                                                                       |
+|-----------------------|-----------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/`                                         | Domain of the private npm registry                                                |
+| `NODE_VERSION`        | 16                                                                    | Node version with which the assets will be compiled                               |
+| `ESLINT_ARGS`         | `'-o eslint_report.json -f json --ext .js,.jsx,.ts,.tsx ./resources'` | Set of arguments passed to ESLint                                                 |
+| `PACKAGE_MANAGER`     | `yarn`                                                                | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 
 #### Secrets
 
@@ -69,12 +69,12 @@ jobs:
 
 #### Inputs
 
-| Name                  | Default                                            | Description                                                                                 |
-|-----------------------|----------------------------------------------------|---------------------------------------------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/`                      | Domain of the private npm registry                                                          |
-| `NODE_VERSION`        | 16                                                 | Node version with which the unit tests are to be executed                                   |
-| `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                                                             |
-| `PACKAGE_MANAGER`     | `yarn`                                             | Package manager with which the dependencies should be installed (`npm` or `yarn` (default)) |
+| Name                  | Default                                            | Description                                                                       |
+|-----------------------|----------------------------------------------------|-----------------------------------------------------------------------------------|
+| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/`                      | Domain of the private npm registry                                                |
+| `NODE_VERSION`        | 16                                                 | Node version with which the unit tests are to be executed                         |
+| `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                                                   |
+| `PACKAGE_MANAGER`     | `yarn`                                             | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 
 **Note**: The default `github-actions` reporter requires Jest 28 or higher.
 

--- a/docs/js.md
+++ b/docs/js.md
@@ -25,6 +25,7 @@ jobs:
 | `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                                       | Domain of the private npm registry                  |
 | `NODE_VERSION`        | 16                                                                    | Node version with which the assets will be compiled |
 | `ESLINT_ARGS`         | `'-o eslint_report.json -f json --ext .js,.jsx,.ts,.tsx ./resources'` | Set of arguments passed to ESLint                   |
+| `PACKAGE_MANAGER`     | `npm`                                                                 | Package manager. Supported are "yarn" and "npm".    |
 
 #### Secrets
 
@@ -73,6 +74,7 @@ jobs:
 | `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                    | Domain of the private npm registry                        |
 | `NODE_VERSION`        | 16                                                 | Node version with which the unit tests are to be executed |
 | `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                           |
+| `PACKAGE_MANAGER`     | `npm`                                              | Package manager. Supported are "yarn" and "npm".          |
 
 **Note**: The default `github-actions` reporter requires Jest 28 or higher.
 

--- a/docs/js.md
+++ b/docs/js.md
@@ -20,12 +20,12 @@ jobs:
 
 #### Inputs
 
-| Name                  | Default                                                               | Description                                         |
-|-----------------------|-----------------------------------------------------------------------|-----------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                                       | Domain of the private npm registry                  |
-| `NODE_VERSION`        | 16                                                                    | Node version with which the assets will be compiled |
-| `ESLINT_ARGS`         | `'-o eslint_report.json -f json --ext .js,.jsx,.ts,.tsx ./resources'` | Set of arguments passed to ESLint                   |
-| `PACKAGE_MANAGER`     | `npm`                                                                 | Package manager with which the dependencies should be installed (`npm` or yarn`).    |
+| Name                  | Default                                                               | Description                                                                       |
+|-----------------------|-----------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                                       | Domain of the private npm registry                                                |
+| `NODE_VERSION`        | 16                                                                    | Node version with which the assets will be compiled                               |
+| `ESLINT_ARGS`         | `'-o eslint_report.json -f json --ext .js,.jsx,.ts,.tsx ./resources'` | Set of arguments passed to ESLint                                                 |
+| `PACKAGE_MANAGER`     | `npm`                                                                 | Package manager with which the dependencies should be installed (`npm` or yarn`). |
 
 #### Secrets
 
@@ -69,12 +69,12 @@ jobs:
 
 #### Inputs
 
-| Name                  | Default                                            | Description                                               |
-|-----------------------|----------------------------------------------------|-----------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                    | Domain of the private npm registry                        |
-| `NODE_VERSION`        | 16                                                 | Node version with which the unit tests are to be executed |
-| `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                           |
-| `PACKAGE_MANAGER`     | `npm`                                              | Package manager with which the dependencies should be installed (`npm` or yarn`).          |
+| Name                  | Default                                            | Description                                                                      |
+|-----------------------|----------------------------------------------------|----------------------------------------------------------------------------------|
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                    | Domain of the private npm registry                                               |
+| `NODE_VERSION`        | 16                                                 | Node version with which the unit tests are to be executed                        |
+| `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                                                  |
+| `PACKAGE_MANAGER`     | `npm`                                              | Package manager with which the dependencies should be installed (`npm` or yarn`) |
 
 **Note**: The default `github-actions` reporter requires Jest 28 or higher.
 

--- a/docs/js.md
+++ b/docs/js.md
@@ -22,7 +22,7 @@ jobs:
 
 | Name                  | Default                                                               | Description                                                                                 |
 |-----------------------|-----------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                                       | Domain of the private npm registry                                                          |
+| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/`                                         | Domain of the private npm registry                                                          |
 | `NODE_VERSION`        | 16                                                                    | Node version with which the assets will be compiled                                         |
 | `ESLINT_ARGS`         | `'-o eslint_report.json -f json --ext .js,.jsx,.ts,.tsx ./resources'` | Set of arguments passed to ESLint                                                           |
 | `PACKAGE_MANAGER`     | `yarn`                                                                | Package manager with which the dependencies should be installed (`npm` or `yarn` (default)) |
@@ -71,7 +71,7 @@ jobs:
 
 | Name                  | Default                                            | Description                                                                                 |
 |-----------------------|----------------------------------------------------|---------------------------------------------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                    | Domain of the private npm registry                                                          |
+| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/`                      | Domain of the private npm registry                                                          |
 | `NODE_VERSION`        | 16                                                 | Node version with which the unit tests are to be executed                                   |
 | `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                                                             |
 | `PACKAGE_MANAGER`     | `yarn`                                             | Package manager with which the dependencies should be installed (`npm` or `yarn` (default)) |

--- a/docs/js.md
+++ b/docs/js.md
@@ -25,7 +25,7 @@ jobs:
 | `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                                       | Domain of the private npm registry                                                |
 | `NODE_VERSION`        | 16                                                                    | Node version with which the assets will be compiled                               |
 | `ESLINT_ARGS`         | `'-o eslint_report.json -f json --ext .js,.jsx,.ts,.tsx ./resources'` | Set of arguments passed to ESLint                                                 |
-| `PACKAGE_MANAGER`     | `npm`                                                                 | Package manager with which the dependencies should be installed (`npm` or yarn`). |
+| `PACKAGE_MANAGER`     | `npm`                                                                 | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 
 #### Secrets
 
@@ -69,12 +69,12 @@ jobs:
 
 #### Inputs
 
-| Name                  | Default                                            | Description                                                                      |
-|-----------------------|----------------------------------------------------|----------------------------------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                    | Domain of the private npm registry                                               |
-| `NODE_VERSION`        | 16                                                 | Node version with which the unit tests are to be executed                        |
-| `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                                                  |
-| `PACKAGE_MANAGER`     | `npm`                                              | Package manager with which the dependencies should be installed (`npm` or yarn`) |
+| Name                  | Default                                            | Description                                                                       |
+|-----------------------|----------------------------------------------------|-----------------------------------------------------------------------------------|
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                    | Domain of the private npm registry                                                |
+| `NODE_VERSION`        | 16                                                 | Node version with which the unit tests are to be executed                         |
+| `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                                                   |
+| `PACKAGE_MANAGER`     | `npm`                                              | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 
 **Note**: The default `github-actions` reporter requires Jest 28 or higher.
 

--- a/docs/sass.md
+++ b/docs/sass.md
@@ -20,12 +20,12 @@ jobs:
 
 #### Inputs
 
-| Name                  | Default                         | Description                                                                       |
-|-----------------------|---------------------------------|-----------------------------------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                |
-| `NODE_VERSION`        | 16                              | Node version with which the assets will be compiled                               |
-| `STYLELINT_ARGS`      | `'./resources/**/*.scss'`       | Set of arguments passed to Stylelint                                              |
-| `PACKAGE_MANAGER`     | `npm`                           | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
+| Name                  | Default                       | Description                                                                       |
+|-----------------------|-------------------------------|-----------------------------------------------------------------------------------|
+| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                |
+| `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled                               |
+| `STYLELINT_ARGS`      | `'./resources/**/*.scss'`     | Set of arguments passed to Stylelint                                              |
+| `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 
 #### Secrets
 

--- a/docs/sass.md
+++ b/docs/sass.md
@@ -25,6 +25,7 @@ jobs:
 | `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                  |
 | `NODE_VERSION`        | 16                              | Node version with which the assets will be compiled |
 | `STYLELINT_ARGS`      | `'./resources/**/*.scss'`       | Set of arguments passed to Stylelint                |
+| `PACKAGE_MANAGER`     | `npm`                           | Package manager. Supported are "yarn" and "npm".    |
 
 #### Secrets
 

--- a/docs/sass.md
+++ b/docs/sass.md
@@ -25,7 +25,7 @@ jobs:
 | `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                  |
 | `NODE_VERSION`        | 16                              | Node version with which the assets will be compiled |
 | `STYLELINT_ARGS`      | `'./resources/**/*.scss'`       | Set of arguments passed to Stylelint                |
-| `PACKAGE_MANAGER`     | `npm`                           | Package manager. Supported are "yarn" and "npm".    |
+| `PACKAGE_MANAGER`     | `npm`                           | Package manager with which the dependencies should be installed (`npm` or yarn`).    |
 
 #### Secrets
 

--- a/docs/sass.md
+++ b/docs/sass.md
@@ -20,12 +20,12 @@ jobs:
 
 #### Inputs
 
-| Name                  | Default                         | Description                                                                      |
-|-----------------------|---------------------------------|----------------------------------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                               |
-| `NODE_VERSION`        | 16                              | Node version with which the assets will be compiled                              |
-| `STYLELINT_ARGS`      | `'./resources/**/*.scss'`       | Set of arguments passed to Stylelint                                             |
-| `PACKAGE_MANAGER`     | `npm`                           | Package manager with which the dependencies should be installed (`npm` or yarn`) |
+| Name                  | Default                         | Description                                                                       |
+|-----------------------|---------------------------------|-----------------------------------------------------------------------------------|
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                |
+| `NODE_VERSION`        | 16                              | Node version with which the assets will be compiled                               |
+| `STYLELINT_ARGS`      | `'./resources/**/*.scss'`       | Set of arguments passed to Stylelint                                              |
+| `PACKAGE_MANAGER`     | `npm`                           | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 
 #### Secrets
 

--- a/docs/sass.md
+++ b/docs/sass.md
@@ -20,12 +20,12 @@ jobs:
 
 #### Inputs
 
-| Name                  | Default                         | Description                                         |
-|-----------------------|---------------------------------|-----------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                  |
-| `NODE_VERSION`        | 16                              | Node version with which the assets will be compiled |
-| `STYLELINT_ARGS`      | `'./resources/**/*.scss'`       | Set of arguments passed to Stylelint                |
-| `PACKAGE_MANAGER`     | `npm`                           | Package manager with which the dependencies should be installed (`npm` or yarn`).    |
+| Name                  | Default                         | Description                                                                      |
+|-----------------------|---------------------------------|----------------------------------------------------------------------------------|
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                               |
+| `NODE_VERSION`        | 16                              | Node version with which the assets will be compiled                              |
+| `STYLELINT_ARGS`      | `'./resources/**/*.scss'`       | Set of arguments passed to Stylelint                                             |
+| `PACKAGE_MANAGER`     | `npm`                           | Package manager with which the dependencies should be installed (`npm` or yarn`) |
 
 #### Secrets
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.


**What is the current behavior?** (You can also link to an open issue here)
It's not possible to select a package manager to install dependencies for QA workflows.

Yarn and npm definitely go in a different ways to provide specific functionality so it will be nice to run QA with the same package manager as locally. And install dependencies from the related `.lock` file if it exists.


**What is the new behavior (if this is a feature change)?**
Add `PACKAGE_MANAGER` input and related functionality. Essentially code was picked from the `Build and push assets` workflow (without autodetection).



**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No. Because by default is `npm` as it is now.


**Other information**:
