### PR TITLE
Remove old ref from checkout step

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -43,7 +43,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: inpsyde/reusable-workflows
-          ref: automatic-release
           path: workflow-repo
 
       - name: Add release.config.js file if not provided


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
The workflow breaks while checking out a repository,  because I've left an old branch ref


**What is the new behavior (if this is a feature change)?**
Removed the ref because now the workflow is in the main one


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
