### PR TITLE
feat: Allow customization of arguments passed into asset compiler

### DIFF
--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -52,6 +52,11 @@ on:
         default: ''
         required: false
         type: string
+      COMPILE_ASSETS_ARGS:
+        description: Set of arguments passed to Composer Asset Compiler.
+        default: '-v --env=root'
+        required: false
+        type: string
     secrets:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
@@ -156,7 +161,7 @@ jobs:
 
       - name: Run Composer Asset Compiler
         if: steps.composer-tools.outputs.assets-compiler == '0' && steps.check-for-package.outputs.has_package == 'true'
-        run: composer compile-assets
+        run: composer compile-assets ${{ inputs.COMPILE_ASSETS_ARGS }}
 
       - name: Run WordPress Translation Downloader
         if: steps.composer-tools.outputs.translation-downloader == '0'

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -51,6 +51,7 @@ jobs:
 | `PLUGIN_MAIN_FILE`    | `"index.php"`                                                 | The name of the plugin main file                                                  |
 | `PLUGIN_VERSION`      | -                                                             | The plugin version                                                                |
 | `PRE_SCRIPT`          | `""`                                                          | Run custom shell code before creating the release archive                         |
+| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`                                             | Set of arguments passed to Composer Asset Compiler                                |
 
 #### A note on `PLUGIN_VERSION`
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
Asset compiler arguments are not configurable at all This hides useful output when something breaks.


**What is the new behavior (if this is a feature change)?**
Following `build-assets-compilation.yml`, I added `COMPILE_ASSETS_ARGS` so we get to see verbose output


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



**Other information**:
