### PR TITLE
Add `NODE_OPTIONS` input

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -65,6 +65,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:
+      NODE_OPTIONS: "--max_old_space_size=8000"
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
       COMPILE_SCRIPT: ${{ inputs.COMPILE_SCRIPT_DEV }} # we'll override if the push is for tag

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -43,6 +43,11 @@ on:
         default: './assets'
         required: false
         type: string
+      NODE_OPTIONS:
+        description: Options for NodeJS Environment.
+        type: string
+        default: ''
+        required: false
     secrets:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
@@ -65,7 +70,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--max_old_space_size=8000"
+      NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
       COMPILE_SCRIPT: ${{ inputs.COMPILE_SCRIPT_DEV }} # we'll override if the push is for tag

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -44,7 +44,7 @@ on:
         required: false
         type: string
       NODE_OPTIONS:
-        description: Options for NodeJS Environment.
+        description: Space-separated list of command-line Node options.
         type: string
         default: ''
         required: false

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -28,6 +28,11 @@ on:
         default: '-v --env=root'
         required: false
         type: string
+      NODE_OPTIONS:
+        description: Space-separated list of command-line Node options.
+        type: string
+        default: ''
+        required: false
     secrets:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
@@ -50,6 +55,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
+      NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -23,6 +23,11 @@ on:
         default: 'yarn'
         required: false
         type: string
+      NODE_OPTIONS:
+        description: Space-separated list of command-line Node options.
+        type: string
+        default: ''
+        required: false
     secrets:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
@@ -33,6 +38,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
+      NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
     steps:
       - name: Checkout

--- a/.github/workflows/static-analysis-sass.yml
+++ b/.github/workflows/static-analysis-sass.yml
@@ -23,6 +23,11 @@ on:
         default: 'yarn'
         required: false
         type: string
+      NODE_OPTIONS:
+        description: Space-separated list of command-line Node options.
+        type: string
+        default: ''
+        required: false
     secrets:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
@@ -33,6 +38,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
+      NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
     steps:
       - name: Checkout

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -23,6 +23,11 @@ on:
         default: 'yarn'
         required: false
         type: string
+      NODE_OPTIONS:
+        description: Space-separated list of command-line Node options.
+        type: string
+        default: ''
+        required: false
     secrets:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
@@ -33,6 +38,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
+      NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
     steps:
       - name: Checkout

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -27,6 +27,7 @@ jobs:
 | `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled             |
 | `COMPOSER_ARGS`       | `'--prefer-dist'`             | Set of arguments passed to Composer                             |
 | `COMPILE_ASSETS_ARGS` | `'-v --env=root'`             | Set of arguments passed to Composer Asset Compiler              |
+| `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options               |
 
 #### Secrets
 

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -82,7 +82,7 @@ This is not the simplest possible example, but it showcases all the recommendati
 | `COMPILE_SCRIPT_PROD` | `'encore prod'`               | Script added to `npm run` or `yarn` to build production assets                         |
 | `COMPILE_SCRIPT_DEV`  | `'encore dev'`                | Script added to `npm run` or `yarn` to build development assets                        |
 | `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                     |
-| `NODE_OPTIONS`        | `''`                          | Options for NodeJS Environment                                                         |
+| `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                      |
 
 <sup>**^1**</sup> `PACKAGE_MANAGER` defaults to "auto" because it tries to determine the package
 manager by looking at lock file (e.g. presence of `yarn.lock` means _Yarn_, `npm-shrinkwrap.json`

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -82,6 +82,7 @@ This is not the simplest possible example, but it showcases all the recommendati
 | `COMPILE_SCRIPT_PROD` | `'encore prod'`               | Script added to `npm run` or `yarn` to build production assets                         |
 | `COMPILE_SCRIPT_DEV`  | `'encore dev'`                | Script added to `npm run` or `yarn` to build development assets                        |
 | `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                     |
+| `NODE_OPTIONS`        | `''`                          | Options for NodeJS Environment                                                         |
 
 <sup>**^1**</sup> `PACKAGE_MANAGER` defaults to "auto" because it tries to determine the package
 manager by looking at lock file (e.g. presence of `yarn.lock` means _Yarn_, `npm-shrinkwrap.json`

--- a/docs/js.md
+++ b/docs/js.md
@@ -26,6 +26,7 @@ jobs:
 | `NODE_VERSION`        | 16                                                                    | Node version with which the assets will be compiled                               |
 | `ESLINT_ARGS`         | `'-o eslint_report.json -f json --ext .js,.jsx,.ts,.tsx ./resources'` | Set of arguments passed to ESLint                                                 |
 | `PACKAGE_MANAGER`     | `yarn`                                                                | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
+| `NODE_OPTIONS`        | `''`                                                                  | Space-separated list of command-line Node options                                 |
 
 #### Secrets
 

--- a/docs/sass.md
+++ b/docs/sass.md
@@ -26,6 +26,7 @@ jobs:
 | `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled                               |
 | `STYLELINT_ARGS`      | `'./resources/**/*.scss'`     | Set of arguments passed to Stylelint                                              |
 | `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
+| `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                 |
 
 #### Secrets
 


### PR DESCRIPTION
Due to a recent Fatal Error produced by an out of memory issue I (as a temporary solution) had to increase the memory available for the Node process.

## The Error

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

## The possible solution

Reading here and there on the web I've see that most of the people simply increase the memory available for the V8 engine on NodeJS.

They set the `--max-old-space-size` to some value like 8gb and this seems solving the problem of the out of memory.

Documentation: https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes

Now, I do not see this as a final and correct solution, the V8 documentation also say to try to split the process into multiple process instead because the obvious reasons related to increasing the memory for a single process and the fact that, jobs tend to increase in memory usage rather than consuming less memory, hence, the problem would be solved only temporary.

I've set an Env variable `NODE_OPTIONS` and I was wondering to know if even in this case would make sense to pass it as an option rather then a fixed configuration (most probably yes), and or if the solution isn't good at all and you would avoid it completely.

Like I said, this is more a temporary patch solution and at somepoint having 1 use case wouldn't be necessary anylonger. Therefore I'm not sure if would help someone else and that's why I created the PR.

If this change wouldn't be approved I would like to keep the branch the time necessary to write a more robust solution.