### PR TITLE
Feature - deprecate inputs.PHP_MATRIX and introduce inputs.PHP_VERSION

### DIFF
--- a/.github/workflows/coding-standards-php.yml
+++ b/.github/workflows/coding-standards-php.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       PHP_VERSION:
-        description: PHP version with which the coding standard analysis is to be executed.
+        description: PHP version with which the scripts are executed.
         default: "8.0"
         required: false
         type: string

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       PHP_MATRIX:
-        description: [deprecated] Matrix of PHP versions as a JSON formatted object.
+        description: deprecated - Matrix of PHP versions as a JSON formatted object.
         required: false
         type: string
       COMPOSER_ARGS:

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -3,9 +3,13 @@ name: Lint PHP
 on:
   workflow_call:
     inputs:
+      PHP_VERSION:
+        description: PHP version with which the assets compilation is to be executed.
+        default: '8.0'
+        required: false
+        type: string
       PHP_MATRIX:
-        description: Matrix of PHP versions as a JSON formatted object.
-        default: '["8.0"]'
+        description: [deprecated] Matrix of PHP versions as a JSON formatted object.
         required: false
         type: string
       COMPOSER_ARGS:
@@ -35,12 +39,13 @@ jobs:
   lint-php:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version: ${{ fromJson(inputs.PHP_MATRIX) }}
     env:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     steps:
+      - name: Deprecation warning
+        if: ${{ inputs.PHP_MATRIX }}
+        run: echo "::warning::The inputs.PHP_MATRIX is deprecated and only the first item in the list is being used. Please use inputs.PHP_VERSION with a matrix in your consuming workflow in future."
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -57,8 +62,10 @@ jobs:
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
+        env:
+          PHP_VERSION: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX)[0] || inputs.PHP_VERSION }}
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: ${{ env.PHP_VERSION }}
           tools: cs2pr, parallel-lint
           coverage: none
 

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -39,11 +39,11 @@ jobs:
   lint-php:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    env:
-      COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     strategy:
       matrix:
         php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJson('["custom"]') }}
+    env:
+      COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          # This is check is being used to support inputs.PHP_MATRIX to run the strategy.matrix
+          # This check is being used to support inputs.PHP_MATRIX to run the strategy.matrix
           # inside of this reusable-workflow and also support inputs.PHP_VERSION and configuration
           # of a strategy.matrix in the calling workflow.
           php-version: ${{ matrix.php-version != 'custom' && matrix.php-version || inputs.PHP_VERSION }}

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}
-        run: echo "::warning::The inputs.PHP_MATRIX is deprecated and will be removed in future. Please use inputs.PHP_VERSION with a matrix in your consuming workflow."
+        run: echo "::warning::The PHP_MATRIX input is deprecated and will be removed in the future. Please create a matrix in your caller workflow and pass it to the PHP_VERSION input."
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       PHP_MATRIX:
-        description: deprecated - Matrix of PHP versions as a JSON formatted object.
+        description: Matrix of PHP versions as a JSON formatted object (deprecated).
         required: false
         type: string
       COMPOSER_ARGS:

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -41,10 +41,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
+    strategy:
+      matrix:
+        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJson('["custom"]') }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}
-        run: echo "::warning::The inputs.PHP_MATRIX is deprecated and only the first item in the list is being used. Please use inputs.PHP_VERSION with a matrix in your consuming workflow in future."
+        run: echo "::warning::The inputs.PHP_MATRIX is deprecated and will be removed in future. Please use inputs.PHP_VERSION with a matrix in your consuming workflow."
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -62,10 +65,11 @@ jobs:
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
-        env:
-          PHP_VERSION: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX)[0] || inputs.PHP_VERSION }}
         with:
