### PR TITLE
Feature/setup node cache mode correctly and generalize inputs

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
-      - name: Setup Git
+      - name: Set up Git
         run: |
           git config --global user.email "${{ secrets.GITHUB_USER_EMAIL }}" 
           git config --global user.name "${{ secrets.GITHUB_USER_NAME }}"
@@ -132,7 +132,7 @@ jobs:
           git checkout -b bot/compiled-assets/${{ github.sha }}
           echo "TAG_BRANCH_NAME=bot/compiled-assets/${{ github.sha }}" >> $GITHUB_ENV
 
-      - name: Setup node cache mode
+      - name: Set up node cache mode
         run: |
           if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
             echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -3,14 +3,24 @@ name: Build and push assets
 on:
   workflow_call:
     inputs:
+      NODE_OPTIONS:
+        description: Space-separated list of command-line Node options.
+        type: string
+        default: ''
+        required: false
+      NODE_VERSION:
+        description: Node version with which the static code analysis is to be executed.
+        default: 16
+        required: false
+        type: string
       NPM_REGISTRY_DOMAIN:
         description: Domain of the private npm registry.
         default: https://npm.pkg.github.com/
         required: false
         type: string
-      NODE_VERSION:
-        description: Node version with which the assets will be compiled.
-        default: 16
+      PACKAGE_MANAGER:
+        description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
+        default: 'yarn'
         required: false
         type: string
       WORKING_DIRECTORY:
@@ -18,11 +28,6 @@ on:
         default: './'
         required: false
         type: string
-      PACKAGE_MANAGER:
-        description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
-        type: string
-        default: 'auto'
-        required: false
       DEPS_INSTALL:
         description: Whether or not to install dependencies before compiling.
         type: boolean
@@ -43,11 +48,6 @@ on:
         default: './assets'
         required: false
         type: string
-      NODE_OPTIONS:
-        description: Space-separated list of command-line Node options.
-        type: string
-        default: ''
-        required: false
     secrets:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
@@ -75,6 +75,7 @@ jobs:
     env:
       NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      NODE_CACHE_MODE: ''
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
       COMPILE_SCRIPT: ${{ inputs.COMPILE_SCRIPT_DEV }} # we'll override if the push is for tag
       TAG_NAME: ''                                     # we'll override if the push is for tag
@@ -131,31 +132,27 @@ jobs:
           git checkout -b bot/compiled-assets/${{ github.sha }}
           echo "TAG_BRANCH_NAME=bot/compiled-assets/${{ github.sha }}" >> $GITHUB_ENV
 
-      - name: Try determining package manager by lock file
-        if: ${{ inputs.PACKAGE_MANAGER == 'auto' }}
+      - name: Setup node cache mode
         run: |
-          [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "LOCK_FILE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
-          [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "LOCK_FILE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
-          [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "LOCK_FILE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
-
-      - name: Warning for fallback package manager
-        if: ${{ (inputs.PACKAGE_MANAGER == 'auto') && (env.LOCK_FILE == '') }}
-        run: echo "::warning::PACKAGE_MANAGER input not defined, and no lock file found, using Yarn as default."
-
-      - name: Determine package manager
-        if: ${{ (env.LOCK_FILE == 'npm') || (inputs.PACKAGE_MANAGER == 'npm') }}
-        run: echo "PACKAGE_MANAGER=npm" >> $GITHUB_ENV
+          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
+            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
+          elif [ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ]; then
+            echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
+          else
+            echo "No lock files found or unknown package manager"
+          fi
 
       - name: Set up node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          cache: ${{ env.PACKAGE_MANAGER }}
+          cache: ${{ env.NODE_CACHE_MODE }}
 
       - name: Install dependencies
-        if: ${{ inputs.DEPS_INSTALL }}
-        run: ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
+        env:
+          ARGS: ${{ env.NODE_CACHE_MODE == 'yarn' && '--frozen-lockfile' || env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
+        run: ${{ format('{0} {1}', inputs.PACKAGE_MANAGER, env.ARGS) }}
 
       - name: Compile assets
         run: ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm run' }} ${{ env.COMPILE_SCRIPT }}

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -91,13 +91,13 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
-      - name: Setup Git
+      - name: Set up Git
         if: ${{ env.GITHUB_USER_EMAIL != '' && env.GITHUB_USER_NAME != '' }}
         run: |
           git config --global user.email "${{ secrets.GITHUB_USER_EMAIL }}" 
           git config --global user.name "${{ secrets.GITHUB_USER_NAME }}"
 
-      - name: Setup node cache mode
+      - name: Set up node cache mode
         run: |
           if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
             echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
@@ -137,7 +137,7 @@ jobs:
         run: |
           echo "TAG_NAME=$(echo ${GITHUB_REF#refs/*/})" >> $GITHUB_ENV
           echo "BUILD_ENV=production" >> $GITHUB_ENV
-          echo "::notice::The `ENCORE_ENV` variable is deprecated and will be removed soon. If you use it, please change it to `BUILD_ENV`."
+          echo "::notice::The ENCORE_ENV variable is deprecated and will be removed soon. If you use it, please change it to BUILD_ENV."
           echo "ENCORE_ENV=production" >> $GITHUB_ENV
 
       - name: Compile assets

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -3,9 +3,14 @@ name: Assets compilation
 on:
   workflow_call:
     inputs:
-      PHP_VERSION:
-        description: PHP version with which the assets compilation is to be executed.
-        default: "8.0"
+      NODE_OPTIONS:
+        description: Space-separated list of command-line Node options.
+        type: string
+        default: ''
+        required: false
+      NODE_VERSION:
+        description: Node version with which the static code analysis is to be executed.
+        default: 16
         required: false
         type: string
       NPM_REGISTRY_DOMAIN:
@@ -13,9 +18,14 @@ on:
         default: https://npm.pkg.github.com/
         required: false
         type: string
-      NODE_VERSION:
-        description: Node version with which the assets will be compiled.
-        default: 16
+      PACKAGE_MANAGER:
+        description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
+        default: 'yarn'
+        required: false
+        type: string
+      PHP_VERSION:
+        description: PHP version with which the assets compilation is to be executed.
+        default: "8.0"
         required: false
         type: string
       COMPOSER_ARGS:
@@ -28,11 +38,6 @@ on:
         default: '-v --env=root'
         required: false
         type: string
-      NODE_OPTIONS:
-        description: Space-separated list of command-line Node options.
-        type: string
-        default: ''
-        required: false
     secrets:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
@@ -59,8 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
-      COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      NODE_CACHE_MODE: ''
+      COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
       GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
       GITHUB_USER_EMAIL: ${{ secrets.GITHUB_USER_EMAIL }}
@@ -91,11 +97,22 @@ jobs:
           git config --global user.email "${{ secrets.GITHUB_USER_EMAIL }}" 
           git config --global user.name "${{ secrets.GITHUB_USER_NAME }}"
 
+      - name: Setup node cache mode
+        run: |
+          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
+            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
+          elif [ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ]; then
+            echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
+          else
+            echo "No lock files found or unknown package manager"
+          fi
+
       - name: Set up node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
+          cache: ${{ env.NODE_CACHE_MODE }}
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -108,14 +125,6 @@ jobs:
         uses: ramsey/composer-install@v2
         with:
           composer-options: ${{ inputs.COMPOSER_ARGS }}
-
-      - name: Cache npm dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
       - name: Set environment variables [DEV]
         if: ${{ !contains(github.ref, 'refs/tags/') }}

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup plugin base name
+      - name: Set up plugin base name
         env:
           ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
         id: plugin-data
@@ -104,7 +104,7 @@ jobs:
               .parse(process.env.ENV_VARS)
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
-      - name: Setup node cache mode
+      - name: Set up node cache mode
         run: |
           if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
             echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -3,6 +3,41 @@ name: Create plugin archive
 on:
   workflow_call:
     inputs:
+      NODE_OPTIONS:
+        description: Space-separated list of command-line Node options.
+        type: string
+        default: ''
+        required: false
+      NODE_VERSION:
+        description: Node version with which the static code analysis is to be executed.
+        default: 16
+        required: false
+        type: string
+      NPM_REGISTRY_DOMAIN:
+        description: Domain of the private npm registry.
+        default: https://npm.pkg.github.com/
+        required: false
+        type: string
+      PACKAGE_MANAGER:
+        description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
+        default: 'yarn'
+        required: false
+        type: string
+      COMPOSER_ARGS:
+        description: Set of arguments passed to Composer.
+        default: '--no-dev --no-scripts --prefer-dist --optimize-autoloader'
+        required: false
+        type: string
+      PHP_VERSION:
+        description: PHP version to use during packaging.
+        default: "8.0"
+        required: false
+        type: string
+      ARCHIVE_NAME:
+        description: The base name of the resulting zip archive. Falls back to the repository name.
+        default: ''
+        required: false
+        type: string
       PLUGIN_MAIN_FILE:
         description: The name of the main plugin file.
         required: false
@@ -12,41 +47,11 @@ on:
         description: The new plugin version.
         required: true
         type: string
-      ARCHIVE_NAME:
-        description: The base name of the resulting zip archive. Falls back to the repository name.
-        default: ''
-        required: false
-        type: string
-      COMPOSER_ARGS:
-        description: Set of arguments passed to Composer.
-        default: '--no-dev --no-scripts --prefer-dist --optimize-autoloader'
-        required: false
-        type: string
-      NPM_REGISTRY_DOMAIN:
-        description: Domain of the private npm registry.
-        default: https://npm.pkg.github.com/
-        required: false
-        type: string
-      NODE_VERSION:
-        description: Node version to use for asset compilation.
-        default: 16
-        required: false
-        type: string
-      PHP_VERSION:
-        description: PHP version to use during packaging.
-        default: "8.0"
-        required: false
-        type: string
       PRE_SCRIPT:
         description: Run custom shell code before creating the release archive.
         default: ''
         required: false
         type: string
-      PACKAGE_MANAGER:
-          description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
-          default: 'yarn'
-          required: false
-          type: string
     secrets:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
@@ -63,12 +68,14 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
+      NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      NODE_CACHE_MODE: ''
+      COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
       # Disables symlinking of local path repositories.
       # During development, symlinking is preferable.
       # In resulting builds, you will likely want to ship the actual install location and remove the source directory.
       COMPOSER_MIRROR_PATH_REPOS: 1
-      COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
     outputs:
       artifact: ${{ steps.set-artifact-name.outputs.artifact }}
     steps:
@@ -96,6 +103,16 @@ jobs:
             JSON
               .parse(process.env.ENV_VARS)
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
+
+      - name: Setup node cache mode
+        run: |
+          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
+            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
+          elif [ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ]; then
+            echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
+          else
+            echo "No lock files found or unknown package manager"
+          fi
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -149,7 +166,7 @@ jobs:
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          cache: ${{ inputs.PACKAGE_MANAGER }}
+          cache: ${{ env.NODE_CACHE_MODE }}
 
       - name: Add commit hash to plugin header
         env:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -137,20 +137,6 @@ jobs:
           echo "assets-compiler=$( hasDep inpsyde/composer-assets-compiler )" >> $GITHUB_OUTPUT
           echo "translation-downloader=$( hasDep inpsyde/wp-translation-downloader )" >> $GITHUB_OUTPUT
 
-      - name: Run Composer Asset Compiler
-        if: steps.composer-tools.outputs.assets-compiler == '0'
-        run: composer compile-assets
-
-      - name: Run WordPress Translation Downloader
-        if: steps.composer-tools.outputs.translation-downloader == '0'
-        run: composer wp-translation-downloader:download
-
-      - name: Install Composer dependencies without dev dependencies
-        # ⬑ Now we want to get rid of dev dependencies and most probably skip composer scripts
-        uses: ramsey/composer-install@v2
-        with:
-          composer-options: ${{ inputs.COMPOSER_ARGS }}
-
       - name: Check for package.json
         id: check-for-package
         run: |
@@ -167,6 +153,20 @@ jobs:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
           cache: ${{ env.NODE_CACHE_MODE }}
+
+      - name: Run Composer Asset Compiler
+        if: steps.composer-tools.outputs.assets-compiler == '0' && steps.check-for-package.outputs.has_package == 'true'
+        run: composer compile-assets
+
+      - name: Run WordPress Translation Downloader
+        if: steps.composer-tools.outputs.translation-downloader == '0'
+        run: composer wp-translation-downloader:download
+
+      - name: Install Composer dependencies without dev dependencies
+        # ⬑ Now we want to get rid of dev dependencies and most probably skip composer scripts
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: ${{ inputs.COMPOSER_ARGS }}
 
       - name: Add commit hash to plugin header
         env:

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -45,7 +45,7 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
     steps:
       - name: Deprecation warning
-        run: echo "::warning::This workflow is deprecated and will be replaced by the `@wordpress/scripts` workflow (`wp-scripts-lint.yml`) in the future."
+        run: echo "::warning::This workflow is deprecated and will be replaced by the @wordpress/scripts workflow (wp-scripts-lint.yml) in the future."
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/static-analysis-sass.yml
+++ b/.github/workflows/static-analysis-sass.yml
@@ -45,7 +45,7 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
     steps:
       - name: Deprecation warning
-        run: echo "::warning::This workflow is deprecated and will be replaced by the `@wordpress/scripts` workflow (`wp-scripts-lint.yml`) in the future."
+        run: echo "::warning::This workflow is deprecated and will be replaced by the @wordpress/scripts workflow (wp-scripts-lint.yml) in the future."
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -97,22 +97,24 @@ jobs:
           cache: ${{ env.NODE_CACHE_MODE }}
 
       - name: Install dependencies
-        run: |
-          if [[ "${{ inputs.PACKAGE_MANAGER }}" == "yarn" ]]; then
-            if [[ "${{ env.NODE_CACHE_MODE }}" == "" ]]; then
-              yarn
-            else
-              yarn --frozen-lockfile
-            fi
-          elif  [[ "${{ inputs.PACKAGE_MANAGER }}" == "npm" ]]; then
-            if [[ "${{ env.NODE_CACHE_MODE }}" == "" ]]; then
-                npm install
-            else
-                npm ci
-            fi
-          else
-            echo "PACKAGE_MANAGER ${{ inputs.PACKAGE_MANAGER }} is not supported by this workflow."
-          fi
+        run: ${{ inputs.PACKAGE_MANAGER }}
+      #- name: Install dependencies
+      #  run: |
+      #    if [[ "${{ inputs.PACKAGE_MANAGER }}" == "yarn" ]]; then
+      #      if [[ "${{ env.NODE_CACHE_MODE }}" == "" ]]; then
+      #        yarn
+      #      else
+      #        yarn --frozen-lockfile
+      #      fi
+      #    elif  [[ "${{ inputs.PACKAGE_MANAGER }}" == "npm" ]]; then
+      #      if [[ "${{ env.NODE_CACHE_MODE }}" == "" ]]; then
+      #          npm install
+      #      else
+      #          npm ci
+      #      fi
+      #    else
+      #      echo "PACKAGE_MANAGER ${{ inputs.PACKAGE_MANAGER }} is not supported by this workflow."
+      #    fi
 
       - name: Lint script files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'js') }}

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -96,22 +96,22 @@ jobs:
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
           cache: ${{ env.NODE_CACHE_MODE }}
 
-      - name: Install dependencies [yarn]
-        if: ${{ inputs.PACKAGE_MANAGER == 'yarn' }}
+      - name: Install dependencies
         run: |
-          if [[ "${{ env.NODE_CACHE_MODE }}" == "" ]]; then
-            yarn
+          if [[ "${{ inputs.PACKAGE_MANAGER }}" == "yarn" ]]; then
+            if [[ "${{ env.NODE_CACHE_MODE }}" == "" ]]; then
+              yarn
+            else
+              yarn --frozen-lockfile
+            fi
+          elif  [[ "${{ inputs.PACKAGE_MANAGER }}" == "npm" ]]; then
+            if [[ "${{ env.NODE_CACHE_MODE }}" == "" ]]; then
+                npm install
+            else
+                npm ci
+            fi
           else
-            yarn --frozen-lockfile
-          fi
-
-      - name: Install dependencies [npm]
-        if: ${{ inputs.PACKAGE_MANAGER == 'npm' }}
-        run: |
-          if [[ "${{ env.NODE_CACHE_MODE }}" == "" ]]; then
-              npm install
-          else
-              npm ci
+            echo "PACKAGE_MANAGER ${{ inputs.PACKAGE_MANAGER }} is not supported by this workflow."
           fi
 
       - name: Lint script files

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -3,14 +3,19 @@ name: WP Scripts lint
 on:
   workflow_call:
     inputs:
-      NPM_REGISTRY_DOMAIN:
-        description: Domain of the private npm registry.
-        default: https://npm.pkg.github.com/
-        required: false
+      NODE_OPTIONS:
+        description: Space-separated list of command-line Node options.
         type: string
+        default: ''
+        required: false
       NODE_VERSION:
         description: Node version with which the static code analysis is to be executed.
         default: 16
+        required: false
+        type: string
+      NPM_REGISTRY_DOMAIN:
+        description: Domain of the private npm registry.
+        default: https://npm.pkg.github.com/
         required: false
         type: string
       PACKAGE_MANAGER:
@@ -18,11 +23,6 @@ on:
         default: 'yarn'
         required: false
         type: string
-      NODE_OPTIONS:
-        description: Space-separated list of command-line Node options.
-        type: string
-        default: ''
-        required: false
       LINT_TOOLS:
         description: Array of checks to be executed by @wordpress/scripts.
         # [!] Note: "pkg-json" is not included by default. This is currently internally reviewed.
@@ -85,9 +85,13 @@ jobs:
 
       - name: Setup node cache mode
         run: |
-          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]] && [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
-          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]] && [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
-          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ]] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
+          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
+            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
+          elif [ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ]; then
+            echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
+          else
+            echo "No lock files found or unknown package manager"
+          fi
 
       - name: Set up node
         uses: actions/setup-node@v3

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -84,10 +84,10 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Setup node cache mode
-        run: |          
-          [ ${{ inputs.PACKAGE_MANAGER }} == "npm" && -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
-          [ ${{ inputs.PACKAGE_MANAGER }} == "npm" && -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
-          [ ${{ inputs.PACKAGE_MANAGER }} == "yarn" &&-f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
+        run: |
+          [ ${{ inputs.PACKAGE_MANAGER }} == "npm" ] && [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
+          [ ${{ inputs.PACKAGE_MANAGER }} == "npm" ] && [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
+          [ ${{ inputs.PACKAGE_MANAGER }} == "yarn" ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
 
       - name: Set up node
         uses: actions/setup-node@v3

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Install dependencies [yarn]
         if: ${{ inputs.PACKAGE_MANAGER }} == "yarn" }}
         run: |
-          if [[ ${{env.NODE_CACHE_MODE}} === '']] then
+          if [[ ${{ env.NODE_CACHE_MODE }} == '']] then
             yarn
           else
             yarn --frozen-lockfile
@@ -114,7 +114,7 @@ jobs:
       - name: Install dependencies [npm]
         if: ${{ inputs.PACKAGE_MANAGER }} == "npm" }}
         run: |
-          if [[ ${{env.NODE_CACHE_MODE}} === '']] then
+          if [[ ${{ env.NODE_CACHE_MODE }} == '']] then
               npm install
           else
               npm ci

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -98,10 +98,8 @@ jobs:
 
       - name: Install dependencies [yarn]
         if: ${{ inputs.PACKAGE_MANAGER }} == "yarn" }}
-        env:
-          NODE_CACHE_MODE: ${{ env.NODE_CACHE_MODE }}
         run: |
-          if [[ ${{ NODE_CACHE_MODE }} == '']] then
+          if [[ "${{ env.NODE_CACHE_MODE }}" == '']] then
             yarn
           else
             yarn --frozen-lockfile
@@ -109,10 +107,8 @@ jobs:
 
       - name: Install dependencies [npm]
         if: ${{ inputs.PACKAGE_MANAGER }} == "npm" }}
-        env:
-          NODE_CACHE_MODE: ${{ env.NODE_CACHE_MODE }}
         run: |
-          if [[ ${{ NODE_CACHE_MODE }} == '']] then
+          if [[ "${{ env.NODE_CACHE_MODE }}" == '']] then
               npm install
           else
               npm ci

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -85,9 +85,9 @@ jobs:
 
       - name: Setup node cache mode
         run: |
-          [ ${{ inputs.PACKAGE_MANAGER }} == "npm" ] && [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
-          [ ${{ inputs.PACKAGE_MANAGER }} == "npm" ] && [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
-          [ ${{ inputs.PACKAGE_MANAGER }} == "yarn" ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
+          [ "${{ inputs.PACKAGE_MANAGER }}" == "npm" ] && [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
+          [ "${{ inputs.PACKAGE_MANAGER }}" == "npm" ] && [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
+          [ "${{ inputs.PACKAGE_MANAGER }}" == "yarn" ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
 
       - name: Set up node
         uses: actions/setup-node@v3
@@ -97,7 +97,7 @@ jobs:
           cache: ${{ env.NODE_CACHE_MODE }}
 
       - name: Install dependencies [yarn]
-        if: ${{ inputs.PACKAGE_MANAGER }} == "yarn" }}
+        if: ${{ inputs.PACKAGE_MANAGER == "yarn" }}
         run: |
           if [ "${{ env.NODE_CACHE_MODE }}" == '']; then
             yarn
@@ -106,7 +106,7 @@ jobs:
           fi
 
       - name: Install dependencies [npm]
-        if: ${{ inputs.PACKAGE_MANAGER }} == "npm" }}
+        if: ${{ inputs.PACKAGE_MANAGER == "npm" }}
         run: |
           if [ "${{ env.NODE_CACHE_MODE }}" == '']; then
               npm install

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -67,6 +67,7 @@ jobs:
     env:
       NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      NODE_CACHE_MODE: ''
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -82,15 +83,40 @@ jobs:
               .parse(process.env.ENV_VARS)
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
+      - name: Setup node cache mode
+        run: |
+          if [[ ${{ inputs.PACKAGE_MANAGER }} == "yarn" && -f "${GITHUB_WORKSPACE}/yarn.lock" ]]; then
+            echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
+          elif [[ ${{ inputs.PACKAGE_MANAGER }} == "npm" && -f "${GITHUB_WORKSPACE}/package-lock.json" ]]; then
+            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
+          elif [[ ${{ inputs.PACKAGE_MANAGER }} == "npm" && -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]]; then
+            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
+          fi
+
       - name: Set up node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          cache: ${{ inputs.PACKAGE_MANAGER }}
+          cache: ${{ env.NODE_CACHE_MODE }}
 
-      - name: Install dependencies
-        run: ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
+      - name: Install dependencies [yarn]
+        if: ${{ inputs.PACKAGE_MANAGER }} == "yarn" }}
+        run: |
+          if [[ ${{env.NODE_CACHE_MODE}} === '']] then
+            yarn
+          else
+            yarn --frozen-lockfile
+          fi
+
+      - name: Install dependencies [npm]
+        if: ${{ inputs.PACKAGE_MANAGER }} == "npm" }}
+        run: |
+          if [[ ${{env.NODE_CACHE_MODE}} === '']] then
+              npm install
+          else
+              npm ci
+          fi
 
       - name: Lint script files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'js') }}

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -83,7 +83,7 @@ jobs:
               .parse(process.env.ENV_VARS)
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
-      - name: Setup node cache mode
+      - name: Set up node cache mode
         run: |
           if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
             echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -85,8 +85,9 @@ jobs:
 
       - name: Setup node cache mode
         run: |
