### PR TITLE
Set ENCORE_ENV deprecated and introduce BUILD_ENV

### DIFF
--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -103,7 +103,7 @@ jobs:
           echo "ASSETS_HASH=$(composer assets-hash)" >> $GITHUB_ENV
           echo "BUILD_ENV=dev" >> $GITHUB_ENV
 
-      - name: Set env variables [PROD]
+      - name: Set environment variables [PROD]
         if: ${{ contains(github.ref, 'refs/tags/') }}
         run: |
           echo "TAG_NAME=$(echo ${GITHUB_REF#refs/*/})" >> $GITHUB_ENV

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -108,7 +108,7 @@ jobs:
         run: |
           echo "TAG_NAME=$(echo ${GITHUB_REF#refs/*/})" >> $GITHUB_ENV
           echo "BUILD_ENV=production" >> $GITHUB_ENV
-          echo "::warning::The `ENCORE_ENV` variable is deprecated and will be removed soon. Please upgrade to using `BUILD_ENV`."
+          echo "::notice::The `ENCORE_ENV` variable is deprecated and will be removed soon. If you use it, please change it to `BUILD_ENV`."
           echo "ENCORE_ENV=production" >> $GITHUB_ENV
 
       - name: Compile assets

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -97,17 +97,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Extract package hash into env [DEV]
+      - name: Set env variables [DEV]
         if: ${{ !contains(github.ref, 'refs/tags/') }}
-        run: echo "ASSETS_HASH=$(composer assets-hash)" >> $GITHUB_ENV
+        run: |
+          echo "ASSETS_HASH=$(composer assets-hash)" >> $GITHUB_ENV
+          echo "BUILD_ENV=dev" >> $GITHUB_ENV
 
-      - name: Extract tag name into env [PROD]
+      - name: Set env variables [PROD]
         if: ${{ contains(github.ref, 'refs/tags/') }}
-        run: echo "TAG_NAME=$(echo ${GITHUB_REF#refs/*/})" >> $GITHUB_ENV
-
-      - name: Set ENCORE_ENV to production [PROD]
-        if: ${{ contains(github.ref, 'refs/tags/') }}
-        run: echo "ENCORE_ENV=production" >> $GITHUB_ENV
+        run: |
+          echo "TAG_NAME=$(echo ${GITHUB_REF#refs/*/})" >> $GITHUB_ENV
+          echo "BUILD_ENV=production" >> $GITHUB_ENV
+          echo "::notice::The ENCORE_ENV variable is deprecated and will be replaced in future by BUILD_ENV"
+          echo "ENCORE_ENV=production" >> $GITHUB_ENV
 
       - name: Compile assets
         run: composer compile-assets ${{ inputs.COMPILE_ASSETS_ARGS }}

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -108,7 +108,7 @@ jobs:
         run: |
           echo "TAG_NAME=$(echo ${GITHUB_REF#refs/*/})" >> $GITHUB_ENV
           echo "BUILD_ENV=production" >> $GITHUB_ENV
-          echo "::notice::The ENCORE_ENV variable is deprecated and will be replaced in future by BUILD_ENV"
+          echo "::warning::The `ENCORE_ENV` variable is deprecated and will be removed soon. Please upgrade to using `BUILD_ENV`."
           echo "ENCORE_ENV=production" >> $GITHUB_ENV
 
       - name: Compile assets

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -97,7 +97,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Set env variables [DEV]
+      - name: Set environment variables [DEV]
         if: ${{ !contains(github.ref, 'refs/tags/') }}
         run: |
           echo "ASSETS_HASH=$(composer assets-hash)" >> $GITHUB_ENV


### PR DESCRIPTION
As described in #33 the "ENCORE_ENV"-variable is way to specific and relates to [Symfony Webpack Encore](https://github.com/symfony/webpack-encore).  Acutally it is possible to use differen build tools in this workflow through [Composer Assets Compiler](https://github.com/inpsyde/composer-asset-compiler). This is why we will set the "ENCORE_ENV" to deprecated and introduce a new env variable "BUILD_ENV".

Signed-off-by: Christian Leucht <3417446+Chrico@users.noreply.github.com>

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)