### PR TITLE
Remove `DEPS_INSTALL` input

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -28,11 +28,6 @@ on:
         default: './'
         required: false
         type: string
-      DEPS_INSTALL:
-        description: Whether or not to install dependencies before compiling.
-        type: boolean
-        default: true
-        required: false
       COMPILE_SCRIPT_PROD:
         description: Script added to "npm run" or "yarn" to build production assets.
         type: string

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -79,7 +79,6 @@ This is not the simplest possible example, but it showcases all the recommendati
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                |
 | `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `WORKING_DIRECTORY`   | `'./'`                        | Working directory path                                                            |
-| `DEPS_INSTALL`        | `true`                        | Whether or not to install dependencies before compiling                           |
 | `COMPILE_SCRIPT_PROD` | `'encore prod'`               | Script added to `npm run` or `yarn` to build production assets                    |
 | `COMPILE_SCRIPT_DEV`  | `'encore dev'`                | Script added to `npm run` or `yarn` to build development assets                   |
 | `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix/feature


**What is the current behavior?** (You can also link to an open issue here)
The `DEPS_INSTALL` input is present but not respected.


**What is the new behavior (if this is a feature change)?**
Removed the `DEPS_INSTALL` input.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
In [`8aff8bf` (#57)](https://github.com/inpsyde/reusable-workflows/pull/57/commits/8aff8bfa78b7857d5566948fee537da302fb8fdb#diff-d4d99141445888d3a9675229e42446c25eae3fe1597815e25a39de0712036646L157), a regression was introduced by no longer valuing the `DEPS_INSTALL` input in the "Install dependencies" step.
However, since the workflow was introduced over a year ago, and nobody ever used that option ([GitHub search](https://github.com/search?q=org%3Ainpsyde+OR+org%3AInpsyde-Global-Service-Provider+language%3AYAML+DEPS_INSTALL&type=code)), we decided to remove the input altogether.