### PR TITLE
feature: add Github User Email, Name and SSH_KEY to build-and-push-assets.yml workflow

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -43,10 +43,10 @@ on:
         description: Authentication for the private npm registry.
         required: false
       GITHUB_USER_EMAIL:
-        description: Email address for Git configuration.
+        description: Email address for the GitHub user configuration.
         required: true
       GITHUB_USER_NAME:
-        description: Username for Git configuration.
+        description: Username for the GitHub user configuration.
         required: true
       GITHUB_USER_SSH_KEY:
         description: Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`.

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       PHP_VERSION:
-        description: PHP version with which the coding standard analysis is to be executed.
+        description: PHP version with which the assets compilation is to be executed.
         default: 7.4
         required: false
         type: string
@@ -36,10 +36,10 @@ on:
         description: Authentication for the private npm registry.
         required: false
       GITHUB_USER_EMAIL:
-        description: Email address for Git configuration.
+        description: Email address for the GitHub user configuration.
         required: false
       GITHUB_USER_NAME:
-        description: Username for Git configuration.
+        description: Username for the GitHub user configuration.
         required: false
       GITHUB_USER_SSH_KEY:
         description: Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`.
@@ -70,7 +70,7 @@ jobs:
         run: |
           git config --global user.email "${{ secrets.GITHUB_USER_EMAIL }}" 
           git config --global user.name "${{ secrets.GITHUB_USER_NAME }}"
-          
+
       - name: Set up node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -35,6 +35,15 @@ on:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
         required: false
+      GITHUB_USER_EMAIL:
+        description: Email address for Git configuration.
+        required: true
+      GITHUB_USER_NAME:
+        description: Username for Git configuration.
+        required: true
+      GITHUB_USER_SSH_KEY:
+        description: Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`.
+        required: false
 
 jobs:
   assets-compilation:
@@ -47,6 +56,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up SSH
+        if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
+
+      - name: Setup Git
+        run: |
+          git config --global user.email "${{ secrets.GITHUB_USER_EMAIL }}" 
+          git config --global user.name "${{ secrets.GITHUB_USER_NAME }}"
+          git config --global advice.addIgnoredFile false
+          git config --global push.autoSetupRemote true
+          mkdir -p ${{ inputs.ASSETS_TARGET_PATHS }}
+          
       - name: Set up node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -70,8 +70,6 @@ jobs:
         run: |
           git config --global user.email "${{ secrets.GITHUB_USER_EMAIL }}" 
           git config --global user.name "${{ secrets.GITHUB_USER_NAME }}"
-          git config --global advice.addIgnoredFile false
-          git config --global push.autoSetupRemote true
           
       - name: Set up node
         uses: actions/setup-node@v3

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -69,7 +69,6 @@ jobs:
           git config --global user.name "${{ secrets.GITHUB_USER_NAME }}"
           git config --global advice.addIgnoredFile false
           git config --global push.autoSetupRemote true
-          mkdir -p ${{ inputs.ASSETS_TARGET_PATHS }}
           
       - name: Set up node
         uses: actions/setup-node@v3

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -37,10 +37,10 @@ on:
         required: false
       GITHUB_USER_EMAIL:
         description: Email address for Git configuration.
-        required: true
+        required: false
       GITHUB_USER_NAME:
         description: Username for Git configuration.
-        required: true
+        required: false
       GITHUB_USER_SSH_KEY:
         description: Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`.
         required: false
@@ -53,6 +53,8 @@ jobs:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
+      GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
+      GITHUB_USER_EMAIL: ${{ secrets.GITHUB_USER_EMAIL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -64,6 +66,7 @@ jobs:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Setup Git
+        if: ${{ env.GITHUB_USER_EMAIL != '' && env.GITHUB_USER_NAME !) '' }}
         run: |
           git config --global user.email "${{ secrets.GITHUB_USER_EMAIL }}" 
           git config --global user.name "${{ secrets.GITHUB_USER_NAME }}"

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -52,6 +52,7 @@ jobs:
     env:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -30,13 +30,13 @@ jobs:
 
 #### Secrets
 
-| Name                 | Description                                                                              |
-|----------------------|------------------------------------------------------------------------------------------|
-| `COMPOSER_AUTH_JSON` | Authentication for privately hosted packages and repositories as a JSON formatted object |
-| `NPM_REGISTRY_TOKEN` | Authentication for the private npm registry.                                             |
-| `GITHUB_USER_EMAIL`  | Email address for Git configuration                                                      |
-| `GITHUB_USER_NAME`   | Username for Git configuration                                                           |
-| `GITHUB_USER_SSH_KEY`| Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`             |
+| Name                  | Description                                                                              |
+|-----------------------|------------------------------------------------------------------------------------------|
+| `COMPOSER_AUTH_JSON`  | Authentication for privately hosted packages and repositories as a JSON formatted object |
+| `NPM_REGISTRY_TOKEN`  | Authentication for the private npm registry                                              |
+| `GITHUB_USER_EMAIL`   | Email address for the GitHub user configuration                                          |
+| `GITHUB_USER_NAME`    | Username for the GitHub user configuration                                               |
+| `GITHUB_USER_SSH_KEY` | Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`             |
 
 **Example with configuration parameters:**
 

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -34,6 +34,9 @@ jobs:
 |----------------------|------------------------------------------------------------------------------------------|
 | `COMPOSER_AUTH_JSON` | Authentication for privately hosted packages and repositories as a JSON formatted object |
 | `NPM_REGISTRY_TOKEN` | Authentication for the private npm registry.                                             |
+| `GITHUB_USER_EMAIL`  | Email address for Git configuration                                                      |
+| `GITHUB_USER_NAME`   | Username for Git configuration                                                           |
+| `GITHUB_USER_SSH_KEY`| Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`             |
 
 **Example with configuration parameters:**
 

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -92,8 +92,8 @@ then `PACKAGE_MANAGER` input is required**.
 | Name                  | Description                                                                  |
 |-----------------------|------------------------------------------------------------------------------|
 | `NPM_REGISTRY_TOKEN`  | Authentication for the private npm registry                                  |
-| `GITHUB_USER_EMAIL`   | Email address for Git configuration                                          |
-| `GITHUB_USER_NAME`    | Username for Git configuration                                               |
+| `GITHUB_USER_EMAIL`   | Email address for the GitHub user configuration                              |
+| `GITHUB_USER_NAME`    | Username for the GitHub user configuration                                   |
 | `GITHUB_USER_SSH_KEY` | Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME` |
 
 ## FAQ


### PR DESCRIPTION
Signed-off-by: Christian Leucht <3417446+Chrico@users.noreply.github.com>

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR will introduce 3 new `inputs.secrets`:

- GITHUB_USER_EMAIL
- GITHUB_USER_NAME
- GITHUB_USER_SSH_KEY

This is just a sync to the current `build-and-push-assets.yml`-workflow which already has those secrets.

**What is the current behavior?** (You can also link to an open issue here)

Right now it is not possible to have something like following in the `package.json`:

```
"some/dependency": "git+ssh://git@github.com:organization/some-dependency.git",
```

This can be used when we configure correctly Git with an User an Email, while the given User has access to that repository.