-          php-version: ${{ env.PHP_VERSION }}
+          # This is check is being used to support inputs.PHP_MATRIX to run the strategy.matrix
+          # inside of this reusable-workflow and also support inputs.PHP_VERSION and configuration
+          # of a strategy.matrix in the calling workflow.
+          php-version: ${{ matrix.php-version != 'custom' && matrix.php-version || inputs.PHP_VERSION }}
           tools: cs2pr, parallel-lint
           coverage: none
 

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       PHP_VERSION:
-        description: PHP version with which the assets compilation is to be executed.
+        description: PHP version with which the scripts are executed.
         default: '8.0'
         required: false
         type: string

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -66,9 +66,9 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          # This check is being used to support inputs.PHP_MATRIX to run the strategy.matrix
-          # inside of this reusable-workflow and also support inputs.PHP_VERSION and configuration
-          # of a strategy.matrix in the calling workflow.
+          # This is necessary to support the deprecated PHP_MATRIX (executing the matrix
+          # inside this reusable workflow) while also supporting the new PHP_VERSION input
+          # (passed from a matrix in the caller workflow).
           php-version: ${{ matrix.php-version != 'custom' && matrix.php-version || inputs.PHP_VERSION }}
           tools: cs2pr, parallel-lint
           coverage: none

--- a/.github/workflows/static-analysis-php.yml
+++ b/.github/workflows/static-analysis-php.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       PHP_VERSION:
-        description: PHP version with which the static code analysis is to be executed.
+        description: PHP version with which the scripts are executed.
         default: "8.0"
         required: false
         type: string

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -38,7 +38,7 @@ jobs:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     strategy:
       matrix:
-        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJSON('[inputs.PHP_VERSION]') }}
+        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || [] }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}
@@ -61,7 +61,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: ${{ matrix.php-version || inputs.PHP_VERSION }}
 
       - name: Set up problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -36,6 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
+      PHP_VERSION: >-
+        ["${{ inputs.PHP_VERSION }}"]
+    strategy:
+      php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJSON(env.PHP_VERSION) }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}
@@ -57,10 +61,8 @@ jobs:
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
-        env:
-          PHP_VERSION: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX)[0] || inputs.PHP_VERSION }}
         with:
-          php-version: ${{ env.PHP_VERSION }}
+          php-version: ${{ matrix.php-version }}
 
       - name: Set up problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          # This is check is being used to support inputs.PHP_MATRIX to run the strategy.matrix
+          # This check is being used to support inputs.PHP_MATRIX to run the strategy.matrix
           # inside of this reusable-workflow and also support inputs.PHP_VERSION and configuration
           # of a strategy.matrix in the calling workflow.
           php-version: ${{ matrix.php-version != 'custom' && matrix.php-version || inputs.PHP_VERSION }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -3,9 +3,13 @@ name: Unit tests PHP
 on:
   workflow_call:
     inputs:
+      PHP_VERSION:
+        description: PHP version with which the assets compilation is to be executed.
+        default: '8.0'
+        required: false
+        type: string
       PHP_MATRIX:
-        description: Matrix of PHP versions as a JSON formatted object.
-        default: '["8.0"]'
+        description: [ deprecated ] Matrix of PHP versions as a JSON formatted object.
         required: false
         type: string
       COMPOSER_ARGS:
@@ -30,12 +34,13 @@ jobs:
   tests-unit-php:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version: ${{ fromJson(inputs.PHP_MATRIX) }}
     env:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     steps:
+      - name: Deprecation warning
+        if: ${{ inputs.PHP_MATRIX }}
+        run: echo "::warning::The inputs.PHP_MATRIX is deprecated and only the first item in the list is being used. Please use inputs.PHP_VERSION with a matrix in your consuming workflow in future."
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -52,8 +57,10 @@ jobs:
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
+        env:
+          PHP_VERSION: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX)[0] || inputs.PHP_VERSION }}
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: ${{ env.PHP_VERSION }}
 
       - name: Set up problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -38,7 +38,7 @@ jobs:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     strategy:
       matrix:
-        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || [env.PHP_VERSION] }}
+        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || [inputs.PHP_VERSION] }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -38,7 +38,7 @@ jobs:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     strategy:
       matrix:
