### PR TITLE
Fix stylelint arguments passing

### DIFF
--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Lint script files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'js') }}
-        run: ./node_modules/.bin/wp-scripts lint-js ${{ inputs.ESLINT_ARGS }}
+        run: ./node_modules/.bin/wp-scripts lint-js "${{ inputs.ESLINT_ARGS }}"
 
       - name: Lint style files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'style') }}
@@ -139,8 +139,8 @@ jobs:
 
       - name: Lint markdown files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'md-docs') }}
-        run: ./node_modules/.bin/wp-scripts lint-md-docs ${{ inputs.MARKDOWNLINT_ARGS }}
+        run: ./node_modules/.bin/wp-scripts lint-md-docs "${{ inputs.MARKDOWNLINT_ARGS }}"
 
       - name: Lint `package.json` files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'pkg-json') }}
-        run: ./node_modules/.bin/wp-scripts lint-pkg-json ${{ inputs.PACKAGE_JSONLINT_ARGS }}
+        run: ./node_modules/.bin/wp-scripts lint-pkg-json "${{ inputs.PACKAGE_JSONLINT_ARGS }}"

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Lint style files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'style') }}
-        run: ./node_modules/.bin/wp-scripts lint-style ${{ inputs.STYLELINT_ARGS }}
+        run: ./node_modules/.bin/wp-scripts lint-style "${{ inputs.STYLELINT_ARGS }}"
 
       - name: Lint markdown files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'md-docs') }}

--- a/docs/wp-scripts.md
+++ b/docs/wp-scripts.md
@@ -61,5 +61,5 @@ jobs:
     with:
       NODE_VERSION: 18
       ESLINT_ARGS: '-o eslint_report.json -f json'
-      STYLELINT_ARGS: './resources/**/*.scs'
+      STYLELINT_ARGS: './resources/**/*.scss'
 ```


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


**What is the current behavior?** (You can also link to an open issue here)
Stylelinting doesn't work as expected if we follow the documentation.
If the lint-style command uses a glob pattern it must be quoted - https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#lint-style and https://stylelint.io/user-guide/cli/#:~:text=stylelint%20%22**/*.css%22-,You%20should%20include%20quotation%20marks%20around%20file%20globs.,-If%20you%20are.




**What is the new behavior (if this is a feature change)?**
Quote arguments (the same as here https://github.com/inpsyde/reusable-workflows/commit/f362c32c9d14f1c27f1586bb1a13a44b5a2e3ab4).


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.



**Other information**:
Alternatively, we could improve the documentation to force provide quoted arguments: `STYLELINT_ARGS: '"./resources/**/*.scss"'` but I'm not sure it's a good idea because users will forget about this.
