### PR TITLE
Update default node version to 18

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -10,7 +10,7 @@ on:
         required: false
       NODE_VERSION:
         description: Node version with which the static code analysis is to be executed.
-        default: 16
+        default: 18
         required: false
         type: string
       NPM_REGISTRY_DOMAIN:

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -10,7 +10,7 @@ on:
         required: false
       NODE_VERSION:
         description: Node version with which the static code analysis is to be executed.
-        default: 16
+        default: 18
         required: false
         type: string
       NPM_REGISTRY_DOMAIN:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -10,7 +10,7 @@ on:
         required: false
       NODE_VERSION:
         description: Node version with which the static code analysis is to be executed.
-        default: 16
+        default: 18
         required: false
         type: string
       NPM_REGISTRY_DOMAIN:

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -10,7 +10,7 @@ on:
         type: string
       NODE_VERSION:
         description: Node version with which the static code analysis is to be executed.
-        default: 16
+        default: 18
         required: false
         type: string
       ESLINT_ARGS:

--- a/.github/workflows/static-analysis-sass.yml
+++ b/.github/workflows/static-analysis-sass.yml
@@ -10,7 +10,7 @@ on:
         type: string
       NODE_VERSION:
         description: Node version with which the static code analysis is to be executed.
-        default: 16
+        default: 18
         required: false
         type: string
       STYLELINT_ARGS:

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -10,7 +10,7 @@ on:
         type: string
       NODE_VERSION:
         description: Node version with which the unit tests are to be executed.
-        default: 16
+        default: 18
         required: false
         type: string
       JEST_ARGS:

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -10,7 +10,7 @@ on:
         required: false
       NODE_VERSION:
         description: Node version with which the static code analysis is to be executed.
-        default: 16
+        default: 18
         required: false
         type: string
       NPM_REGISTRY_DOMAIN:

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -42,7 +42,7 @@ jobs:
 | Name                  | Default                                                       | Description                                                                       |
 |-----------------------|---------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | `NODE_OPTIONS`        | `''`                                                          | Space-separated list of command-line Node options                                 |
-| `NODE_VERSION`        | `"16"`                                                        | Node version with which the assets will be compiled                               |
+| `NODE_VERSION`        | `18`                                                          | Node version with which the assets will be compiled                               |
 | `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                               | Domain of the private npm registry                                                |
 | `PACKAGE_MANAGER`     | `"yarn"`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                               |

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -23,7 +23,7 @@ jobs:
 | Name                  | Default                       | Description                                                                       |
 |-----------------------|-------------------------------|-----------------------------------------------------------------------------------|
 | `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                 |
-| `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled                               |
+| `NODE_VERSION`        | `18`                          | Node version with which the assets will be compiled                               |
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                |
 | `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `PHP_VERSION`         | `"8.0"`                       | PHP version with which the assets compilation is to be executed                   |

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -75,7 +75,7 @@ This is not the simplest possible example, but it showcases all the recommendati
 | Name                  | Default                       | Description                                                                       |
 |-----------------------|-------------------------------|-----------------------------------------------------------------------------------|
 | `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                 |
-| `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled                               |
+| `NODE_VERSION`        | `18`                          | Node version with which the assets will be compiled                               |
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                |
 | `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `WORKING_DIRECTORY`   | `'./'`                        | Working directory path                                                            |

--- a/docs/js.md
+++ b/docs/js.md
@@ -25,7 +25,7 @@ jobs:
 | Name                  | Default                                                               | Description                                                                       |
 |-----------------------|-----------------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/`                                         | Domain of the private npm registry                                                |
-| `NODE_VERSION`        | 16                                                                    | Node version with which the assets will be compiled                               |
+| `NODE_VERSION`        | `18`                                                                  | Node version with which the assets will be compiled                               |
 | `ESLINT_ARGS`         | `'-o eslint_report.json -f json --ext .js,.jsx,.ts,.tsx ./resources'` | Set of arguments passed to ESLint                                                 |
 | `PACKAGE_MANAGER`     | `yarn`                                                                | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `NODE_OPTIONS`        | `''`                                                                  | Space-separated list of command-line Node options                                 |
@@ -78,7 +78,7 @@ jobs:
 | Name                  | Default                                            | Description                                                                       |
 |-----------------------|----------------------------------------------------|-----------------------------------------------------------------------------------|
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/`                      | Domain of the private npm registry                                                |
-| `NODE_VERSION`        | 16                                                 | Node version with which the unit tests are to be executed                         |
+| `NODE_VERSION`        | `18`                                               | Node version with which the unit tests are to be executed                         |
 | `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                                                   |
 | `PACKAGE_MANAGER`     | `yarn`                                             | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 

--- a/docs/sass.md
+++ b/docs/sass.md
@@ -25,7 +25,7 @@ jobs:
 | Name                  | Default                       | Description                                                                       |
 |-----------------------|-------------------------------|-----------------------------------------------------------------------------------|
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                |
-| `NODE_VERSION`        | 16                            | Node version with which the assets will be compiled                               |
+| `NODE_VERSION`        | `18`                          | Node version with which the assets will be compiled                               |
 | `STYLELINT_ARGS`      | `'./resources/**/*.scss'`     | Set of arguments passed to Stylelint                                              |
 | `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                 |

--- a/docs/wp-scripts.md
+++ b/docs/wp-scripts.md
@@ -24,7 +24,7 @@ jobs:
 | Name                    | Default                        | Description                                                                       |
 |-------------------------|--------------------------------|-----------------------------------------------------------------------------------|
 | `NODE_OPTIONS`          | `''`                           | Space-separated list of command-line Node options                                 |
-| `NODE_VERSION`          | 16                             | Node version with which the assets will be compiled                               |
+| `NODE_VERSION`          | `18`                           | Node version with which the assets will be compiled                               |
 | `NPM_REGISTRY_DOMAIN`   | `https://npm.pkg.github.com/`  | Domain of the private npm registry                                                |
 | `PACKAGE_MANAGER`       | `yarn`                         | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `LINT_TOOLS`            | `'["js", "style", "md-docs"]'` | Array of checks to be executed by @wordpress/scripts                              |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
The reusable workflows default to Node 16, which has end-of-life for security support on 11. Sep 2023.


**What is the new behavior (if this is a feature change)?**
Default to Node 18.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Consuming workflows might fail if they don't use the `NODE_VERSION` input and are incompatible with Node 18. However, API changes from Node 16 to 18 are relatively small.


**Other information**:
Fixes #40 