-        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJSON('["inputs.PHP_VERSION"]') }}
+        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJSON('[inputs.PHP_VERSION]') }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -5,7 +5,6 @@ on:
     inputs:
       PHP_VERSION:
         description: PHP version with which the assets compilation is to be executed.
-        default: '8.0'
         required: false
         type: string
       PHP_MATRIX:
@@ -38,7 +37,7 @@ jobs:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     strategy:
       matrix:
-        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJson('[]') }}
+        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJson('["8.0"]') }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}
@@ -61,7 +60,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version || inputs.PHP_VERSION }}
+          php-version: ${{ inputs.PHP_VERSION || matrix.php-version }}
 
       - name: Set up problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -34,11 +34,11 @@ jobs:
   tests-unit-php:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    env:
-      COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     strategy:
       matrix:
         php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJson('["custom"]') }}
+    env:
+      COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -76,7 +76,7 @@ jobs:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     strategy:
       matrix:
-        php-version: ${{ inputs.PHP_MATRIX }}
+        php-version: ${{ fromJSON(inputs.PHP_MATRIX) }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       PHP_VERSION:
         description: PHP version with which the assets compilation is to be executed.
+        default: '8.0'
         required: false
         type: string
       PHP_MATRIX:
@@ -37,7 +38,7 @@ jobs:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     strategy:
       matrix:
-        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJson('["8.0"]') }}
+        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJson('["custom"]') }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}
@@ -60,7 +61,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ inputs.PHP_VERSION || matrix.php-version }}
+          php-version: ${{ matrix.php-version != 'custom' && matrix.php-version || inputs.PHP_VERSION }}
 
       - name: Set up problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       PHP_MATRIX:
-        description: deprecated - Matrix of PHP versions as a JSON formatted object.
+        description: Matrix of PHP versions as a JSON formatted object (deprecated).
         required: false
         type: string
       COMPOSER_ARGS:

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -36,11 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
-      PHP_VERSION: >-
-        ["${{ inputs.PHP_VERSION }}"]
     strategy:
       matrix:
-        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJSON(env.PHP_VERSION) }}
+        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || [env.PHP_VERSION] }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}
-        run: echo "::warning::The inputs.PHP_MATRIX is deprecated and only the first item in the list is being used. Please use inputs.PHP_VERSION with a matrix in your consuming workflow in future."
+        run: echo "::warning::The PHP_MATRIX input is deprecated and will be removed in the future. Please create a matrix in your caller workflow and pass it to the PHP_VERSION input."
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -34,53 +34,15 @@ jobs:
   tests-unit-php:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    if: ${{ !inputs.PHP_MATRIX }}
-    env:
-      COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Set up custom environment variables
-        env:
-          ENV_VARS: ${{ secrets.ENV_VARS }}
-        if: ${{ env.ENV_VARS }}
-        uses: actions/github-script@v6
-        with:
-          script: |
-            JSON
-              .parse(process.env.ENV_VARS)
-              .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ inputs.PHP_VERSION }}
-
-      - name: Set up problem matchers for PHPUnit
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
-        with:
-          composer-options: ${{ inputs.COMPOSER_ARGS }}
-
-      - name: Run PHPUnit
-        run: ./vendor/bin/phpunit ${{ inputs.PHPUNIT_ARGS }}
-
-  deprecated-tests-unit-php:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    if: ${{ inputs.PHP_MATRIX }}
     env:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     strategy:
       matrix:
-        php-version: ${{ fromJSON(inputs.PHP_MATRIX) }}
+        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJson('["custom"]') }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}
-        run: echo "::warning::The inputs.PHP_MATRIX is deprecated and will be removed in future. Please use inputs.PHP_VERSION with a matrix in your consuming workflow."
+        run: echo "::warning::The inputs.PHP_MATRIX is deprecated and only the first item in the list is being used. Please use inputs.PHP_VERSION with a matrix in your consuming workflow in future."
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -99,7 +61,10 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          # This is check is being used to support inputs.PHP_MATRIX to run the strategy.matrix
+          # inside of this reusable-workflow and also support inputs.PHP_VERSION and configuration
+          # of a strategy.matrix in the calling workflow.
+          php-version: ${{ matrix.php-version != 'custom' && matrix.php-version || inputs.PHP_VERSION }}
 
       - name: Set up problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}
