### PR TITLE
feat: adds possibility to install WP_CLI and the possibility to use t…

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -53,6 +53,21 @@ on:
         type: string
         default: ''
         required: false
+      INSTALL_WP_CLI:
+        description: Whether to Install WP cli or not.
+        default: false
+        required: false
+        type: boolean
+      PHP_VERSION:
+        description: PHP version with which the WP CLI is going to be executed.
+        default: "8.1"
+        required: false
+        type: string
+      BRANCHES_USING_COMPILE_SCRIPT_PROD:
+        description: Branches that should use the COMPILE_SCRIPT_PROD script
+        default: '[]'
+        required: false
+        type: string
     secrets:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
@@ -126,6 +141,7 @@ jobs:
       GITHUB_USER_EMAIL: ${{ secrets.GITHUB_USER_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
+      BRANCHES_USING_COMPILE_SCRIPT_PROD: ${{ inputs.BRANCHES_USING_COMPILE_SCRIPT_PROD }}
       COMPILE_SCRIPT: ${{ inputs.COMPILE_SCRIPT_DEV }} # we'll override if the push is for tag
       TAG_NAME: ''                                     # we'll override if the push is for tag
       TAG_BRANCH_NAME: ''                              # we'll override if the push is for tag
@@ -175,6 +191,11 @@ jobs:
           echo "COMPILE_SCRIPT=${{ inputs.COMPILE_SCRIPT_PROD }}" >> $GITHUB_ENV
           echo "RELEASE_BRANCH_ENABLED=${{ (needs.checks.outputs.is_development_branch_last_commit == 'yes' && inputs.RELEASE_BRANCH_NAME != '') && 'yes' || 'no' }}" >> $GITHUB_ENV
 
+      - name: Set branch COMPILE_SCRIPT
+        if: ${{ github.ref_type == 'branch' && contains(fromJSON(env.BRANCHES_USING_COMPILE_SCRIPT_PROD), github.ref_name) }}
+        run: |
+          echo "COMPILE_SCRIPT=${{ inputs.COMPILE_SCRIPT_PROD }}" >> $GITHUB_ENV
+
       - name: Checkout and merge the built branch
         if: ${{ github.ref_type == 'branch' }}
         run: |
@@ -218,6 +239,14 @@ jobs:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
           cache: ${{ env.NODE_CACHE_MODE }}
+
+      - name: Install WP CLI
+        if: ${{ inputs.INSTALL_WP_CLI }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.PHP_VERSION }}
+          tools: wp-cli
+          coverage: none
 
       - name: Install dependencies
         env:


### PR DESCRIPTION
…he PROD compile script on specified branches

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the ability to configure the environment to use the WP CLI and PHP, these will help if the consumer requires to:

- Use the WP CLI to build the POT files.

We are also adding the possibility to use the COMPILE_SCRIPT_PROD on the branches workflow since this was not possible.

**What is the current behavior?** (You can also link to an open issue here).

1. There is no possibility of using the WP CLI.
2. There is no possibility to use the COMPILE_SCRIPT_PROD in the branches


**What is the new behavior (if this is a feature change)?**
Consumers can:

1. Optionally add the WP CLI by configuring it along with the PHP version to use
2. Optionally define an array of branches to run the COMPILE_SCRIPT_PROD


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
