### PR TITLE
Build to release branches add wp cli

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -132,12 +132,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.GITHUB_USER_TOKEN }}
 
       - name: Setup Git
         run: |
-          git config --global user.email "${{ secrets.GITHUB_USER_EMAIL }}" 
-          git config --global user.name "${{ secrets.GITHUB_USER_NAME }}"
+#          git config --global user.email "${{ secrets.GITHUB_USER_EMAIL }}"
+#          git config --global user.name "${{ secrets.GITHUB_USER_NAME }}"
           git config --global advice.addIgnoredFile false
           git config --global push.autoSetupRemote true
 
@@ -219,8 +219,6 @@ jobs:
           git add -A
           git commit -m "[BUILD] ${{ github.sha }}" --no-verify || echo "No changes to commit"
           git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.DEPLOYBOT_REPO_READ_WRITE_TOKEN }}
 
       - name: Move tag
         if: ${{ github.ref_type == 'tag' }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -74,7 +74,7 @@ on:
       GITHUB_USER_EMAIL:
         description: Email address for the GitHub user configuration.
         required: true
-      GITHUB_TOKEN:
+      GITHUB_CLI_TOKEN:
         description: The token to be used to interact with GH Cli.
         required: true
       GITHUB_USER_NAME:
@@ -229,7 +229,7 @@ jobs:
       - name: Move tag
         if: ${{ github.ref_type == 'tag' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_CLI_TOKEN }}
         run: |
           echo "Preparation: Getting owner and repo name"
           echo "owner_repo=$(gh repo view --json  url,owner,name --template '{{.owner.login}}/{{.name}}')" >> $GITHUB_ENV

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -136,8 +136,6 @@ jobs:
 
       - name: Setup Git
         run: |
-#          git config --global user.email "${{ secrets.GITHUB_USER_EMAIL }}"
-#          git config --global user.name "${{ secrets.GITHUB_USER_NAME }}"
           git config --global advice.addIgnoredFile false
           git config --global push.autoSetupRemote true
 

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -127,6 +127,7 @@ jobs:
       TAG_BRANCH_NAME: ''                              # we'll override if the push is for tag
       LOCK_FILE: ''                                    # we'll override after checking files
       PACKAGE_MANAGER: 'yarn'                          # we'll override based on env/inputs
+      GITHUB_TOKEN: ${{ secrets.GITHUB_USER_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -246,7 +246,8 @@ jobs:
           then
             IS_PRERELEASE=$(echo $RELEASE_INFO | jq '.prerelease')
             IS_DRAFT=$(echo $RELEASE_INFO | jq '.draft')
-            RELEASE_EDIT_ARGS="${{ env.TAG_NAME }} --tag=${{ env.TAG_NAME }} --draft=$IS_DRAFT $(if [ $IS_PRERELEASE ]; then echo '--prerelease'";fi)
+            echo "Preparing the ARGS for the Release edit"
+            RELEASE_EDIT_ARGS="${{ env.TAG_NAME }} --tag=${{ env.TAG_NAME }} --draft=$IS_DRAFT $(if [ $IS_PRERELEASE ]; then echo '--prerelease';fi)"
             echo "Release edit args: $RELEASE_EDIT_ARGS"
             gh release edit "$RELEASE_EDIT_ARGS"
           fi

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -136,8 +136,8 @@ jobs:
 
       - name: Setup Git
         run: |
-          git config --global advice.addIgnoredFile false
-          git config --global push.autoSetupRemote true
+          git config --local advice.addIgnoredFile false
+          git config --local push.autoSetupRemote true
 
       - name: Set branch environment variables
         if: ${{ github.ref_type == 'branch' }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -200,20 +200,13 @@ jobs:
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
           cache: ${{ env.PACKAGE_MANAGER }}
 
-      - name: Set up PHP
+      - name: Install WP CLI
         if: ${{ inputs.INSTALL_WP_CLI }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.PHP_VERSION }}
-          tools: composer
+          tools: wp-cli
           coverage: none
-
-      - name: Set up WP CLI
-        if: ${{ inputs.INSTALL_WP_CLI }}
-        run: |
-          curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-          chmod +x wp-cli.phar
-          sudo mv wp-cli.phar /usr/local/bin/wp
 
       - name: Install dependencies
         if: ${{ inputs.DEPS_INSTALL }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -112,7 +112,7 @@ jobs:
 
   compile-assets:
     needs: checks
-    if: ${{ github.ref_type == 'branch' || (github.ref_type == 'tag' && needs.checks.outputs.is_moved_tag == 'no') }}
+    if: ${{ (github.ref_type == 'branch' && !contains(github.ref_name, '-built') ) || (github.ref_type == 'tag' && needs.checks.outputs.is_moved_tag == 'no') }}
     defaults:
       run:
         working-directory: ${{ inputs.WORKING_DIRECTORY }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -74,6 +74,9 @@ on:
       GITHUB_USER_EMAIL:
         description: Email address for the GitHub user configuration.
         required: true
+      GITHUB_TOKEN:
+        description: The token to be used to interact with GH Cli.
+        required: true
       GITHUB_USER_NAME:
         description: Username for the GitHub user configuration.
         required: true
@@ -225,6 +228,8 @@ jobs:
 
       - name: Move tag
         if: ${{ github.ref_type == 'tag' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Preparation: Getting owner and repo name"
           echo "owner_repo=$(gh repo view --json  url,owner,name --template '{{.owner.login}}/{{.name}}')" >> $GITHUB_ENV

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -74,8 +74,8 @@ on:
       GITHUB_USER_EMAIL:
         description: Email address for the GitHub user configuration.
         required: true
-      GITHUB_CLI_TOKEN:
-        description: The token to be used to interact with GH Cli.
+      GITHUB_USER_TOKEN:
+        description: The token to be used to interact with GH Cli and making the commits.
         required: true
       GITHUB_USER_NAME:
         description: Username for the GitHub user configuration.
@@ -133,13 +133,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
-
-      - name: Set up SSH
-        if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Setup Git
         run: |
@@ -226,6 +219,8 @@ jobs:
           git add -A
           git commit -m "[BUILD] ${{ github.sha }}" --no-verify || echo "No changes to commit"
           git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEPLOYBOT_REPO_READ_WRITE_TOKEN }}
 
       - name: Move tag
         if: ${{ github.ref_type == 'tag' }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -234,9 +234,9 @@ jobs:
           echo "Preparation: Getting owner and repo name"
           echo "The GH owner & repo $GITHUB_REPOSITORY"
           echo "Preparation: Checking if tag has a release associated"
-          gh api repos/$GITHUB_REPOSITORY/releases/tags/${{ env.TAG_NAME }} --silent --repo $GITHUB_REPOSITORY && FOUND="yes" || FOUND="false"
+          gh api repos/$GITHUB_REPOSITORY/releases/tags/${{ env.TAG_NAME }} --silent && FOUND="yes" || FOUND="false"
           TAG_HAS_RELEASE_ASSOCIATED="$FOUND"
-          if [ $TAG_HAS_RELEASE_ASSOCIATED = "yes" ]; then RELEASE_INFO=$(gh api repos/$GITHUB_REPOSITORY/releases/tags/${{ env.TAG_NAME }} -q '{draft,prerelease,tag_name,name}' --repo $GITHUB_REPOSITORY);fi
+          if [ $TAG_HAS_RELEASE_ASSOCIATED = "yes" ]; then RELEASE_INFO=$(gh api repos/$GITHUB_REPOSITORY/releases/tags/${{ env.TAG_NAME }} -q '{draft,prerelease,tag_name,name}');fi
           echo "Is this tag associated with a release?: $TAG_HAS_RELEASE_ASSOCIATED"
           git tag -d ${{ env.TAG_NAME }}
           git push origin :refs/tags/${{ env.TAG_NAME }}
@@ -248,7 +248,7 @@ jobs:
             IS_DRAFT=$(echo $RELEASE_INFO | jq '.draft')
             RELEASE_EDIT_ARGS="${{ env.TAG_NAME }} --tag=${{ env.TAG_NAME }} --draft=$IS_DRAFT $(if [ $IS_PRERELEASE ]; then echo '--prerelease'";fi)
             echo "Release edit args: $RELEASE_EDIT_ARGS"
-            gh release edit "$RELEASE_EDIT_ARGS" --repo $GITHUB_REPOSITORY
+            gh release edit "$RELEASE_EDIT_ARGS"
           fi
 
       - name: Delete temporary tag branch

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -242,7 +242,7 @@ jobs:
           then
             IS_PRERELEASE=$(echo $RELEASE_INFO | jq '.prerelease')
             IS_DRAFT=$(echo $RELEASE_INFO | jq '.draft')
-            RELEASE_EDIT_ARGS="${{ env.TAG_NAME }} --tag=${{ env.TAG_NAME }} --draft=$(echo "IS_DRAFT") $(if [ $IS_PRERELEASE ]; then echo '--prerelease')";fi
+            RELEASE_EDIT_ARGS="${{ env.TAG_NAME }} --tag=${{ env.TAG_NAME }} --draft=$(echo "$IS_DRAFT") $(if [ $IS_PRERELEASE ]; then echo '--prerelease')";fi
             echo "Release edit args: $RELEASE_EDIT_ARGS"
             gh release edit $RELEASE_EDIT_ARGS
           fi

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -136,7 +136,7 @@ jobs:
           ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Set up SSH
-        if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
+        if: ${{ secrets.GITHUB_USER_SSH_KEY != '' }}
         uses: webfactory/ssh-agent@v0.8.0
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -132,6 +132,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
           ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Set up SSH

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -247,7 +247,7 @@ jobs:
           then
             IS_PRERELEASE=$(echo $RELEASE_INFO | jq '.prerelease')
             IS_DRAFT=$(echo $RELEASE_INFO | jq '.draft')
-            RELEASE_EDIT_ARGS="${{ env.TAG_NAME }} --tag=${{ env.TAG_NAME }} --draft=$IS_DRAFT $(if [ $IS_PRERELEASE ]; then echo '--prerelease')";fi
+            RELEASE_EDIT_ARGS="${{ env.TAG_NAME }} --tag=${{ env.TAG_NAME }} --draft=$IS_DRAFT $(if [ $IS_PRERELEASE ]; then echo '--prerelease'";fi)
             echo "Release edit args: $RELEASE_EDIT_ARGS"
             gh release edit "$RELEASE_EDIT_ARGS"
           fi

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -249,7 +249,7 @@ jobs:
             echo "Preparing the ARGS for the Release edit"
             RELEASE_EDIT_ARGS="${{ env.TAG_NAME }} --tag=${{ env.TAG_NAME }} --draft=$IS_DRAFT $(if [ $IS_PRERELEASE ]; then echo '--prerelease';fi)"
             echo "Release edit args: $RELEASE_EDIT_ARGS"
-            gh release edit "$RELEASE_EDIT_ARGS"
+            gh release edit $RELEASE_EDIT_ARGS
           fi
 
       - name: Delete temporary tag branch

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -136,7 +136,7 @@ jobs:
           ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Set up SSH
-        if: ${{ secrets.GITHUB_USER_SSH_KEY != '' }}
+        if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
         uses: webfactory/ssh-agent@v0.8.0
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -133,13 +133,20 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_USER_TOKEN }}
-          persist-credentials: true
+          persist-credentials: false
+
+      - name: Set up SSH
+        if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
+        uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Setup Git
         run: |
-          git config --local advice.addIgnoredFile false
-          git config --local push.autoSetupRemote true
+          git config --global user.email "${{ secrets.GITHUB_USER_EMAIL }}" 
+          git config --global user.name "${{ secrets.GITHUB_USER_NAME }}"
+          git config --global advice.addIgnoredFile false
+          git config --global push.autoSetupRemote true
 
       - name: Set branch environment variables
         if: ${{ github.ref_type == 'branch' }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -57,6 +57,16 @@ on:
         type: string
         default: ''
         required: true
+      INSTALL_WP_CLI:
+        description: Whether to Install WP cli or not.
+        default: false
+        required: false
+        type: boolean
+      PHP_VERSION:
+        description: PHP version with which the WP CLI is going to be executed.
+        default: "8.1"
+        required: false
+        type: string
     secrets:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
@@ -188,6 +198,21 @@ jobs:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
           cache: ${{ env.PACKAGE_MANAGER }}
+
+      - name: Set up PHP
+        if: ${{ inputs.INSTALL_WP_CLI }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.PHP_VERSION }}
+          tools: composer
+          coverage: none
+
+      - name: Set up WP CLI
+        if: ${{ inputs.INSTALL_WP_CLI }}
+        run: |
+          curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+          chmod +x wp-cli.phar
+          sudo mv wp-cli.phar /usr/local/bin/wp
 
       - name: Install dependencies
         if: ${{ inputs.DEPS_INSTALL }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -134,6 +134,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_USER_TOKEN }}
+          persist-credentials: true
 
       - name: Setup Git
         run: |

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -232,12 +232,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_CLI_TOKEN }}
         run: |
           echo "Preparation: Getting owner and repo name"
-          echo "owner_repo=$(gh repo view --json  url,owner,name --template '{{.owner.login}}/{{.name}}')" >> $GITHUB_ENV
-          echo "${{ env.owner_repo }}"
+          echo "The GH owner & repo $GITHUB_REPOSITORY"
           echo "Preparation: Checking if tag has a release associated"
-          gh api repos/${{ env.owner_repo }}/releases/tags/${{ env.TAG_NAME }} --silent && FOUND="yes" || FOUND="false"
+          gh api repos/$GITHUB_REPOSITORY/releases/tags/${{ env.TAG_NAME }} --silent --repo $GITHUB_REPOSITORY && FOUND="yes" || FOUND="false"
           TAG_HAS_RELEASE_ASSOCIATED="$FOUND"
-          if [ $TAG_HAS_RELEASE_ASSOCIATED = "yes" ]; then RELEASE_INFO=$(gh api repos/$owner_repo/releases/tags/${{ env.TAG_NAME }} -q '{draft,prerelease,tag_name,name}');fi
+          if [ $TAG_HAS_RELEASE_ASSOCIATED = "yes" ]; then RELEASE_INFO=$(gh api repos/$GITHUB_REPOSITORY/releases/tags/${{ env.TAG_NAME }} -q '{draft,prerelease,tag_name,name}' --repo $GITHUB_REPOSITORY);fi
           echo "Is this tag associated with a release?: $TAG_HAS_RELEASE_ASSOCIATED"
           git tag -d ${{ env.TAG_NAME }}
           git push origin :refs/tags/${{ env.TAG_NAME }}
@@ -249,7 +248,7 @@ jobs:
             IS_DRAFT=$(echo $RELEASE_INFO | jq '.draft')
             RELEASE_EDIT_ARGS="${{ env.TAG_NAME }} --tag=${{ env.TAG_NAME }} --draft=$IS_DRAFT $(if [ $IS_PRERELEASE ]; then echo '--prerelease'";fi)
             echo "Release edit args: $RELEASE_EDIT_ARGS"
-            gh release edit "$RELEASE_EDIT_ARGS"
+            gh release edit "$RELEASE_EDIT_ARGS" --repo $GITHUB_REPOSITORY
           fi
 
       - name: Delete temporary tag branch

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -220,6 +220,8 @@ jobs:
         run: ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm run' }} ${{ env.COMPILE_SCRIPT }}
 
       - name: Git add, commit, push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_USER_TOKEN }}
         run: |
           declare -a TARGET_PATHS_ARRAY=(${{ inputs.ASSETS_TARGET_PATHS }})
           for path in "${TARGET_PATHS_ARRAY[@]}"; do git add -f "${path}/*"; done
@@ -230,7 +232,7 @@ jobs:
       - name: Move tag
         if: ${{ github.ref_type == 'tag' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_CLI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_USER_TOKEN }}
         run: |
           echo "Preparation: Getting owner and repo name"
           echo "The GH owner & repo $GITHUB_REPOSITORY"

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -226,10 +226,26 @@ jobs:
       - name: Move tag
         if: ${{ github.ref_type == 'tag' }}
         run: |
+          echo "Preparation: Getting owner and repo name"
+          echo "owner_repo=$(gh repo view --json  url,owner,name --template '{{.owner.login}}/{{.name}}')" >> $GITHUB_ENV
+          echo "${{ env.owner_repo }}"
+          echo "Preparation: Checking if tag has a release associated"
+          gh api repos/${{ env.owner_repo }}/releases/tags/${{ env.TAG_NAME }} --silent && FOUND="yes" || FOUND="false"
+          TAG_HAS_RELEASE_ASSOCIATED="$FOUND"
+          if [ $TAG_HAS_RELEASE_ASSOCIATED = "yes" ]; then RELEASE_INFO=$(gh api repos/$owner_repo/releases/tags/${{ env.TAG_NAME }} -q '{draft,prerelease,tag_name,name}');fi
+          echo "Is this tag associated with a release?: $TAG_HAS_RELEASE_ASSOCIATED"
           git tag -d ${{ env.TAG_NAME }}
           git push origin :refs/tags/${{ env.TAG_NAME }}
           git tag -a -m "[RELEASE] ${{ github.sha }} // Released by '${{ github.workflow }}'" ${{ env.TAG_NAME }}
           git push origin --tags
+          if [ $TAG_HAS_RELEASE_ASSOCIATED = "yes" ];
+          then
+            IS_PRERELEASE=$(echo $RELEASE_INFO | jq '.prerelease')
+            IS_DRAFT=$(echo $RELEASE_INFO | jq '.draft')
+            RELEASE_EDIT_ARGS="${{ env.TAG_NAME }} --tag=${{ env.TAG_NAME }} --draft=$(echo "IS_DRAFT") $(if [ $IS_PRERELEASE ]; then echo '--prerelease')";fi
+            echo "Release edit args: $RELEASE_EDIT_ARGS"
+            gh release edit $RELEASE_EDIT_ARGS
+          fi
 
       - name: Delete temporary tag branch
         if: ${{ always() && (env.TAG_BRANCH_NAME != '') }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -133,7 +133,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          persist-credentials: false
+          ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Set up SSH
         if: ${{ env.GITHUB_USER_SSH_KEY != '' }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -74,9 +74,6 @@ on:
       GITHUB_USER_EMAIL:
         description: Email address for the GitHub user configuration.
         required: true
-      GITHUB_USER_TOKEN:
-        description: The token to be used to interact with GH Cli and making the commits.
-        required: true
       GITHUB_USER_NAME:
         description: Username for the GitHub user configuration.
         required: true
@@ -106,9 +103,8 @@ jobs:
         id: detect_tag_annotation
         if: ${{ github.ref_type == 'tag' }}
         run: |
-          echo "LAST_TAG_FIRST_LINE_CONTENT=$(git --no-pager tag -l --format='%(contents)' ${{ github.ref_name }} | head -n 1)" >> $GITHUB_ENV
-          echo "${{ env.LAST_TAG_FIRST_LINE_CONTENT }}"
-          echo "tag_annotation=${{ env.LAST_TAG_FIRST_LINE_CONTENT }}" >> "$GITHUB_OUTPUT"
+          echo $(git --no-pager tag -l --format='%(contents)' ${{ github.ref_name }})
+          echo "tag_annotation=$(git --no-pager tag -l --format='%(contents)' ${{ github.ref_name }})" >> "$GITHUB_OUTPUT"
 
   compile-assets:
     needs: checks
@@ -127,7 +123,6 @@ jobs:
       TAG_BRANCH_NAME: ''                              # we'll override if the push is for tag
       LOCK_FILE: ''                                    # we'll override after checking files
       PACKAGE_MANAGER: 'yarn'                          # we'll override based on env/inputs
-      GITHUB_TOKEN: ${{ secrets.GITHUB_USER_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -220,8 +215,6 @@ jobs:
         run: ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm run' }} ${{ env.COMPILE_SCRIPT }}
 
       - name: Git add, commit, push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_USER_TOKEN }}
         run: |
           declare -a TARGET_PATHS_ARRAY=(${{ inputs.ASSETS_TARGET_PATHS }})
           for path in "${TARGET_PATHS_ARRAY[@]}"; do git add -f "${path}/*"; done
@@ -231,29 +224,11 @@ jobs:
 
       - name: Move tag
         if: ${{ github.ref_type == 'tag' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_USER_TOKEN }}
         run: |
-          echo "Preparation: Getting owner and repo name"
-          echo "The GH owner & repo $GITHUB_REPOSITORY"
-          echo "Preparation: Checking if tag has a release associated"
-          gh api repos/$GITHUB_REPOSITORY/releases/tags/${{ env.TAG_NAME }} --silent && FOUND="yes" || FOUND="false"
-          TAG_HAS_RELEASE_ASSOCIATED="$FOUND"
-          if [ $TAG_HAS_RELEASE_ASSOCIATED = "yes" ]; then RELEASE_INFO=$(gh api repos/$GITHUB_REPOSITORY/releases/tags/${{ env.TAG_NAME }} -q '{draft,prerelease,tag_name,name}');fi
-          echo "Is this tag associated with a release?: $TAG_HAS_RELEASE_ASSOCIATED"
           git tag -d ${{ env.TAG_NAME }}
           git push origin :refs/tags/${{ env.TAG_NAME }}
           git tag -a -m "[RELEASE] ${{ github.sha }} // Released by '${{ github.workflow }}'" ${{ env.TAG_NAME }}
           git push origin --tags
-          if [ $TAG_HAS_RELEASE_ASSOCIATED = "yes" ];
-          then
-            IS_PRERELEASE=$(echo $RELEASE_INFO | jq '.prerelease')
-            IS_DRAFT=$(echo $RELEASE_INFO | jq '.draft')
-            echo "Preparing the ARGS for the Release edit"
-            RELEASE_EDIT_ARGS="${{ env.TAG_NAME }} --tag=${{ env.TAG_NAME }} --draft=$IS_DRAFT $(if [ $IS_PRERELEASE ]; then echo '--prerelease';fi)"
-            echo "Release edit args: $RELEASE_EDIT_ARGS"
-            gh release edit $RELEASE_EDIT_ARGS
-          fi
 
       - name: Delete temporary tag branch
         if: ${{ always() && (env.TAG_BRANCH_NAME != '') }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -247,9 +247,9 @@ jobs:
           then
             IS_PRERELEASE=$(echo $RELEASE_INFO | jq '.prerelease')
             IS_DRAFT=$(echo $RELEASE_INFO | jq '.draft')
-            RELEASE_EDIT_ARGS="${{ env.TAG_NAME }} --tag=${{ env.TAG_NAME }} --draft=$(echo "$IS_DRAFT") $(if [ $IS_PRERELEASE ]; then echo '--prerelease')";fi
+            RELEASE_EDIT_ARGS="${{ env.TAG_NAME }} --tag=${{ env.TAG_NAME }} --draft=$IS_DRAFT $(if [ $IS_PRERELEASE ]; then echo '--prerelease')";fi
             echo "Release edit args: $RELEASE_EDIT_ARGS"
-            gh release edit $RELEASE_EDIT_ARGS
+            gh release edit "$RELEASE_EDIT_ARGS"
           fi
 
       - name: Delete temporary tag branch


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Adds the possibility to add WP CLI in the build & push built branches strategy
- Adds the possibility to add an array of branches were to run the build prod command


**What is the current behavior?** (You can also link to an open issue here)
There is no possibility to install wpcli
There is no possibility to run the build prod command on branches


**What is the new behavior (if this is a feature change)?**
The installation of WP CLI is optional
Users can specify an array of branches where to use the build prod command 

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