-        run: echo "::warning::The inputs.PHP_MATRIX is deprecated and only the first item in the list is being used. Please use inputs.PHP_VERSION with a matrix in your consuming workflow in future."
+        run: echo "::warning::The inputs.PHP_MATRIX is deprecated and will be removed in future. Please use inputs.PHP_VERSION with a matrix in your consuming workflow."
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -61,6 +61,9 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
+          # This is check is being used to support inputs.PHP_MATRIX to run the strategy.matrix
+          # inside of this reusable-workflow and also support inputs.PHP_VERSION and configuration
+          # of a strategy.matrix in the calling workflow.
           php-version: ${{ matrix.php-version != 'custom' && matrix.php-version || inputs.PHP_VERSION }}
 
       - name: Set up problem matchers for PHPUnit

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -38,7 +38,7 @@ jobs:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     strategy:
       matrix:
-        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || [] }}
+        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJson('[]') }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       PHP_MATRIX:
-        description: [ deprecated ] Matrix of PHP versions as a JSON formatted object.
+        description: deprecated - Matrix of PHP versions as a JSON formatted object.
         required: false
         type: string
       COMPOSER_ARGS:

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       PHP_VERSION:
-        description: PHP version with which the assets compilation is to be executed.
+        description: PHP version with which the scripts are executed.
         default: '8.0'
         required: false
         type: string

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -61,9 +61,9 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          # This check is being used to support inputs.PHP_MATRIX to run the strategy.matrix
-          # inside of this reusable-workflow and also support inputs.PHP_VERSION and configuration
-          # of a strategy.matrix in the calling workflow.
+          # This is necessary to support the deprecated PHP_MATRIX (executing the matrix
+          # inside this reusable workflow) while also supporting the new PHP_VERSION input
+          # (passed from a matrix in the caller workflow).
           php-version: ${{ matrix.php-version != 'custom' && matrix.php-version || inputs.PHP_VERSION }}
 
       - name: Set up problem matchers for PHPUnit

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -38,7 +38,7 @@ jobs:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     strategy:
       matrix:
-        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || [inputs.PHP_VERSION] }}
+        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJSON('["inputs.PHP_VERSION"]') }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -39,7 +39,8 @@ jobs:
       PHP_VERSION: >-
         ["${{ inputs.PHP_VERSION }}"]
     strategy:
-      php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJSON(env.PHP_VERSION) }}
+      matrix:
+        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJSON(env.PHP_VERSION) }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -34,11 +34,49 @@ jobs:
   tests-unit-php:
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    if: ${{ !inputs.PHP_MATRIX }}
+    env:
+      COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up custom environment variables
+        env:
+          ENV_VARS: ${{ secrets.ENV_VARS }}
+        if: ${{ env.ENV_VARS }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            JSON
+              .parse(process.env.ENV_VARS)
+              .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.PHP_VERSION }}
+
+      - name: Set up problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: ${{ inputs.COMPOSER_ARGS }}
+
+      - name: Run PHPUnit
+        run: ./vendor/bin/phpunit ${{ inputs.PHPUNIT_ARGS }}
+
+  deprecated-tests-unit-php:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    if: ${{ inputs.PHP_MATRIX }}
     env:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     strategy:
       matrix:
-        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJson('["custom"]') }}
+        php-version: ${{ inputs.PHP_MATRIX }}
     steps:
       - name: Deprecation warning
         if: ${{ inputs.PHP_MATRIX }}
@@ -61,10 +99,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          # This is check is being used to support inputs.PHP_MATRIX to run the strategy.matrix
-          # inside of this reusable-workflow and also support inputs.PHP_VERSION and configuration
-          # of a strategy.matrix in the calling workflow.
-          php-version: ${{ matrix.php-version != 'custom' && matrix.php-version || inputs.PHP_VERSION }}
+          php-version: ${{ matrix.php-version }}
 
       - name: Set up problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/docs/php.md
