### PR TITLE
Make possible to specify a working directory

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       WORKING_DIRECTORY:
-        description: The Working Directory.
+        description: Working directory path.
         default: './'
         required: false
         type: string

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       WORKING_DIRECTORY:
-        description: Set a different working directory for the job.
+        description: The Working Directory.
         default: './'
         required: false
         type: string

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -3,6 +3,11 @@ name: Build and push assets
 on:
   workflow_call:
     inputs:
+      WORKING_DIRECTORY:
+        description: Set a different working directory for the job.
+        default: './'
+        required: false
+        type: string
       NODE_VERSION:
         description: Node version with which the assets will be compiled.
         default: 16
@@ -54,6 +59,9 @@ on:
 
 jobs:
   compile-assets:
+    defaults:
+      run:
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -27,6 +27,7 @@ jobs:
 | `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled             |
 | `COMPOSER_ARGS`       | `'--prefer-dist'`             | Set of arguments passed to Composer                             |
 | `COMPILE_ASSETS_ARGS` | `'-v --env=root'`             | Set of arguments passed to Composer Asset Compiler              |
+| `WORKING_DIRECTORY`   | `'./'`                        | Working directory path.                                         |
 
 #### Secrets
 

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -27,7 +27,6 @@ jobs:
 | `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled             |
 | `COMPOSER_ARGS`       | `'--prefer-dist'`             | Set of arguments passed to Composer                             |
 | `COMPILE_ASSETS_ARGS` | `'-v --env=root'`             | Set of arguments passed to Composer Asset Compiler              |
-| `WORKING_DIRECTORY`   | `'./'`                        | Working directory path.                                         |
 
 #### Secrets
 

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -74,6 +74,7 @@ This is not the simplest possible example, but it showcases all the recommendati
 
 | Name                  | Default                         | Description                                                                            |
 |-----------------------|---------------------------------|----------------------------------------------------------------------------------------|
+| `WORKING_DIRECTORY`   | `'./'`                          | Working directory path                                                                 |
 | `NODE_VERSION`        | `16`                            | Node version with which the assets will be compiled                                    |
 | `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"` | Domain of the private npm registry                                                     |
 | `PACKAGE_MANAGER`     | `"auto"` <sup>**^1**</sup>      | Package manager. Supported are "yarn" and "npm". Required if no lock file is available |


### PR DESCRIPTION
There might be edge cases where a project might have different modules or packages requiring a specific configuration to build the assets. In most cases the problem is solvable with monorepo strategies but it's not always possible due to a different set of reasons, mainly legacy reasons and different unresolvable dependencies hierarchies.

Github allow to specify a `workflow-directory` different than the project root which would help in such cases.

The changes are non intrusives and are an opt-in enhancement, hence they will not force any consumer to adapt to the new configuration.  

 