### PR TITLE
Change `DEPS_INSTALL` input type to `bool`

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -19,9 +19,9 @@ on:
         default: "auto"
         required: false
       DEPS_INSTALL:
-        description: Install dependencies before compiling?
-        type: string
-        default: "yes"
+        description: Whether or not to install dependencies before compiling.
+        type: boolean
+        default: true
         required: false
       COMPILE_SCRIPT_PROD:
         description: Script added to "npm run" or "yarn" to build production assets.
@@ -131,7 +131,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ inputs.NODE_VERSION }}-${{ env.PACKAGE_MANAGER }}-${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') }}
 
       - name: Install dependencies
-        if: ${{ ! startsWith( 'no', inputs.DEPS_INSTALL ) }}
+        if: ${{ inputs.DEPS_INSTALL }}
         run: |
           ${{ ((env.PACKAGE_MANAGER == 'npm') && 'npm config set cache ~/.deps_cache --global') || 'yarn config set cache-folder ~/.deps_cache' }}
           ${{ ((env.PACKAGE_MANAGER == 'npm') && 'npm install') || 'yarn' }}

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -77,7 +77,7 @@ This is not the simplest possible example, but it showcases all the recommendati
 | `NODE_VERSION`        | `16`                            | Node version with which the assets will be compiled                                    |
 | `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"` | Domain of the private npm registry                                                     |
 | `PACKAGE_MANAGER`     | `"auto"` <sup>**^1**</sup>      | Package manager. Supported are "yarn" and "npm". Required if no lock file is available |
-| `DEPS_INSTALL`        | `"yes"`                         | Install dependencies before compiling? Options: `"yes"` (default) `"no"`               |
+| `DEPS_INSTALL`        | `true`                          | Whether or not to install dependencies before compiling                                |
 | `COMPILE_SCRIPT_PROD` | `"encore prod"`                 | Script added to `npm run` or `yarn` to build production assets                         |
 | `COMPILE_SCRIPT_DEV`  | `"encore dev"`                  | Script added to `npm run` or `yarn` to build development assets                        |
 | `ASSETS_TARGET_PATHS` | `"./assets"`                    | Target path(s) for compiled assets                                                     |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement


**What is the current behavior?** (You can also link to an open issue here)
In the "Build and push assets" workflow, the `DEPS_INSTALL` is of type `string`. However, it would make more sense if it would be of type `bool`.


**What is the new behavior (if this is a feature change)?**
The `DEPS_INSTALL` input type is changed from `string` to `bool`.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No. According to the GitHub search linked in #30, at the time of writing, no (public) calling workflows use this input.


**Other information**:
Closes #30