+++ b/docs/php.md
@@ -10,6 +10,7 @@ executing the binary in the `./vendor/bin/` folder.
 ```yml
 name: Coding standards analysis PHP
 on:
+  push:
   pull_request:
 jobs:
   coding-standards-analysis-php:
@@ -39,6 +40,7 @@ jobs:
 ```yml
 name: Coding standards analysis PHP
 on:
+  push:
   pull_request:
 jobs:
   coding-standards-analysis-php:
@@ -64,6 +66,7 @@ the `./vendor/bin/` folder.
 ```yml
 name: Static code analysis PHP
 on:
+  push:
   pull_request:
 jobs:
   static-code-analysis-php:
@@ -92,6 +95,7 @@ jobs:
 ```yml
 name: Static code analysis PHP
 on:
+  push:
   pull_request:
 jobs:
   static-code-analysis-php:
@@ -116,6 +120,7 @@ the `./vendor/bin/` folder.
 ```yml
 name: Unit tests PHP
 on:
+  push:
   pull_request:
 jobs:
   tests-unit-php:
@@ -126,11 +131,12 @@ jobs:
 
 #### Inputs
 
-| Name            | Default             | Description                                       |
-|-----------------|---------------------|---------------------------------------------------|
-| `PHP_MATRIX`    | `["8.0"]`           | Matrix of PHP versions as a JSON formatted object |
-| `COMPOSER_ARGS` | `'--prefer-dist'`   | Set of arguments passed to Composer               |
-| `PHPUNIT_ARGS`  | `'--coverage-text'` | Set of arguments passed to PHPUnit                |
+| Name            | Default             | Description                                                              |
+|-----------------|---------------------|--------------------------------------------------------------------------|
+| `PHP_MATRIX`    | `["8.0"]`           | :warning: deprecated - Matrix of PHP versions as a JSON formatted object |
+| `PHP_VERSION`   | `"8.0"`             | PHP version with which the coding standard analysis is to be executed    |
+| `COMPOSER_ARGS` | `'--prefer-dist'`   | Set of arguments passed to Composer                                      |
+| `PHPUNIT_ARGS`  | `'--coverage-text'` | Set of arguments passed to PHPUnit                                       |
 
 #### Secrets
 
@@ -144,6 +150,7 @@ jobs:
 ```yml
 name: Unit tests PHP
 on:
+  push:
   pull_request:
 jobs:
   tests-unit-php:
@@ -158,6 +165,24 @@ jobs:
       PHPUNIT_ARGS: '--coverage-text --debug'
 ```
 
+**Example with PHP_VERSION in matrix:**
+
+```yml
+name: Unit tests PHP
+on:
+  push:
+  pull_request:
+jobs:
+  lint-php:
+    strategy:
+      matrix:
+        php: ["7.4", "8.0", "8.1"]
+    uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@main
+    with:
+      PHP_VERSION: ${{ matrix.php }}
+```
+
+
 ## Lint PHP
 
 This workflow runs [PHP Parallel Lint](https://github.com/php-parallel-lint/PHP-Parallel-Lint). 
@@ -167,6 +192,7 @@ This workflow runs [PHP Parallel Lint](https://github.com/php-parallel-lint/PHP-
 ```yml
 name: Lint PHP
 on:
+  push:
   pull_request:
 jobs:
   lint-php:
@@ -177,12 +203,13 @@ jobs:
 
 #### Inputs
 
-| Name                    | Default                                 | Description                                                    |
-|-------------------------|-----------------------------------------|----------------------------------------------------------------|
-| `PHP_MATRIX`            | `["8.0"]`                               | Matrix of PHP versions as a JSON formatted object              |
-| `COMPOSER_ARGS`         | `'--prefer-dist'`                       | Set of arguments passed to Composer                            |
-| `LINT_ARGS`             | `'-e php --colors --show-deprecated .'` | Set of arguments passed to PHP Parallel Lint                   |
-| `COMPOSER_DEPS_INSTALL` | `false`                                 | Whether or not to install Composer dependencies before linting |
+| Name                    | Default                                 | Description                                                              |
+|-------------------------|-----------------------------------------|--------------------------------------------------------------------------|
+| `PHP_MATRIX`            | `["8.0"]`                               | :warning: deprecated - Matrix of PHP versions as a JSON formatted object |
+| `PHP_VERSION`           | `"8.0"`                                 | PHP version with which the coding standard analysis is to be executed    |
+| `COMPOSER_ARGS`         | `'--prefer-dist'`                       | Set of arguments passed to Composer                                      |
+| `LINT_ARGS`             | `'-e php --colors --show-deprecated .'` | Set of arguments passed to PHP Parallel Lint                             |
+| `COMPOSER_DEPS_INSTALL` | `false`                                 | Whether or not to install Composer dependencies before linting           |
 
 #### Secrets
 
@@ -196,6 +223,7 @@ jobs:
 ```yml
 name: Lint PHP
 on:
+  push:
   pull_request:
 jobs:
   lint-php:
@@ -205,8 +233,24 @@ jobs:
       ENV_VARS: >-
         [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
     with:
-      PHP_MATRIX: >-
-        ["7.4", "8.0", "8.1"]
+      PHP_VERSION: '8.1'
       LINT_ARGS: '. --exclude vendor'
       COMPOSER_DEPS_INSTALL: true
+```
+
+**Example with PHP_VERSION in matrix:**
+
+```yml
+name: Lint PHP
+on:
+  push:
+  pull_request:
+jobs:
+  lint-php:
+    strategy:
+      matrix:
+        php: ["7.4", "8.0", "8.1"]
+    uses: inpsyde/reusable-workflows/.github/workflows/lint-php.yml@main
+    with:
+      PHP_VERSION: ${{ matrix.php }}
 ```

--- a/docs/php.md
+++ b/docs/php.md
@@ -173,7 +173,7 @@ on:
   push:
   pull_request:
 jobs:
-  lint-php:
+  tests-unit-php:
     strategy:
       matrix:
         php: ["7.4", "8.0", "8.1"]

--- a/docs/php.md
+++ b/docs/php.md
@@ -238,7 +238,7 @@ jobs:
       COMPOSER_DEPS_INSTALL: true
 ```
 
-**Example with PHP_VERSION in matrix:**
+**Example with `PHP_VERSION` in matrix:**
 
 ```yml
 name: Lint PHP

--- a/docs/php.md
+++ b/docs/php.md
@@ -165,7 +165,7 @@ jobs:
       PHPUNIT_ARGS: '--coverage-text --debug'
 ```
 
-**Example with PHP_VERSION in matrix:**
+**Example with `PHP_VERSION` in matrix:**
 
 ```yml
 name: Unit tests PHP

--- a/docs/php.md
+++ b/docs/php.md
@@ -21,12 +21,12 @@ jobs:
 
 #### Inputs
 
-| Name            | Default                                                  | Description                                                           |
-|-----------------|----------------------------------------------------------|-----------------------------------------------------------------------|
-| `PHP_VERSION`   | `"8.0"`                                                  | PHP version with which the coding standard analysis is to be executed |
-| `COMPOSER_ARGS` | `'--prefer-dist'`                                        | Set of arguments passed to Composer                                   |
-| `PHPCS_ARGS`    | `'--report-full --report-checkstyle=./phpcs-report.xml'` | Set of arguments passed to PHP_CodeSniffer                            |
-| `CS2PR_ARGS`    | `'--graceful-warnings ./phpcs-report.xml'`               | Set of arguments passed to cs2pr                                      |
+| Name            | Default                                                  | Description                                     |
+|-----------------|----------------------------------------------------------|-------------------------------------------------|
+| `PHP_VERSION`   | `"8.0"`                                                  | PHP version with which the scripts are executed |
+| `COMPOSER_ARGS` | `'--prefer-dist'`                                        | Set of arguments passed to Composer             |
+| `PHPCS_ARGS`    | `'--report-full --report-checkstyle=./phpcs-report.xml'` | Set of arguments passed to PHP_CodeSniffer      |
+| `CS2PR_ARGS`    | `'--graceful-warnings ./phpcs-report.xml'`               | Set of arguments passed to cs2pr                |
 
 #### Secrets
 
