### PR TITLE
[Feature] Add to all workflows on.workflow_call.secrets.ENV_VARS.

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -61,6 +61,9 @@ on:
       GITHUB_USER_SSH_KEY:
         description: Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`.
         required: false
+      ENV_VARS:
+        description: Additional environment variables as a JSON formatted object.
+        required: false
 
 jobs:
   compile-assets:
@@ -86,6 +89,17 @@ jobs:
           fetch-depth: 0
           # when current push is a tag, we check out the tag's SHA, we'll create a new branch later
           ref: ${{ ((github.ref_type == 'tag') && github.sha) || github.ref }}
+
+      - name: Set up custom environment variables
+        env:
+          ENV_VARS: ${{ secrets.ENV_VARS }}
+        if: ${{ env.ENV_VARS }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            JSON
+              .parse(process.env.ENV_VARS)
+              .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set production environment variables
         if: ${{ contains(github.ref, 'refs/tags/') }}

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -49,6 +49,9 @@ on:
       GITHUB_USER_SSH_KEY:
         description: Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`.
         required: false
+      ENV_VARS:
+        description: Additional environment variables as a JSON formatted object.
+        required: false
 
 jobs:
   assets-compilation:
@@ -64,6 +67,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up custom environment variables
+        env:
+          ENV_VARS: ${{ secrets.ENV_VARS }}
+        if: ${{ env.ENV_VARS }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            JSON
+              .parse(process.env.ENV_VARS)
+              .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up SSH
         if: ${{ env.GITHUB_USER_SSH_KEY != '' }}

--- a/.github/workflows/coding-standards-php.yml
+++ b/.github/workflows/coding-standards-php.yml
@@ -27,6 +27,9 @@ on:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
         required: false
+      ENV_VARS:
+        description: Additional environment variables as a JSON formatted object.
+        required: false
 
 jobs:
   coding-standards-php:
@@ -37,6 +40,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up custom environment variables
+        env:
+          ENV_VARS: ${{ secrets.ENV_VARS }}
+        if: ${{ env.ENV_VARS }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            JSON
+              .parse(process.env.ENV_VARS)
+              .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -27,6 +27,9 @@ on:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
         required: false
+      ENV_VARS:
+        description: Additional environment variables as a JSON formatted object.
+        required: false
 
 jobs:
   lint-php:
@@ -40,6 +43,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up custom environment variables
+        env:
+          ENV_VARS: ${{ secrets.ENV_VARS }}
+        if: ${{ env.ENV_VARS }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            JSON
+              .parse(process.env.ENV_VARS)
+              .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -32,6 +32,9 @@ on:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
         required: false
+      ENV_VARS:
+        description: Additional environment variables as a JSON formatted object.
+        required: false
 
 jobs:
   static-analysis-js:
@@ -46,6 +49,17 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up custom environment variables
+        env:
+          ENV_VARS: ${{ secrets.ENV_VARS }}
+        if: ${{ env.ENV_VARS }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            JSON
+              .parse(process.env.ENV_VARS)
+              .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up node
         uses: actions/setup-node@v3

--- a/.github/workflows/static-analysis-php.yml
+++ b/.github/workflows/static-analysis-php.yml
@@ -22,6 +22,9 @@ on:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
         required: false
+      ENV_VARS:
+        description: Additional environment variables as a JSON formatted object.
+        required: false
 
 jobs:
   static-analysis-php:
@@ -32,6 +35,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up custom environment variables
+        env:
+          ENV_VARS: ${{ secrets.ENV_VARS }}
+        if: ${{ env.ENV_VARS }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            JSON
+              .parse(process.env.ENV_VARS)
+              .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/static-analysis-sass.yml
+++ b/.github/workflows/static-analysis-sass.yml
@@ -32,6 +32,9 @@ on:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
         required: false
+      ENV_VARS:
+        description: Additional environment variables as a JSON formatted object.
+        required: false
 
 jobs:
   static-analysis-sass:
@@ -46,6 +49,17 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up custom environment variables
+        env:
+          ENV_VARS: ${{ secrets.ENV_VARS }}
+        if: ${{ env.ENV_VARS }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            JSON
+              .parse(process.env.ENV_VARS)
+              .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up node
         uses: actions/setup-node@v3

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -32,6 +32,9 @@ on:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
         required: false
+      ENV_VARS:
+        description: Additional environment variables as a JSON formatted object.
+        required: false
 
 jobs:
   tests-unit-js:
@@ -43,6 +46,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up custom environment variables
+        env:
+          ENV_VARS: ${{ secrets.ENV_VARS }}
+        if: ${{ env.ENV_VARS }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            JSON
+              .parse(process.env.ENV_VARS)
+              .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up node
         uses: actions/setup-node@v3

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -39,11 +39,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-
       - name: Set up custom environment variables
         env:
           ENV_VARS: ${{ secrets.ENV_VARS }}
@@ -54,6 +49,11 @@ jobs:
             JSON
               .parse(process.env.ENV_VARS)
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
 
       - name: Set up problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -56,6 +56,9 @@ on:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
         required: false
+      ENV_VARS:
+        description: Additional environment variables as a JSON formatted object.
+        required: false
 
 jobs:
   static-analysis-assets:
@@ -67,6 +70,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set up custom environment variables
+        env:
+          ENV_VARS: ${{ secrets.ENV_VARS }}
+        if: ${{ env.ENV_VARS }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            JSON
+              .parse(process.env.ENV_VARS)
+              .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up node
         uses: actions/setup-node@v3

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -38,6 +38,7 @@ jobs:
 | `GITHUB_USER_EMAIL`   | Email address for the GitHub user configuration                                          |
 | `GITHUB_USER_NAME`    | Username for the GitHub user configuration                                               |
 | `GITHUB_USER_SSH_KEY` | Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`             |
+| `ENV_VARS`            | Additional environment variables as a JSON formatted object                              |
 
 **Example with configuration parameters:**
 
@@ -52,6 +53,8 @@ jobs:
     secrets:
       COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      ENV_VARS: >-
+        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
     with:
       COMPILE_ASSETS_ARGS: '-vv --env=root'
       NPM_REGISTRY_DOMAIN: 'https://registry.example.com/'

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -54,7 +54,7 @@ jobs:
       COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       ENV_VARS: >-
-        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
+        [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
     with:
       COMPILE_ASSETS_ARGS: '-vv --env=root'
       NPM_REGISTRY_DOMAIN: 'https://registry.example.com/'

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -97,7 +97,7 @@ then `PACKAGE_MANAGER` input is required**.
 | `GITHUB_USER_EMAIL`   | Email address for the GitHub user configuration                              |
 | `GITHUB_USER_NAME`    | Username for the GitHub user configuration                                   |
 | `GITHUB_USER_SSH_KEY` | Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME` |
-| `ENV_VARS`           | Additional environment variables as a JSON formatted object                              |
+| `ENV_VARS`            | Additional environment variables as a JSON formatted object                  |
 
 ## FAQ
 

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -137,7 +137,7 @@ jobs:
       GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.INPSYDE_BOT_USER }}
       ENV_VARS: >-
-        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
+        [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
 ```
 
 ---

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -97,6 +97,7 @@ then `PACKAGE_MANAGER` input is required**.
 | `GITHUB_USER_EMAIL`   | Email address for the GitHub user configuration                              |
 | `GITHUB_USER_NAME`    | Username for the GitHub user configuration                                   |
 | `GITHUB_USER_SSH_KEY` | Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME` |
+| `ENV_VARS`           | Additional environment variables as a JSON formatted object                              |
 
 ## FAQ
 
@@ -135,6 +136,8 @@ jobs:
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.INPSYDE_BOT_USER }}
+      ENV_VARS: >-
+        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
 ```
 
 ---

--- a/docs/js.md
+++ b/docs/js.md
@@ -32,9 +32,10 @@ jobs:
 
 #### Secrets
 
-| Name                 | Description                                 |
-|----------------------|---------------------------------------------|
-| `NPM_REGISTRY_TOKEN` | Authentication for the private npm registry |
+| Name                 | Description                                                 |
+|----------------------|-------------------------------------------------------------|
+| `NPM_REGISTRY_TOKEN` | Authentication for the private npm registry                 |
+| `ENV_VARS`           | Additional environment variables as a JSON formatted object |
 
 **Example with configuration parameters:**
 
@@ -47,6 +48,8 @@ jobs:
     uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-js.yml@main
     secrets:
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      ENV_VARS: >-
+        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
     with:
       NODE_VERSION: 14
       ESLINT_ARGS: './resources --ext .js'
@@ -83,9 +86,10 @@ jobs:
 
 #### Secrets
 
-| Name                 | Description                                 |
-|----------------------|---------------------------------------------|
-| `NPM_REGISTRY_TOKEN` | Authentication for the private npm registry |
+| Name                 | Description                                                 |
+|----------------------|-------------------------------------------------------------|
+| `NPM_REGISTRY_TOKEN` | Authentication for the private npm registry                 |
+| `ENV_VARS`           | Additional environment variables as a JSON formatted object |
 
 **Example with configuration parameters:**
 
@@ -98,6 +102,8 @@ jobs:
     uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-js.yml@main
     secrets:
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      ENV_VARS: >-
+        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
     with:
       NODE_VERSION: 14
       JEST_ARGS: 'my-test --reporters=jest-junit --coverage'

--- a/docs/js.md
+++ b/docs/js.md
@@ -49,7 +49,7 @@ jobs:
     secrets:
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       ENV_VARS: >-
-        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
+        [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
     with:
       NODE_VERSION: 14
       ESLINT_ARGS: './resources --ext .js'
@@ -103,7 +103,7 @@ jobs:
     secrets:
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       ENV_VARS: >-
-        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
+        [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
     with:
       NODE_VERSION: 14
       JEST_ARGS: 'my-test --reporters=jest-junit --coverage'

--- a/docs/php.md
+++ b/docs/php.md
@@ -46,7 +46,7 @@ jobs:
     secrets:
       COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
       ENV_VARS: >-
-        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
+        [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
     with:
       PHPCS_ARGS: '--report=summary'
 ```
@@ -99,7 +99,7 @@ jobs:
     secrets:
       COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
       ENV_VARS: >-
-        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
+        [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
     with:
       PSALM_ARGS: '--threads=3'
 ```
@@ -151,7 +151,7 @@ jobs:
     secrets:
       COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
       ENV_VARS: >-
-        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}, {"name":"EXAMPLE_TOKEN", "value":"${{ secrets.EXAMPLE_TOKEN }}"}]
+        [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
     with:
       PHP_MATRIX: >-
         ["7.4", "8.0", "8.1"]
@@ -203,7 +203,7 @@ jobs:
     secrets:
       COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
       ENV_VARS: >-
-        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
+        [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
     with:
       PHP_MATRIX: >-
         ["7.4", "8.0", "8.1"]

--- a/docs/php.md
+++ b/docs/php.md
@@ -32,6 +32,7 @@ jobs:
 | Name                 | Description                                                                              |
 |----------------------|------------------------------------------------------------------------------------------|
 | `COMPOSER_AUTH_JSON` | Authentication for privately hosted packages and repositories as a JSON formatted object |
+| `ENV_VARS`           | Additional environment variables as a JSON formatted object                              |
 
 **Example with configuration parameters:**
 
@@ -44,6 +45,8 @@ jobs:
     uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
     secrets:
       COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
+      ENV_VARS: >-
+        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
     with:
       PHPCS_ARGS: '--report=summary'
 ```
@@ -82,6 +85,7 @@ jobs:
 | Name                 | Description                                                                              |
 |----------------------|------------------------------------------------------------------------------------------|
 | `COMPOSER_AUTH_JSON` | Authentication for privately hosted packages and repositories as a JSON formatted object |
+| `ENV_VARS`           | Additional environment variables as a JSON formatted object                              |
 
 **Example with configuration parameters:**
 
@@ -94,6 +98,8 @@ jobs:
     uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@main
     secrets:
       COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
+      ENV_VARS: >-
+        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
     with:
       PSALM_ARGS: '--threads=3'
 ```
@@ -183,6 +189,7 @@ jobs:
 | Name                 | Description                                                                              |
 |----------------------|------------------------------------------------------------------------------------------|
 | `COMPOSER_AUTH_JSON` | Authentication for privately hosted packages and repositories as a JSON formatted object |
+| `ENV_VARS`           | Additional environment variables as a JSON formatted object                              |
 
 **Example with configuration parameters:**
 
@@ -195,6 +202,8 @@ jobs:
     uses: inpsyde/reusable-workflows/.github/workflows/lint-php.yml@main
     secrets:
       COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
+      ENV_VARS: >-
+        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
     with:
       PHP_MATRIX: >-
         ["7.4", "8.0", "8.1"]

--- a/docs/sass.md
+++ b/docs/sass.md
@@ -49,7 +49,7 @@ jobs:
     secrets:
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       ENV_VARS: >-
-        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
+        [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
     with:
       NODE_VERSION: 14
       STYLELINT_ARGS: './assets/scss/*.scss'

--- a/docs/sass.md
+++ b/docs/sass.md
@@ -32,9 +32,10 @@ jobs:
 
 #### Secrets
 
-| Name                 | Description                                 |
-|----------------------|---------------------------------------------|
-| `NPM_REGISTRY_TOKEN` | Authentication for the private npm registry |
+| Name                 | Description                                                 |
+|----------------------|-------------------------------------------------------------|
+| `NPM_REGISTRY_TOKEN` | Authentication for the private npm registry                 |
+| `ENV_VARS`           | Additional environment variables as a JSON formatted object |
 
 **Example with configuration parameters:**
 
@@ -47,6 +48,8 @@ jobs:
     uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-sass.yml@main
     secrets:
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      ENV_VARS: >-
+        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
     with:
       NODE_VERSION: 14
       STYLELINT_ARGS: './assets/scss/*.scss'

--- a/docs/wp-scripts.md
+++ b/docs/wp-scripts.md
@@ -37,9 +37,10 @@ jobs:
 
 #### Secrets
 
-| Name                 | Description                                 |
-|----------------------|---------------------------------------------|
-| `NPM_REGISTRY_TOKEN` | Authentication for the private npm registry |
+| Name                 | Description                                                 |
+|----------------------|-------------------------------------------------------------|
+| `NPM_REGISTRY_TOKEN` | Authentication for the private npm registry                 |
+| `ENV_VARS`           | Additional environment variables as a JSON formatted object |
 
 **Example with configuration parameters:**
 
@@ -52,6 +53,8 @@ jobs:
     uses: inpsyde/reusable-workflows/.github/workflows/wp-scripts-lint-js.yml@main
     secrets:
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      ENV_VARS: >-
+        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
     with:
       NODE_VERSION: 18
       ESLINT_ARGS: '-o eslint_report.json -f json'

--- a/docs/wp-scripts.md
+++ b/docs/wp-scripts.md
@@ -54,7 +54,7 @@ jobs:
     secrets:
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       ENV_VARS: >-
-        [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
+        [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
     with:
       NODE_VERSION: 18
       ESLINT_ARGS: '-o eslint_report.json -f json'


### PR DESCRIPTION
This commit will generalize the usage of ENV_VARS across all reusable workflows. ENV_VARS will be handled as "secrets" and can be a JSON string like following:

```
ENV_VARS: >-
    [{"name":"EXAMPLE_USERNAME", "value":"deploybot"}]
```

All ENV_VARS will be set in an own step through "actions/github-script" right after the "actions/checkout"-step to make them available as soon as possible.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


Fixes #51