### PR TITLE
Compile assets not respecting package manager

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -243,7 +243,7 @@ jobs:
         run: ${{ format('{0} {1}', inputs.PACKAGE_MANAGER, env.ARGS) }}
 
       - name: Compile assets
-        run: ${{ env.PACKAGE_MANAGER == 'yarn' && 'yarn' || format('{0} {1}', 'npm run', env.COMPILE_SCRIPT) }}
+        run: ${{ env.PACKAGE_MANAGER == 'yarn' && 'yarn' || 'npm run' }} ${{ env.COMPILE_SCRIPT }}
 
       - name: Git add, commit
         run: |

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -243,7 +243,7 @@ jobs:
         run: ${{ format('{0} {1}', inputs.PACKAGE_MANAGER, env.ARGS) }}
 
       - name: Compile assets
-        run: ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm run' }} ${{ env.COMPILE_SCRIPT }}
+        run: ${{ env.PACKAGE_MANAGER == 'yarn' && 'yarn' || format('{0} {1}', 'npm run', env.COMPILE_SCRIPT) }}
 
       - name: Git add, commit
         run: |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes wrong package manager used when compile assets step happens


**What is the current behavior?** (You can also link to an open issue here)
When selecting **npm** as package manager the compile assets step uses **yarn**


**What is the new behavior (if this is a feature change)?**
When selecting **npm** as package manager the compile assets step uses **npm**


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
