### PR TITLE
fix: fixes Compile assets not respecting package manager when using npm

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -152,7 +152,7 @@ jobs:
         run: ${{ format('{0} {1}', inputs.PACKAGE_MANAGER, env.ARGS) }}
 
       - name: Compile assets
-        run: ${{ ((env.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm run' }} ${{ env.COMPILE_SCRIPT }}
+        run: ${{ env.PACKAGE_MANAGER == 'yarn' && 'yarn' || 'npm run' }} ${{ env.COMPILE_SCRIPT }}
 
       - name: Git add, commit, push
         run: |

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -78,7 +78,6 @@ jobs:
       TAG_NAME: ''                                     # we'll override if the push is for tag
       TAG_BRANCH_NAME: ''                              # we'll override if the push is for tag
       LOCK_FILE: ''                                    # we'll override after checking files
-      PACKAGE_MANAGER: 'yarn'                          # we'll override based on env/inputs
       NO_CHANGES: ''                                   # we'll override if no changes to commit
     steps:
       - name: Checkout
@@ -152,7 +151,7 @@ jobs:
         run: ${{ format('{0} {1}', inputs.PACKAGE_MANAGER, env.ARGS) }}
 
       - name: Compile assets
-        run: ${{ env.PACKAGE_MANAGER == 'yarn' && 'yarn' || 'npm run' }} ${{ env.COMPILE_SCRIPT }}
+        run: ${{ inputs.PACKAGE_MANAGER == 'yarn' && 'yarn' || 'npm run' }} ${{ env.COMPILE_SCRIPT }}
 
       - name: Git add, commit, push
         run: |

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -89,7 +89,7 @@ jobs:
           cache: ${{ inputs.PACKAGE_MANAGER }}
 
       - name: Install dependencies
-        run: ${{ ((inputs.PACKAGE_MANAGER == 'yarn') && 'yarn') || 'npm install' }}
+        run: ${{ inputs.PACKAGE_MANAGER == 'yarn' && 'yarn' || 'npm install' }}
 
       - name: Run Jest
         run: ./node_modules/.bin/jest ${{ inputs.JEST_ARGS }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes wrong package manager used when compile assets step happens


**What is the current behavior?** (You can also link to an open issue here)
When selecting **npm** as package manager the compile assets step uses **yarn**


**What is the new behavior (if this is a feature change)?**
When selecting **npm** as package manager the compile assets step uses **npm**


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No



**Other information**:
