### PR TITLE
Update default PHP version from 7.4 to 8.0

### DIFF
--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       PHP_VERSION:
         description: PHP version with which the coding standard analysis is to be executed.
-        default: 7.4
+        default: 8.0
         required: false
         type: string
       NPM_REGISTRY_DOMAIN:

--- a/.github/workflows/coding-standards-php.yml
+++ b/.github/workflows/coding-standards-php.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       PHP_VERSION:
         description: PHP version with which the coding standard analysis is to be executed.
-        default: 7.4
+        default: 8.0
         required: false
         type: string
       COMPOSER_ARGS:

--- a/.github/workflows/static-analysis-php.yml
+++ b/.github/workflows/static-analysis-php.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       PHP_VERSION:
         description: PHP version with which the static code analysis is to be executed.
-        default: 7.4
+        default: 8.0
         required: false
         type: string
       COMPOSER_ARGS:

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       PHP_MATRIX:
         description: Matrix of PHP versions as a JSON formatted object.
-        default: '["7.4"]'
+        default: '["8.0"]'
         required: false
         type: string
       COMPOSER_ARGS:

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -22,7 +22,7 @@ jobs:
 
 | Name                  | Default                       | Description                                                      |
 |-----------------------|-------------------------------|------------------------------------------------------------------|
-| `PHP_VERSION`         | 7.4                           | PHP version with which the assets compilation is to be executed  |
+| `PHP_VERSION`         | 8.0                           | PHP version with which the assets compilation is to be executed  |
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                               |
 | `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled              |
 | `COMPOSER_ARGS`       | `'--prefer-dist'`             | Set of arguments passed to Composer                              |

--- a/docs/php.md
+++ b/docs/php.md
@@ -22,7 +22,7 @@ jobs:
 
 | Name            | Default                                                  | Description                                                           |
 |-----------------|----------------------------------------------------------|-----------------------------------------------------------------------|
-| `PHP_VERSION`   | 7.4                                                      | PHP version with which the coding standard analysis is to be executed |
+| `PHP_VERSION`   | 8.0                                                      | PHP version with which the coding standard analysis is to be executed |
 | `COMPOSER_ARGS` | `'--prefer-dist'`                                        | Set of arguments passed to Composer                                   |
 | `PHPCS_ARGS`    | `'--report-full --report-checkstyle=./phpcs-report.xml'` | Set of arguments passed to PHP_CodeSniffer                            |
 | `CS2PR_ARGS`    | `'--graceful-warnings ./phpcs-report.xml'`               | Set of arguments passed to cs2pr                                      |
@@ -73,7 +73,7 @@ jobs:
 
 | Name            | Default                               | Description                                                       |
 |-----------------|---------------------------------------|-------------------------------------------------------------------|
-| `PHP_VERSION`   | 7.4                                   | PHP version with which the static code analysis is to be executed |
+| `PHP_VERSION`   | 8.0                                   | PHP version with which the static code analysis is to be executed |
 | `COMPOSER_ARGS` | `'--prefer-dist'`                     | Set of arguments passed to Composer                               |
 | `PSALM_ARGS`    | `'--output-format=github --no-cache'` | Set of arguments passed to Psalm                                  |
 
@@ -122,7 +122,7 @@ jobs:
 
 | Name            | Default             | Description                                       |
 |-----------------|---------------------|---------------------------------------------------|
-| `PHP_MATRIX`    | `["7.4"]`           | Matrix of PHP versions as a JSON formatted object |
+| `PHP_MATRIX`    | `["8.0"]`           | Matrix of PHP versions as a JSON formatted object |
 | `COMPOSER_ARGS` | `'--prefer-dist'`   | Set of arguments passed to Composer               |
 | `PHPUNIT_ARGS`  | `'--coverage-text'` | Set of arguments passed to PHPUnit                |
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
In workflows that use PHP, the default PHP version is 7.4. That version reached EOL on 2022-11-28.


**What is the new behavior (if this is a feature change)?**
In workflows that use PHP, change the default PHP version to PHP 8.0.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. Calling workflows for packages that don't pass `PHP_VERSION` to the called workflow and are incompatible with PHP 8.0 will break.


**Other information**:
Closes #28