### PR TITLE
Use github.sha

### DIFF
--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Add commit hash to plugin header
         env:
-          GIT_SHA: ${{ GITHUB_SHA }}
+          GIT_SHA: ${{ github.sha }}
         run: 'sed -Ei "s/SHA: .*/SHA: ${GIT_SHA}/g" ${{ inputs.PLUGIN_MAIN_FILE }}'
 
       - name: Set plugin version header


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here) se 
The use of `${{ GITHUB_SHA }}` gave me a 

>'Unrecognized named-value: 'GITHUB_SHA''

error. 
I am sorry about this, the docs I've seen suggested this was the way to use it. 


**What is the new behavior (if this is a feature change)?**
We now use `${{ github.sha }}` instead, which produces the desired result without errors


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