-          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]] && ( [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] ) && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
-          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ]] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
+          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]] && [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
+          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]] && [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
+          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ]] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
 
       - name: Set up node
         uses: actions/setup-node@v3

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -85,9 +85,9 @@ jobs:
 
       - name: Setup node cache mode
         run: |
-          [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
-          [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
-          [ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
+          [ "${{ inputs.PACKAGE_MANAGER }}" = 'npm' ] && [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
+          [ "${{ inputs.PACKAGE_MANAGER }}" = 'npm' ] && [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
+          [ "${{ inputs.PACKAGE_MANAGER }}" = 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
 
       - name: Set up node
         uses: actions/setup-node@v3
@@ -97,9 +97,9 @@ jobs:
           cache: ${{ env.NODE_CACHE_MODE }}
 
       - name: Install dependencies [yarn]
-        if: ${{ inputs.PACKAGE_MANAGER == 'yarn' }}
+        if: ${{ inputs.PACKAGE_MANAGER = 'yarn' }}
         run: |
-          if [ "${{ env.NODE_CACHE_MODE }}" == '']; then
+          if [ "${{ env.NODE_CACHE_MODE }}" = ""]; then
             yarn
           else
             yarn --frozen-lockfile
@@ -108,7 +108,7 @@ jobs:
       - name: Install dependencies [npm]
         if: ${{ inputs.PACKAGE_MANAGER == 'npm' }}
         run: |
-          if [ "${{ env.NODE_CACHE_MODE }}" == '']; then
+          if [ "${{ env.NODE_CACHE_MODE }}" = ""]; then
               npm install
           else
               npm ci

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -91,6 +91,8 @@ jobs:
             echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
           elif [[ ${{ inputs.PACKAGE_MANAGER }} == "npm" && -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]]; then
             echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
+          else
+            echo "No .lock files were found. Using no NODE_CACHE_MODE"
           fi
 
       - name: Set up node

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install dependencies [yarn]
         if: ${{ inputs.PACKAGE_MANAGER }} == "yarn" }}
         run: |
-          if [[ "${{ env.NODE_CACHE_MODE }}" == '']] then
+          if [ "${{ env.NODE_CACHE_MODE }}" == '']; then
             yarn
           else
             yarn --frozen-lockfile
@@ -108,7 +108,7 @@ jobs:
       - name: Install dependencies [npm]
         if: ${{ inputs.PACKAGE_MANAGER }} == "npm" }}
         run: |
-          if [[ "${{ env.NODE_CACHE_MODE }}" == '']] then
+          if [ "${{ env.NODE_CACHE_MODE }}" == '']; then
               npm install
           else
               npm ci

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -101,9 +101,6 @@ jobs:
           ARGS: ${{ env.NODE_CACHE_MODE == 'yarn' && '--frozen-lockfile' || env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
         run: ${{ format('{0} {1}', inputs.PACKAGE_MANAGER, env.ARGS) }}
 
-      #- name: Install dependencies
-      #  run: ${{ env.INSTALL_NPM_DEPS_CMD }}
-
       - name: Lint script files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'js') }}
         run: ./node_modules/.bin/wp-scripts lint-js ${{ inputs.ESLINT_ARGS }}

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -85,9 +85,9 @@ jobs:
 
       - name: Setup node cache mode
         run: |
-          [ "${{ inputs.PACKAGE_MANAGER }}" = 'npm' ] && [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
-          [ "${{ inputs.PACKAGE_MANAGER }}" = 'npm' ] && [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
-          [ "${{ inputs.PACKAGE_MANAGER }}" = 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
+          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]] && [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
+          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]] && [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
+          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ]] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
 
       - name: Set up node
         uses: actions/setup-node@v3
