### PR TITLE
Update Stylelint documentation

### DIFF
--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Lint script files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'js') }}
-        run: ./node_modules/.bin/wp-scripts lint-js "${{ inputs.ESLINT_ARGS }}"
+        run: ./node_modules/.bin/wp-scripts lint-js ${{ inputs.ESLINT_ARGS }}
 
       - name: Lint style files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'style') }}
@@ -139,8 +139,8 @@ jobs:
 
       - name: Lint markdown files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'md-docs') }}
-        run: ./node_modules/.bin/wp-scripts lint-md-docs "${{ inputs.MARKDOWNLINT_ARGS }}"
+        run: ./node_modules/.bin/wp-scripts lint-md-docs ${{ inputs.MARKDOWNLINT_ARGS }}
 
       - name: Lint `package.json` files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'pkg-json') }}
-        run: ./node_modules/.bin/wp-scripts lint-pkg-json "${{ inputs.PACKAGE_JSONLINT_ARGS }}"
+        run: ./node_modules/.bin/wp-scripts lint-pkg-json ${{ inputs.PACKAGE_JSONLINT_ARGS }}

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Lint style files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'style') }}
-        run: ./node_modules/.bin/wp-scripts lint-style "${{ inputs.STYLELINT_ARGS }}"
+        run: ./node_modules/.bin/wp-scripts lint-style ${{ inputs.STYLELINT_ARGS }}
 
       - name: Lint markdown files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'md-docs') }}

--- a/docs/wp-scripts.md
+++ b/docs/wp-scripts.md
@@ -61,5 +61,5 @@ jobs:
     with:
       NODE_VERSION: 18
       ESLINT_ARGS: '-o eslint_report.json -f json'
-      STYLELINT_ARGS: './resources/**/*.scss'
+      STYLELINT_ARGS: './resources/**/*.scs'
 ```

--- a/docs/wp-scripts.md
+++ b/docs/wp-scripts.md
@@ -67,6 +67,6 @@ jobs:
 ---
 **Note**
 
-The Stylelint [requires quotes](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#lint-style) around glob pattern.
+Stylelint [requires quotes](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#lint-style) around file glob patterns.
 
 ---

--- a/docs/wp-scripts.md
+++ b/docs/wp-scripts.md
@@ -61,5 +61,12 @@ jobs:
     with:
       NODE_VERSION: 18
       ESLINT_ARGS: '-o eslint_report.json -f json'
-      STYLELINT_ARGS: './resources/**/*.scs'
+      STYLELINT_ARGS: '"./resources/**/*.scss" --formatter github'
 ```
+
+---
+**Note**
+
+The Stylelint [requires quotes](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#lint-style) around glob pattern.
+
+---


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix.


**What is the current behavior?** (You can also link to an open issue here)
The PR reverts changes from https://github.com/inpsyde/reusable-workflows/pull/65. The problem is not the whole argument passed to the `wp-scripts` command should be quoted but only the pattern part. So the single possible solution to do it is the consuming action side.


**What is the new behavior (if this is a feature change)?**
Provide documentation for Styling glob pattern required quoting.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, I hope.



**Other information**:
