### PR TITLE
Change defaults compile scripts

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -31,12 +31,12 @@ on:
       COMPILE_SCRIPT_PROD:
         description: Script added to "npm run" or "yarn" to build production assets.
         type: string
-        default: 'encore prod'
+        default: 'build'
         required: false
       COMPILE_SCRIPT_DEV:
         description: Script added to "npm run" or "yarn" to build development assets.
         type: string
-        default: 'encore dev'
+        default: 'build:dev'
         required: false
       MODE:
         description: Mode for compiling assets (`prod` or `dev`)

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -80,8 +80,8 @@ This is not the simplest possible example, but it showcases all the recommendati
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                |
 | `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `WORKING_DIRECTORY`   | `'./'`                        | Working directory path                                                            |
-| `COMPILE_SCRIPT_PROD` | `'encore prod'`               | Script added to `npm run` or `yarn` to build production assets                    |
-| `COMPILE_SCRIPT_DEV`  | `'encore dev'`                | Script added to `npm run` or `yarn` to build development assets                   |
+| `COMPILE_SCRIPT_PROD` | `'build'`                     | Script added to `npm run` or `yarn` to build production assets                    |
+| `COMPILE_SCRIPT_DEV`  | `'build:dev'`                 | Script added to `npm run` or `yarn` to build development assets                   |
 | `MODE`                | `''`                          | Mode for compiling assets (`prod` or `dev`)                                       |
 | `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                |
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
Encore-based scripts are the default values for the `COMPILE_SCRIPT_DEV` and `COMPILE_SCRIPT_PROD` inputs. However, we no longer use Encore in new packages. Instead, we are gradually switching to [`@wordpress/scripts`](https://www.npmjs.com/package/@wordpress/scripts).


**What is the new behavior (if this is a feature change)?**
* Change default value for `COMPILE_SCRIPT_DEV` from `encore dev` to `build:dev`
* Change default value for `COMPILE_SCRIPT_PROD` from `encore prod` to `build`

The script names are aligned with `@wordpress/scripts` and are expected to be in the `scripts` section of the caller workflow's `package.json`.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes.
However, only one package calls this workflow without specifying the `COMPILE_SCRIPT_*` inputs.
CC @2ndkauboy


**Other information**:
Closes #85