@@ -99,7 +99,7 @@ jobs:
       - name: Install dependencies [yarn]
         if: ${{ inputs.PACKAGE_MANAGER = 'yarn' }}
         run: |
-          if [ "${{ env.NODE_CACHE_MODE }}" = ""]; then
+          if [[ "${{ env.NODE_CACHE_MODE }}" == ""]]; then
             yarn
           else
             yarn --frozen-lockfile
@@ -108,7 +108,7 @@ jobs:
       - name: Install dependencies [npm]
         if: ${{ inputs.PACKAGE_MANAGER == 'npm' }}
         run: |
-          if [ "${{ env.NODE_CACHE_MODE }}" = ""]; then
+          if [[ "${{ env.NODE_CACHE_MODE }}" == ""]]; then
               npm install
           else
               npm ci

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -84,16 +84,10 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Setup node cache mode
-        run: |
-          if [[ ${{ inputs.PACKAGE_MANAGER }} == "yarn" && -f "${GITHUB_WORKSPACE}/yarn.lock" ]]; then
-            echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
-          elif [[ ${{ inputs.PACKAGE_MANAGER }} == "npm" && -f "${GITHUB_WORKSPACE}/package-lock.json" ]]; then
-            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
-          elif [[ ${{ inputs.PACKAGE_MANAGER }} == "npm" && -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]]; then
-            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
-          else
-            echo "No .lock files were found. Using no NODE_CACHE_MODE"
-          fi
+        run: |          
+          [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
+          [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
+          [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
 
       - name: Set up node
         uses: actions/setup-node@v3
@@ -104,8 +98,10 @@ jobs:
 
       - name: Install dependencies [yarn]
         if: ${{ inputs.PACKAGE_MANAGER }} == "yarn" }}
+        env:
+          NODE_CACHE_MODE: ${{ env.NODE_CACHE_MODE }}
         run: |
-          if [[ ${{ env.NODE_CACHE_MODE }} == '']] then
+          if [[ "$NODE_CACHE_MODE" == '']] then
             yarn
           else
             yarn --frozen-lockfile
@@ -113,8 +109,10 @@ jobs:
 
       - name: Install dependencies [npm]
         if: ${{ inputs.PACKAGE_MANAGER }} == "npm" }}
+        env:
+          NODE_CACHE_MODE: ${{ env.NODE_CACHE_MODE }}
         run: |
-          if [[ ${{ env.NODE_CACHE_MODE }} == '']] then
+          if [[ "$NODE_CACHE_MODE" == '']] then
               npm install
           else
               npm ci

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -85,9 +85,9 @@ jobs:
 
       - name: Setup node cache mode
         run: |
-          [ "${{ inputs.PACKAGE_MANAGER }}" == "npm" ] && [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
-          [ "${{ inputs.PACKAGE_MANAGER }}" == "npm" ] && [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
-          [ "${{ inputs.PACKAGE_MANAGER }}" == "yarn" ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
+          [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
+          [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
+          [ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
 
       - name: Set up node
         uses: actions/setup-node@v3
@@ -97,7 +97,7 @@ jobs:
           cache: ${{ env.NODE_CACHE_MODE }}
 
       - name: Install dependencies [yarn]
-        if: ${{ inputs.PACKAGE_MANAGER == "yarn" }}
+        if: ${{ inputs.PACKAGE_MANAGER == 'yarn' }}
         run: |
           if [ "${{ env.NODE_CACHE_MODE }}" == '']; then
             yarn
@@ -106,7 +106,7 @@ jobs:
           fi
 
       - name: Install dependencies [npm]
-        if: ${{ inputs.PACKAGE_MANAGER == "npm" }}
+        if: ${{ inputs.PACKAGE_MANAGER == 'npm' }}
         run: |
           if [ "${{ env.NODE_CACHE_MODE }}" == '']; then
               npm install

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -85,9 +85,8 @@ jobs:
 
       - name: Setup node cache mode
         run: |
-          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]] && [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
-          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]] && [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
-          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ]] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
+          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]] && ( [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] ) && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
+          [[ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ]] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
 
       - name: Set up node
         uses: actions/setup-node@v3

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -97,9 +97,9 @@ jobs:
           cache: ${{ env.NODE_CACHE_MODE }}
 
       - name: Install dependencies [yarn]
-        if: ${{ inputs.PACKAGE_MANAGER = 'yarn' }}
+        if: ${{ inputs.PACKAGE_MANAGER == 'yarn' }}
         run: |
-          if [[ "${{ env.NODE_CACHE_MODE }}" == ""]]; then
+          if [[ "${{ env.NODE_CACHE_MODE }}" == "" ]]; then
             yarn
           else
             yarn --frozen-lockfile
@@ -108,7 +108,7 @@ jobs:
       - name: Install dependencies [npm]
         if: ${{ inputs.PACKAGE_MANAGER == 'npm' }}
         run: |
-          if [[ "${{ env.NODE_CACHE_MODE }}" == ""]]; then
+          if [[ "${{ env.NODE_CACHE_MODE }}" == "" ]]; then
               npm install
           else
               npm ci

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -85,9 +85,9 @@ jobs:
 
       - name: Setup node cache mode
         run: |          
-          [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
-          [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
-          [ -f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
+          [ ${{ inputs.PACKAGE_MANAGER }} == "npm" && -f "${GITHUB_WORKSPACE}/package-lock.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No package-lock.json found"
+          [ ${{ inputs.PACKAGE_MANAGER }} == "npm" && -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ] && echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV || echo "No npm-shrinkwrap.json found"
+          [ ${{ inputs.PACKAGE_MANAGER }} == "yarn" &&-f "${GITHUB_WORKSPACE}/yarn.lock" ] && echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV || echo "No yarn.lock found"
 
       - name: Set up node
         uses: actions/setup-node@v3
@@ -101,7 +101,7 @@ jobs:
         env:
           NODE_CACHE_MODE: ${{ env.NODE_CACHE_MODE }}
         run: |
-          if [[ "$NODE_CACHE_MODE" == '']] then
+          if [[ ${{ NODE_CACHE_MODE }} == '']] then
             yarn
           else
             yarn --frozen-lockfile
@@ -112,7 +112,7 @@ jobs:
         env:
           NODE_CACHE_MODE: ${{ env.NODE_CACHE_MODE }}
         run: |
-          if [[ "$NODE_CACHE_MODE" == '']] then
+          if [[ ${{ NODE_CACHE_MODE }} == '']] then
               npm install
           else
               npm ci

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -97,24 +97,12 @@ jobs:
           cache: ${{ env.NODE_CACHE_MODE }}
 
       - name: Install dependencies
-        run: ${{ inputs.PACKAGE_MANAGER }}
+        env:
+          ARGS: ${{ env.NODE_CACHE_MODE == 'yarn' && '--frozen-lockfile' || env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
+        run: ${{ format('{0} {1}', inputs.PACKAGE_MANAGER, env.ARGS) }}
+
       #- name: Install dependencies
-      #  run: |
-      #    if [[ "${{ inputs.PACKAGE_MANAGER }}" == "yarn" ]]; then
-      #      if [[ "${{ env.NODE_CACHE_MODE }}" == "" ]]; then
-      #        yarn
-      #      else
-      #        yarn --frozen-lockfile
-      #      fi
-      #    elif  [[ "${{ inputs.PACKAGE_MANAGER }}" == "npm" ]]; then
-      #      if [[ "${{ env.NODE_CACHE_MODE }}" == "" ]]; then
-      #          npm install
-      #      else
-      #          npm ci
-      #      fi
-      #    else
-      #      echo "PACKAGE_MANAGER ${{ inputs.PACKAGE_MANAGER }} is not supported by this workflow."
-      #    fi
+      #  run: ${{ env.INSTALL_NPM_DEPS_CMD }}
 
       - name: Lint script files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'js') }}

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -12,7 +12,6 @@ To achieve that, the reusable workflow:
 6. Runs `wp dist-archive` to create the final archive (with builtin support for a `.distignore` file)
 7. Uploads it as an artifact for download or further processing
 
-
 ## Simple usage example:
 
 ```yml
@@ -42,15 +41,16 @@ jobs:
 
 | Name                  | Default                                                       | Description                                                                       |
 |-----------------------|---------------------------------------------------------------|-----------------------------------------------------------------------------------|
-| `PLUGIN_MAIN_FILE`    | `"index.php"`                                                 | The name of the plugin main file                                                  |
-| `PLUGIN_VERSION`      | -                                                             | The plugin version                                                                |
-| `ARCHIVE_NAME`        | `""`                                                          | The base name of the resulting zip archive. Falls back to the repository name     |
-| `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                               |
+| `NODE_OPTIONS`        | `''`                                                          | Space-separated list of command-line Node options                                 |
 | `NODE_VERSION`        | `"16"`                                                        | Node version with which the assets will be compiled                               |
 | `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                               | Domain of the private npm registry                                                |
-| `EXTRA_PHP_FILE`      | `""`                                                          | Path to a custom php script to run before creating the release archive            |
-| `PRE_SCRIPT`          | `""`                                                          | Run custom shell code before creating the release archive                         |
 | `PACKAGE_MANAGER`     | `"yarn"`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
+| `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                               |
+| `PHP_VERSION`         | `"8.0"`                                                       | PHP version to use during packaging                                               |
+| `ARCHIVE_NAME`        | `""`                                                          | The base name of the resulting zip archive. Falls back to the repository name     |
+| `PLUGIN_MAIN_FILE`    | `"index.php"`                                                 | The name of the plugin main file                                                  |
+| `PLUGIN_VERSION`      | -                                                             | The plugin version                                                                |
+| `PRE_SCRIPT`          | `""`                                                          | Run custom shell code before creating the release archive                         |
 
 #### A note on `PLUGIN_VERSION`
 
@@ -63,6 +63,6 @@ of the project/team/client are known.
 
 | Name                 | Description                                                                              |
 |----------------------|------------------------------------------------------------------------------------------|
-| `NPM_REGISTRY_TOKEN` | Authentication for the private npm registry                                              |
 | `COMPOSER_AUTH_JSON` | Authentication for privately hosted packages and repositories as a JSON formatted object |
+| `NPM_REGISTRY_TOKEN` | Authentication for the private npm registry                                              |
 | `ENV_VARS`           | Additional environment variables as a JSON formatted object                              |

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -20,14 +20,15 @@ jobs:
 
 #### Inputs
 
-| Name                  | Default                       | Description                                                     |
-|-----------------------|-------------------------------|-----------------------------------------------------------------|
-| `PHP_VERSION`         | `"8.0"`                       | PHP version with which the assets compilation is to be executed |
-| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                              |
-| `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled             |
-| `COMPOSER_ARGS`       | `'--prefer-dist'`             | Set of arguments passed to Composer                             |
-| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`             | Set of arguments passed to Composer Asset Compiler              |
-| `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options               |
+| Name                  | Default                       | Description                                                                       |
+|-----------------------|-------------------------------|-----------------------------------------------------------------------------------|
+| `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                 |
+| `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled                               |
+| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                |
+| `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
+| `PHP_VERSION`         | `"8.0"`                       | PHP version with which the assets compilation is to be executed                   |
+| `COMPOSER_ARGS`       | `'--prefer-dist'`             | Set of arguments passed to Composer                                               |
+| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`             | Set of arguments passed to Composer Asset Compiler                                |
 
 #### Secrets
 

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -72,22 +72,17 @@ This is not the simplest possible example, but it showcases all the recommendati
 
 ### Inputs
 
-| Name                  | Default                       | Description                                                                            |
-|-----------------------|-------------------------------|----------------------------------------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                     |
-| `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled                                    |
-| `WORKING_DIRECTORY`   | `'./'`                        | Working directory path                                                                 |
-| `PACKAGE_MANAGER`     | `'auto'` <sup>**^1**</sup>    | Package manager. Supported are "yarn" and "npm". Required if no lock file is available |
-| `DEPS_INSTALL`        | `true`                        | Whether or not to install dependencies before compiling                                |
-| `COMPILE_SCRIPT_PROD` | `'encore prod'`               | Script added to `npm run` or `yarn` to build production assets                         |
-| `COMPILE_SCRIPT_DEV`  | `'encore dev'`                | Script added to `npm run` or `yarn` to build development assets                        |
-| `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                     |
-| `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                      |
-
-<sup>**^1**</sup> `PACKAGE_MANAGER` defaults to "auto" because it tries to determine the package
-manager by looking at lock file (e.g. presence of `yarn.lock` means _Yarn_, `npm-shrinkwrap.json`
-or `package-lock.json` means _npm_). **In the case no lock file is found in the repository,
-then `PACKAGE_MANAGER` input is required**.
+| Name                  | Default                       | Description                                                                       |
+|-----------------------|-------------------------------|-----------------------------------------------------------------------------------|
+| `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                 |
+| `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled                               |
+| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                |
+| `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
+| `WORKING_DIRECTORY`   | `'./'`                        | Working directory path                                                            |
+| `DEPS_INSTALL`        | `true`                        | Whether or not to install dependencies before compiling                           |
+| `COMPILE_SCRIPT_PROD` | `'encore prod'`               | Script added to `npm run` or `yarn` to build production assets                    |
+| `COMPILE_SCRIPT_DEV`  | `'encore dev'`                | Script added to `npm run` or `yarn` to build development assets                   |
+| `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                |
 
 ## Secrets
 

--- a/docs/wp-scripts.md
+++ b/docs/wp-scripts.md
@@ -23,10 +23,10 @@ jobs:
 
 | Name                    | Default                        | Description                                                                       |
 |-------------------------|--------------------------------|-----------------------------------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN`   | `https://npm.pkg.github.com/`  | Domain of the private npm registry                                                |
-| `NODE_VERSION`          | 16                             | Node version with which the assets will be compiled                               |
-| `PACKAGE_MANAGER`       | `yarn`                         | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `NODE_OPTIONS`          | `''`                           | Space-separated list of command-line Node options                                 |
+| `NODE_VERSION`          | 16                             | Node version with which the assets will be compiled                               |
+| `NPM_REGISTRY_DOMAIN`   | `https://npm.pkg.github.com/`  | Domain of the private npm registry                                                |
+| `PACKAGE_MANAGER`       | `yarn`                         | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `LINT_TOOLS`            | `'["js", "style", "md-docs"]'` | Array of checks to be executed by @wordpress/scripts                              |
 | `ESLINT_ARGS`           | `''`                           | Set of arguments passed to `wp-script lint-js`                                    |
 | `STYLELINT_ARGS`        | `'--formatter github'`         | Set of arguments passed to `wp-script lint-style`                                 |


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce?

Right now we have a few node-based reusable-workflows which do set in `actions/setup-node@v3` the `cache` always. This leads to failing Github Actions when the `.lock`-file is not part of the repo (gitignored).

This PR does generalize the `on.workflow_call.inputs` and checks, based on the `PACKAGE_MANAGER`, if a `.lock`-file is present. If so, the `cache` is used in `actions/setup-node@v3`. Additionally, for all reusable workflows which do not use `composer compile-assets`, we make use of either `npm ci` or `yarn --frozen-lockfile` to speed up the installation in case we found a `.lock`-file.

## What is the new behavior (if this is a feature change)?

**build-and-push-assets.yml**
inputs are now sorted and updated steps to have:

- setup `NODE_CACHE_MODE` env var
- setup node (with or without cache)
- install dependencies


--> removed "auto" for "PACKAGE_MANAGER. Default is now "yarn".

-------------------
**build-assets-compilation.yml**
inputs are now sorted and updated steps to have:

- setup `NODE_CACHE_MODE` env var
- setup node (with or without cache)

--> Installing of dependencies is executed through "composer compile-assets".

-------------------
**wp-scripts-lint.yml**

inputs are now sorted and updated steps to have:

- setup `NODE_CACHE_MODE` env var
- setup node (with or without cache)
- install dependencies

--> setup-node "cache" is now only set if a .lock-file is present.

-------------------
**build-plugin-archive.yml**
inputs are now sorted.

updated steps to have:
- setup `NODE_CACHE_MODE` env var
- setup node (with or without cache) 

--> fixes also order of "Set up node"- to be done before "Run Composer Asset Compiler"-step. 
--> Additionally checks for `has_package` in "Run Composer Asset Compiler"-step