### PR TITLE
Introduce Dry Run option

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -48,6 +48,11 @@ on:
         default: './assets'
         required: false
         type: string
+      DRY_RUN:
+        description: Compile the assets but do not push them to the repository.
+        default: false
+        required: false
+        type: boolean
     secrets:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
@@ -160,6 +165,7 @@ jobs:
         run: ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm run' }} ${{ env.COMPILE_SCRIPT }}
 
       - name: Git add, commit, push
+        if: ${{ env.DRY_RUN != 'true' }}
         run: |
           declare -a TARGET_PATHS_ARRAY=(${{ inputs.ASSETS_TARGET_PATHS }})
           for path in "${TARGET_PATHS_ARRAY[@]}"; do git add -f "${path}/*"; done
@@ -171,7 +177,7 @@ jobs:
         run: git push
 
       - name: Move tag
-        if: ${{ env.TAG_NAME != '' && env.NO_CHANGES != 'yes' }}
+        if: ${{ env.TAG_NAME != '' && env.NO_CHANGES != 'yes' && env.DRY_RUN != 'true' }}
         run: |
           git tag -d ${{ env.TAG_NAME }}
           git push origin :refs/tags/${{ env.TAG_NAME }}
@@ -179,7 +185,7 @@ jobs:
           git push origin --tags
 
       - name: Delete tag branch
-        if: ${{ always() && (env.TAG_BRANCH_NAME != '' && env.NO_CHANGES != 'yes') }}
+        if: ${{ always() && (env.TAG_BRANCH_NAME != '' && env.NO_CHANGES != 'yes' && env.DRY_RUN != 'true') }}
         run: |
           git checkout --detach
           git branch -d ${{ env.TAG_BRANCH_NAME }}

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -83,6 +83,7 @@ This is not the simplest possible example, but it showcases all the recommendati
 | `COMPILE_SCRIPT_PROD` | `'encore prod'`               | Script added to `npm run` or `yarn` to build production assets                    |
 | `COMPILE_SCRIPT_DEV`  | `'encore dev'`                | Script added to `npm run` or `yarn` to build development assets                   |
 | `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                |
+| `DRY_RUN`             | `false`                       | Compile the assets but do not push them to the repository                         |
 
 ## Secrets
 
@@ -162,7 +163,7 @@ same as the two commits would have been made as a single commit including both.
 ---
 
 > Does the workflow mess up the git history or add noise to it? How do we know which "compilation"
-commit belongs to which "real" commit?
+> commit belongs to which "real" commit?
 
 As a side effect of using the
 recommended [concurrency settings] (https://docs.github.com/en/actions/using-jobs/using-concurrency)
@@ -177,7 +178,7 @@ start with the prefix `[BOT]`, it would be quite easy to ignore them without any
 ---
 
 > When using commit-precise Composer version constraints like `dev-master#a1bcde`, is there a risk
-of referencing a commit that has no compiled assets?
+> of referencing a commit that has no compiled assets?
 
 Yes. However, commit-accurate version constraints are not recommended (especially in production),
 are usually temporary, and are objectively rare. And in the unlikely event that we need to maintain
@@ -203,7 +204,7 @@ complexity required to do so was not deemed worthwhile.
 ---
 
 > I use the `git+ssh` protocol for dependencies in `package.json`. How can I use it with this
-workflow?
+> workflow?
 
 The workflow supports a private SSH key passed via the `GITHUB_USER_SSH_KEY` secret.
 

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -162,8 +162,7 @@ same as the two commits would have been made as a single commit including both.
 
 ---
 
-> Does the workflow mess up the git history or add noise to it? How do we know which "compilation"
-> commit belongs to which "real" commit?
+> Does the workflow mess up the git history or add noise to it? How do we know which "compilation" commit belongs to which "real" commit?
 
 As a side effect of using the
 recommended [concurrency settings] (https://docs.github.com/en/actions/using-jobs/using-concurrency)
@@ -177,8 +176,7 @@ start with the prefix `[BOT]`, it would be quite easy to ignore them without any
 
 ---
 
-> When using commit-precise Composer version constraints like `dev-master#a1bcde`, is there a risk
-> of referencing a commit that has no compiled assets?
+> When using commit-precise Composer version constraints like `dev-master#a1bcde`, is there a risk of referencing a commit that has no compiled assets?
 
 Yes. However, commit-accurate version constraints are not recommended (especially in production),
 are usually temporary, and are objectively rare. And in the unlikely event that we need to maintain

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -201,8 +201,7 @@ complexity required to do so was not deemed worthwhile.
 
 ---
 
-> I use the `git+ssh` protocol for dependencies in `package.json`. How can I use it with this
-> workflow?
+> I use the `git+ssh` protocol for dependencies in `package.json`. How can I use it with this workflow?
 
 The workflow supports a private SSH key passed via the `GITHUB_USER_SSH_KEY` secret.
 


### PR DESCRIPTION
Allow third parties to perform a compilation without committing or pushing the assets.

This is useful in a CI context when in a PR you need to compile the assets to prevent wrong changes to affect the target branch.

An example for a possible configuration is `DRY_RUN: ${{ github.event_name != 'pull_request' }}`

---

Let's assume your colleague made a PR, the PR includes changes in some .ts|.tsx files. The action is not running in the PR but only in the target branch and only after the merge. 

It might happen that after the merge the compilation of the assets failed, now you have a broken build. 

To prevent that, we would like to run the assets compilation in the PR but the branch associated to the PR does not need to get the assets updated since them will be compiled when the PR will be merged. 

Having the dry-run option ON will allow us to run the compilation as part of the CI of the PR to ensure the changes are not impacting negatively the project. Nonetheless we do not want to commit and push the assets in the branch but only when the PR is merged, hence in the target branch.

It is the target branch responsible to commit and push the assets to avoid conflicts and problems.