@@ -77,11 +77,11 @@ jobs:
 
 #### Inputs
 
-| Name            | Default                               | Description                                                       |
-|-----------------|---------------------------------------|-------------------------------------------------------------------|
-| `PHP_VERSION`   | `"8.0"`                               | PHP version with which the static code analysis is to be executed |
-| `COMPOSER_ARGS` | `'--prefer-dist'`                     | Set of arguments passed to Composer                               |
-| `PSALM_ARGS`    | `'--output-format=github --no-cache'` | Set of arguments passed to Psalm                                  |
+| Name            | Default                               | Description                                     |
+|-----------------|---------------------------------------|-------------------------------------------------|
+| `PHP_VERSION`   | `"8.0"`                               | PHP version with which the scripts are executed |
+| `COMPOSER_ARGS` | `'--prefer-dist'`                     | Set of arguments passed to Composer             |
+| `PSALM_ARGS`    | `'--output-format=github --no-cache'` | Set of arguments passed to Psalm                |
 
 #### Secrets
 
@@ -134,7 +134,7 @@ jobs:
 | Name            | Default             | Description                                                              |
 |-----------------|---------------------|--------------------------------------------------------------------------|
 | `PHP_MATRIX`    | `["8.0"]`           | :warning: deprecated - Matrix of PHP versions as a JSON formatted object |
-| `PHP_VERSION`   | `"8.0"`             | PHP version with which the coding standard analysis is to be executed    |
+| `PHP_VERSION`   | `"8.0"`             | PHP version with which the scripts are executed                          |
 | `COMPOSER_ARGS` | `'--prefer-dist'`   | Set of arguments passed to Composer                                      |
 | `PHPUNIT_ARGS`  | `'--coverage-text'` | Set of arguments passed to PHPUnit                                       |
 
@@ -206,7 +206,7 @@ jobs:
 | Name                    | Default                                 | Description                                                              |
 |-------------------------|-----------------------------------------|--------------------------------------------------------------------------|
 | `PHP_MATRIX`            | `["8.0"]`                               | :warning: deprecated - Matrix of PHP versions as a JSON formatted object |
-| `PHP_VERSION`           | `"8.0"`                                 | PHP version with which the coding standard analysis is to be executed    |
+| `PHP_VERSION`           | `"8.0"`                                 | PHP version with which the scripts are executed                          |
 | `COMPOSER_ARGS`         | `'--prefer-dist'`                       | Set of arguments passed to Composer                                      |
 | `LINT_ARGS`             | `'-e php --colors --show-deprecated .'` | Set of arguments passed to PHP Parallel Lint                             |
 | `COMPOSER_DEPS_INSTALL` | `false`                                 | Whether or not to install Composer dependencies before linting           |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR introduces into our 2 workflows `lint-php.yml` and `tests-unit-php.yml` a new input called `PHP_VERSION`. Additionally the `PHP_MATRIX` will be marked as "deprecated" with a message when being used. In future we're planning to remove the PHP_MATRIX and 1 reusable-workflow executes exactly 1 thing. Using a reusable workflow with a matrix can now be configured on the consuming workflow.

See also here: https://github.com/inpsyde/reusable-workflows/issues/58

**What is the current behavior?** (You can also link to an open issue here)

Right now we have to inject a array as string in the `PHP_MATRIX` input which will be parsed into JSON in the reusable workflow to run a `strategy.matrix.php-version`.

**What is the new behavior (if this is a feature change)?**

The new behavior will still allow the `PHP_MATRIX` to be set, but will print a deprecated message. Instead the new input `PHP_VERSION` should be used in combination with a matrix in the consuming workflow.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no.

**Other information**:
