### PR TITLE
build-assets-compilation.yml // use BUILD_ENV "development"

### DIFF
--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -130,7 +130,10 @@ jobs:
         if: ${{ !contains(github.ref, 'refs/tags/') }}
         run: |
           echo "ASSETS_HASH=$(composer assets-hash)" >> $GITHUB_ENV
-          echo "BUILD_ENV=dev" >> $GITHUB_ENV
+          # We set here "development" to align with Webpack "mode" to be
+          # used in composer-asset-compiler as placeholder variable.
+          # @link https://webpack.js.org/configuration/mode/
+          echo "BUILD_ENV=development" >> $GITHUB_ENV
 
       - name: Set environment variables [PROD]
         if: ${{ contains(github.ref, 'refs/tags/') }}

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -130,8 +130,8 @@ jobs:
         if: ${{ !contains(github.ref, 'refs/tags/') }}
         run: |
           echo "ASSETS_HASH=$(composer assets-hash)" >> $GITHUB_ENV
-          # We set here "development" to align with Webpack "mode" to be
-          # used in composer-asset-compiler as placeholder variable.
+          # We set "development" here to align with webpack's "mode"
+          # to be used in Composer Asset Compiler as a placeholder variable.
           # @link https://webpack.js.org/configuration/mode/
           echo "BUILD_ENV=development" >> $GITHUB_ENV
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Right now we set `BUILD_ENV` to `dev`, which comes from Webpack Encore `ENCORE_ENV` we had used in the past to run something like `yarn encore {ENCORE_ENV}`. 

But with the company-switch to `@wordpress/scripts` and or using just plain Webpack we might want to use `--mode=development|production`. So `dev` is incorrect and should be `development` to align with Webpack.

https://webpack.js.org/configuration/mode/