### PR TITLE
[PROD-141] Overridable filename and plugin dir name for the 'Create plugin archive' action

### DIFF
--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -81,6 +81,11 @@ jobs:
       NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       NODE_CACHE_MODE: ''
+      ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
+      PLUGIN_FOLDER_NAME: ${{ inputs.PLUGIN_FOLDER_NAME }}
+      ENV_VARS: ${{ secrets.ENV_VARS }}
+      GIT_SHA: ${{ github.sha }}
+      PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
       # Disables symlinking of local path repositories.
       # During development, symlinking is preferable.
@@ -93,21 +98,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up archive name
-        env:
-          ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
         id: plugin-data
         run: echo "archive-name=${ARCHIVE_NAME:-${{ github.event.repository.name }}}" >> $GITHUB_OUTPUT
 
       - name: Set up plugin folder name
-        env:
-          PLUGIN_FOLDER_NAME: ${{ inputs.PLUGIN_FOLDER_NAME }}
-          ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
         id: plugin-folder-name
         run: echo "plugin-folder-name=${PLUGIN_FOLDER_NAME:-${ARCHIVE_NAME:-${{ github.event.repository.name }}}}" >> $GITHUB_OUTPUT
 
       - name: Set up custom environment variables
-        env:
-          ENV_VARS: ${{ secrets.ENV_VARS }}
         if: ${{ env.ENV_VARS }}
         uses: actions/github-script@v7
         with:
@@ -181,13 +179,9 @@ jobs:
           composer-options: ${{ inputs.COMPOSER_ARGS }}
 
       - name: Add commit hash to plugin header
-        env:
-          GIT_SHA: ${{ github.sha }}
         run: 'sed -Ei "s/SHA: .*/SHA: ${GIT_SHA}/g" ${{ inputs.PLUGIN_MAIN_FILE }}'
 
       - name: Set plugin version header
-        env:
-            PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}
         run: 'sed -Ei "s/Version: .*/Version: ${PLUGIN_VERSION}/g" ${{ inputs.PLUGIN_MAIN_FILE }}'
 
       - name: Install dist-archive command

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -120,6 +120,7 @@ jobs:
       - name: Set up plugin dir name
         env:
           PLUGIN_DIR_NAME: ${{ inputs.PLUGIN_DIR_NAME }}
+          ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
         id: plugin-dir-name
         run: |
           if [ ! -z "$PLUGIN_DIR_NAME" ]; then

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -234,7 +234,7 @@ jobs:
       - name: Set artifact name
         id: set-artifact-name
         run: |
-          if [ ! -z ${{ steps.set-archive-full-name.outputs.archive-full-name }}]; then
+          if [ ! -z ${{ steps.set-archive-full-name.outputs.archive-full-name }} ]; then
             echo "artifact=${{ steps.set-archive-full-name.outputs.archive-full-name }}" >> $GITHUB_OUTPUT
             echo "archive-full-name is ${{ steps.set-archive-full-name.outputs.archive-full-name }}"
           else

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -41,7 +41,7 @@ on:
       ARCHIVE_FULL_NAME:
         description: The full name of the resulting zip archive. Falls back to the ARCHIVE_NAME-PLUGIN_VERSION template.
         required: false
-        default: '',
+        default: ''
         type: string
       PLUGIN_MAIN_FILE:
         description: The name of the main plugin file.

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -34,7 +34,7 @@ on:
         required: false
         type: string
       ARCHIVE_NAME:
-        description: The full name of the resulting zip archive. Falls back to the repository name.
+        description: The name of the zip archive (falls back to the repository name).
         default: ''
         required: false
         type: string

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -115,7 +115,6 @@ jobs:
         run: |
           if [ ! -z "$ARCHIVE_FULL_NAME" ]; then
               echo "archive-full-name=$ARCHIVE_FULL_NAME" >> $GITHUB_OUTPUT
-              echo "Full archive name set up as $ARCHIVE_FULL_NAME"
           fi
 
       - name: Set up plugin dir name
@@ -236,11 +235,8 @@ jobs:
         run: |
           if [ ! -z ${{ steps.set-archive-full-name.outputs.archive-full-name }} ]; then
             echo "artifact=${{ steps.set-archive-full-name.outputs.archive-full-name }}" >> $GITHUB_OUTPUT
-            echo "archive-full-name is ${{ steps.set-archive-full-name.outputs.archive-full-name }}"
-            echo "Run attempt is ${{ github.run_attempt }}".
           else
             echo "artifact=${{ steps.plugin-data.outputs.archive-name }}-${{ inputs.PLUGIN_VERSION }}" >> $GITHUB_OUTPUT
-            echo "archive full name not found"
           fi
 
       - name: Upload artifact

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -224,7 +224,7 @@ jobs:
             ${{ inputs.PRE_SCRIPT }}
 
       - name: Run WP-CLI command
-        run: wp dist-archive . ./archive.zip --plugin-dirname=${{ steps.plugin-data.outputs.archive-name }}
+        run: wp dist-archive . ./archive.zip --plugin-dirname=${{ steps.plugin-dir-name.outputs.plugin-dir-name }}
 
         # GitHub Action artifacts would otherwise produce a zip within a zip
       - name: Unzip archive to dist/

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Set up full archive name
         env:
           ARCHIVE_FULL_NAME: ${{ inputs.ARCHIVE_FULL_NAME }}
-        id: archive-full-name
+        id: set-archive-full-name
         run: |
           if [ ! -z "$ARCHIVE_FULL_NAME" ]; then
               echo "archive-full-name=$ARCHIVE_FULL_NAME" >> $GITHUB_OUTPUT
@@ -233,8 +233,8 @@ jobs:
       - name: Set artifact name
         id: set-artifact-name
         run: |
-          if [ ! -z ${{ steps.plugin-data.outputs.archive-full-name }}]; then
-            echo "artifact=${{ steps.plugin-data.outputs.archive-full-name }}" >> $GITHUB_OUTPUT
+          if [ ! -z ${{ steps.set-archive-full-name.outputs.archive-full-name }}]; then
+            echo "artifact=${{ steps.set-archive-full-name.outputs.archive-full-name }}" >> $GITHUB_OUTPUT
           else
             echo "artifact=${{ steps.plugin-data.outputs.archive-name }}-${{ inputs.PLUGIN_VERSION }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -107,15 +107,9 @@ jobs:
         env:
           PLUGIN_FOLDER_NAME: ${{ inputs.PLUGIN_FOLDER_NAME }}
           ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
-        id: plugin-dir-name
+        id: plugin-folder-name
         run: |
-          if [ ! -z "$PLUGIN_DIR_NAME" ]; then
-            echo "plugin-dir-name=$PLUGIN_DIR_NAME" >> $GITHUB_OUTPUT
-          elif [ ! -z "$ARCHIVE_NAME" ]; then
-            echo "plugin-dir-name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
-          else
-            echo "plugin-dir-name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
-          fi
+          echo "plugin-folder-name=${PLUGIN_FOLDER_NAME:-$ARCHIVE_NAME:-${{ github.event.repository.name }}}" >> $GITHUB_OUTPUT
 
       - name: Set up custom environment variables
         env:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -233,7 +233,7 @@ jobs:
       - name: Set artifact name
         id: set-artifact-name
         run: |
-          if [! -z ${{ steps.plugin-data.outputs.archive-full-name }}]; then
+          if [ ! -z ${{ steps.plugin-data.outputs.archive-full-name }}]; then
             echo "artifact=${{ steps.plugin-data.outputs.archive-full-name }}" >> $GITHUB_OUTPUT
           else
             echo "artifact=${{ steps.plugin-data.outputs.archive-name }}-${{ inputs.PLUGIN_VERSION }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -129,6 +129,7 @@ jobs:
             echo "plugin-dir-name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
           else
             echo "plugin-dir-name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set up custom environment variables
         env:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -236,7 +236,7 @@ jobs:
         run: |
           if [ ! -z ${{ steps.set-archive-full-name.outputs.archive-full-name }}]; then
             echo "artifact=${{ steps.set-archive-full-name.outputs.archive-full-name }}" >> $GITHUB_OUTPUT
-            echo "archive-full-name is ${{ steps.set-archive-full-name.outputs.archive-full-name }}
+            echo "archive-full-name is ${{ steps.set-archive-full-name.outputs.archive-full-name }}"
           else
             echo "artifact=${{ steps.plugin-data.outputs.archive-name }}-${{ inputs.PLUGIN_VERSION }}" >> $GITHUB_OUTPUT
             echo "archive full name not found"

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -210,7 +210,7 @@ jobs:
             ${{ inputs.PRE_SCRIPT }}
 
       - name: Run WP-CLI command
-        run: wp dist-archive . ./archive.zip --plugin-dirname=${{ steps.plugin-dir-name.outputs.plugin-dir-name }}
+        run: wp dist-archive . ./archive.zip --plugin-dirname=${{ steps.plugin-folder-name.outputs.plugin-folder-name }}
 
         # GitHub Action artifacts would otherwise produce a zip within a zip
       - name: Unzip archive to dist/

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           if [ ! -z "$PLUGIN_DIR_NAME" ]; then
             echo "plugin-dir-name=$PLUGIN_DIR_NAME" >> $GITHUB_OUTPUT
-          elif [! -z "$ARCHIVE_NAME"]; then
+          elif [ ! -z "$ARCHIVE_NAME"]; then
             echo "plugin-dir-name=$ARCHIVE_NAME"
           else
             echo "plugin-dir-name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -9,7 +9,7 @@ on:
         default: ''
         required: false
       NODE_VERSION:
-        description: Node version with which the static code analysis is to be executed.
+        description: Node version with which the assets will be compiled.
         default: 18
         required: false
         type: string

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -125,7 +125,7 @@ jobs:
           if [ ! -z "$PLUGIN_DIR_NAME" ]; then
             echo "plugin-dir-name=$PLUGIN_DIR_NAME" >> $GITHUB_OUTPUT
           elif [ ! -z "$ARCHIVE_NAME"]; then
-            echo "plugin-dir-name=$ARCHIVE_NAME"
+            echo "plugin-dir-name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
           else
             echo "plugin-dir-name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -103,7 +103,7 @@ jobs:
               echo "archive-name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Set up plugin dir name
+      - name: Set up plugin folder name
         env:
           PLUGIN_FOLDER_NAME: ${{ inputs.PLUGIN_FOLDER_NAME }}
           ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           if [ ! -z "$PLUGIN_DIR_NAME" ]; then
             echo "plugin-dir-name=$PLUGIN_DIR_NAME" >> $GITHUB_OUTPUT
-          elif [ ! -z "$ARCHIVE_NAME"]; then
+          elif [ ! -z "$ARCHIVE_NAME" ]; then
             echo "plugin-dir-name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
           else
             echo "plugin-dir-name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -43,7 +43,7 @@ on:
         required: false
         default: 'index.php'
         type: string
-      PLUGIN_DIR_NAME:
+      PLUGIN_FOLDER_NAME:
         description: The name of the plugin directory inside the archive. Falls back to the archive name and repository name.
         required: false
         default: ''

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -124,11 +124,11 @@ jobs:
         id: plugin-dir-name
         run: |
           if [ ! -z "$PLUGIN_DIR_NAME" ]; then
-            echo "plugin-dir-name=$PLUGIN_DIR_NAME" >> "$GITHUB_OUTPUT"
+            echo "plugin-dir-name=$PLUGIN_DIR_NAME" >> $GITHUB_OUTPUT
           elif [ ! -z "$ARCHIVE_NAME" ]; then
-            echo "plugin-dir-name=$ARCHIVE_NAME" >> "$GITHUB_OUTPUT"
+            echo "plugin-dir-name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
           else
-            echo "plugin-dir-name=${{ github.event.repository.name }}" >> "$GITHUB_OUTPUT"
+            echo "plugin-dir-name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
 
       - name: Set up custom environment variables
         env:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -96,7 +96,7 @@ jobs:
         env:
           ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
         id: plugin-data
-        run: echo "archive-name=${ARCHIVE_NAME:-${{ github.event.repository.name }}}"
+        run: echo "archive-name=${ARCHIVE_NAME:-${{ github.event.repository.name }}}" >> $GITHUB_OUTPUT
 
       - name: Set up plugin folder name
         env:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -34,14 +34,9 @@ on:
         required: false
         type: string
       ARCHIVE_NAME:
-        description: The base name of the resulting zip archive. Falls back to the repository name.
+        description: The full name of the resulting zip archive. Falls back to the repository name.
         default: ''
         required: false
-        type: string
-      ARCHIVE_FULL_NAME:
-        description: The full name of the resulting zip archive. Falls back to the ARCHIVE_NAME-PLUGIN_VERSION template.
-        required: false
-        default: ''
         type: string
       PLUGIN_MAIN_FILE:
         description: The name of the main plugin file.
@@ -106,15 +101,6 @@ jobs:
               echo "archive-name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
           else
               echo "archive-name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Set up full archive name
-        env:
-          ARCHIVE_FULL_NAME: ${{ inputs.ARCHIVE_FULL_NAME }}
-        id: set-archive-full-name
-        run: |
-          if [ ! -z "$ARCHIVE_FULL_NAME" ]; then
-              echo "archive-full-name=$ARCHIVE_FULL_NAME" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up plugin dir name
@@ -232,12 +218,7 @@ jobs:
 
       - name: Set artifact name
         id: set-artifact-name
-        run: |
-          if [ ! -z ${{ steps.set-archive-full-name.outputs.archive-full-name }} ]; then
-            echo "artifact=${{ steps.set-archive-full-name.outputs.archive-full-name }}" >> $GITHUB_OUTPUT
-          else
-            echo "artifact=${{ steps.plugin-data.outputs.archive-name }}-${{ inputs.PLUGIN_VERSION }}" >> $GITHUB_OUTPUT
-          fi
+        run: echo "artifact=${{ steps.plugin-data.outputs.archive-name }}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -108,8 +108,7 @@ jobs:
           PLUGIN_FOLDER_NAME: ${{ inputs.PLUGIN_FOLDER_NAME }}
           ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
         id: plugin-folder-name
-        run: |
-          echo "plugin-folder-name=${PLUGIN_FOLDER_NAME:-${ARCHIVE_NAME:-${{ github.event.repository.name }}}}" >> $GITHUB_OUTPUT
+        run: echo "plugin-folder-name=${PLUGIN_FOLDER_NAME:-${ARCHIVE_NAME:-${{ github.event.repository.name }}}}" >> $GITHUB_OUTPUT
 
       - name: Set up custom environment variables
         env:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Set up plugin dir name
         env:
-          PLUGIN_DIR_NAME: ${{ inputs.PLUGIN_DIR_NAME }}
+          PLUGIN_FOLDER_NAME: ${{ inputs.PLUGIN_FOLDER_NAME }}
           ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
         id: plugin-dir-name
         run: |

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -96,12 +96,7 @@ jobs:
         env:
           ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
         id: plugin-data
-        run: |
-          if [ ! -z "$ARCHIVE_NAME" ]; then
-              echo "archive-name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
-          else
-              echo "archive-name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
-          fi
+        run: echo "archive-name=${ARCHIVE_NAME:-${{ github.event.repository.name }}}"
 
       - name: Set up plugin folder name
         env:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -109,7 +109,7 @@ jobs:
           ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
         id: plugin-folder-name
         run: |
-          echo "plugin-folder-name=${PLUGIN_FOLDER_NAME:-$ARCHIVE_NAME:-${{ github.event.repository.name }}}" >> $GITHUB_OUTPUT
+          echo "plugin-folder-name=${PLUGIN_FOLDER_NAME:-${ARCHIVE_NAME:-${{ github.event.repository.name }}}}" >> $GITHUB_OUTPUT
 
       - name: Set up custom environment variables
         env:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -237,6 +237,7 @@ jobs:
           if [ ! -z ${{ steps.set-archive-full-name.outputs.archive-full-name }} ]; then
             echo "artifact=${{ steps.set-archive-full-name.outputs.archive-full-name }}" >> $GITHUB_OUTPUT
             echo "archive-full-name is ${{ steps.set-archive-full-name.outputs.archive-full-name }}"
+            echo "Run attempt is ${{ github.run_attempt }}".
           else
             echo "artifact=${{ steps.plugin-data.outputs.archive-name }}-${{ inputs.PLUGIN_VERSION }}" >> $GITHUB_OUTPUT
             echo "archive full name not found"

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -38,10 +38,20 @@ on:
         default: ''
         required: false
         type: string
+      ARCHIVE_FULL_NAME:
+        description: The full name of the resulting zip archive. Falls back to the ARCHIVE_NAME-PLUGIN_VERSION template.
+        required: false
+        default: '',
+        type: string
       PLUGIN_MAIN_FILE:
         description: The name of the main plugin file.
         required: false
         default: 'index.php'
+        type: string
+      PLUGIN_DIR_NAME:
+        description: The name of the plugin directory inside the archive. Falls back to the archive name and repository name.
+        required: false
+        default: ''
         type: string
       PLUGIN_VERSION:
         description: The new plugin version.
@@ -97,6 +107,27 @@ jobs:
           else
               echo "archive-name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Set up full archive name
+        env:
+          ARCHIVE_FULL_NAME: ${{ inputs.ARCHIVE_FULL_NAME }}
+        id: archive-full-name
+        run: |
+          if [ ! -z "$ARCHIVE_FULL_NAME" ]; then
+              echo "archive-full-name=$ARCHIVE_FULL_NAME" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up plugin dir name
+        env:
+          PLUGIN_DIR_NAME: {{ inputs.PLUGIN_DIR_NAME }}
+        id: plugin-dir-name
+        run: |
+          if [ ! -z "$PLUGIN_DIR_NAME" ]; then
+            echo "plugin-dir-name=$PLUGIN_DIR_NAME" >> $GITHUB_OUTPUT
+          elif [! -z "$ARCHIVE_NAME"]; then
+            echo "plugin-dir-name=$ARCHIVE_NAME"
+          else
+            echo "plugin-dir-name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
 
       - name: Set up custom environment variables
         env:
@@ -199,7 +230,11 @@ jobs:
 
       - name: Set artifact name
         id: set-artifact-name
-        run: echo "artifact=${{ steps.plugin-data.outputs.archive-name }}-${{ inputs.PLUGIN_VERSION }}" >> $GITHUB_OUTPUT
+        run: |
+          if [! -z ${{ steps.plugin-data.outputs.archive-full-name }}]; then
+            echo "artifact=${{ steps.plugin-data.outputs.archive-full-name }}" >> $GITHUB_OUTPUT
+          else
+            echo "artifact=${{ steps.plugin-data.outputs.archive-name }}-${{ inputs.PLUGIN_VERSION }}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -115,6 +115,7 @@ jobs:
         run: |
           if [ ! -z "$ARCHIVE_FULL_NAME" ]; then
               echo "archive-full-name=$ARCHIVE_FULL_NAME" >> $GITHUB_OUTPUT
+              echo "Full archive name set up as $ARCHIVE_FULL_NAME"
           fi
 
       - name: Set up plugin dir name
@@ -235,8 +236,10 @@ jobs:
         run: |
           if [ ! -z ${{ steps.set-archive-full-name.outputs.archive-full-name }}]; then
             echo "artifact=${{ steps.set-archive-full-name.outputs.archive-full-name }}" >> $GITHUB_OUTPUT
+            echo "archive-full-name is ${{ steps.set-archive-full-name.outputs.archive-full-name }}
           else
             echo "artifact=${{ steps.plugin-data.outputs.archive-name }}-${{ inputs.PLUGIN_VERSION }}" >> $GITHUB_OUTPUT
+            echo "archive full name not found"
           fi
 
       - name: Upload artifact

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Set up plugin dir name
         env:
-          PLUGIN_DIR_NAME: {{ inputs.PLUGIN_DIR_NAME }}
+          PLUGIN_DIR_NAME: ${{ inputs.PLUGIN_DIR_NAME }}
         id: plugin-dir-name
         run: |
           if [ ! -z "$PLUGIN_DIR_NAME" ]; then

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -237,6 +237,7 @@ jobs:
             echo "artifact=${{ steps.plugin-data.outputs.archive-full-name }}" >> $GITHUB_OUTPUT
           else
             echo "artifact=${{ steps.plugin-data.outputs.archive-name }}-${{ inputs.PLUGIN_VERSION }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up plugin base name
+      - name: Set up archive name
         env:
           ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
         id: plugin-data

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -124,11 +124,11 @@ jobs:
         id: plugin-dir-name
         run: |
           if [ ! -z "$PLUGIN_DIR_NAME" ]; then
-            echo "plugin-dir-name=$PLUGIN_DIR_NAME" >> $GITHUB_OUTPUT
+            echo "plugin-dir-name=$PLUGIN_DIR_NAME" >> "$GITHUB_OUTPUT"
           elif [ ! -z "$ARCHIVE_NAME" ]; then
-            echo "plugin-dir-name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
+            echo "plugin-dir-name=$ARCHIVE_NAME" >> "$GITHUB_OUTPUT"
           else
-            echo "plugin-dir-name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
+            echo "plugin-dir-name=${{ github.event.repository.name }}" >> "$GITHUB_OUTPUT"
 
       - name: Set up custom environment variables
         env:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -44,7 +44,7 @@ on:
         default: 'index.php'
         type: string
       PLUGIN_FOLDER_NAME:
-        description: The name of the plugin directory inside the archive. Falls back to the archive name and repository name.
+        description: The name of the plugin folder (falls back to the archive name, if set, or the repository name).
         required: false
         default: ''
         type: string

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -39,20 +39,20 @@ jobs:
 
 ### Inputs
 
-| Name                  | Default                                                       | Description                                                                                   |
-|-----------------------|---------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
-| `NODE_OPTIONS`        | `''`                                                          | Space-separated list of command-line Node options                                             |
-| `NODE_VERSION`        | `18`                                                          | Node version with which the assets will be compiled                                           |
-| `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                               | Domain of the private npm registry                                                            |
-| `PACKAGE_MANAGER`     | `"yarn"`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`)             |
-| `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                                           |
-| `PHP_VERSION`         | `"8.0"`                                                       | PHP version to use during packaging                                                           |
-| `ARCHIVE_NAME`        | `""`                                                          | Desired full name of resulting archive. Falls back to repository name.                        |
-| `PLUGIN_DIR_NAME`     | `""`                                                          | Name of the directory inside the archive. Falls back to the archive name and repository name. |
-| `PLUGIN_MAIN_FILE`    | `"index.php"`                                                 | The name of the plugin main file                                                              |
-| `PLUGIN_VERSION`      | -                                                             | The plugin version                                                                            |
-| `PRE_SCRIPT`          | `""`                                                          | Run custom shell code before creating the release archive                                     |
-| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`                                             | Set of arguments passed to Composer Asset Compiler                                            |
+| Name                  | Default                                                       | Description                                                                                |
+|-----------------------|---------------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| `NODE_OPTIONS`        | `''`                                                          | Space-separated list of command-line Node options                                          |
+| `NODE_VERSION`        | `18`                                                          | Node version with which the assets will be compiled                                        |
+| `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                               | Domain of the private npm registry                                                         |
+| `PACKAGE_MANAGER`     | `"yarn"`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`)          |
+| `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                                        |
+| `PHP_VERSION`         | `"8.0"`                                                       | PHP version to use during packaging                                                        |
+| `ARCHIVE_NAME`        | `""`                                                          | Desired full name of resulting archive. Falls back to repository name.                     |
+| `PLUGIN_FOLDER_NAME`  | `""`                                                          | Name of the folder inside the archive. Falls back to the archive name and repository name. |
+| `PLUGIN_MAIN_FILE`    | `"index.php"`                                                 | The name of the plugin main file                                                           |
+| `PLUGIN_VERSION`      | -                                                             | The plugin version                                                                         |
+| `PRE_SCRIPT`          | `""`                                                          | Run custom shell code before creating the release archive                                  |
+| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`                                             | Set of arguments passed to Composer Asset Compiler                                         |
 
 #### A note on `PLUGIN_VERSION`
 

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -39,20 +39,20 @@ jobs:
 
 ### Inputs
 
-| Name                  | Default                                                       | Description                                                                                |
-|-----------------------|---------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| `NODE_OPTIONS`        | `''`                                                          | Space-separated list of command-line Node options                                          |
-| `NODE_VERSION`        | `18`                                                          | Node version with which the assets will be compiled                                        |
-| `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                               | Domain of the private npm registry                                                         |
-| `PACKAGE_MANAGER`     | `"yarn"`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`)          |
-| `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                                        |
-| `PHP_VERSION`         | `"8.0"`                                                       | PHP version to use during packaging                                                        |
-| `ARCHIVE_NAME`        | `""`                                                          | Desired full name of resulting archive. Falls back to repository name.                     |
-| `PLUGIN_FOLDER_NAME`  | `""`                                                          | Name of the folder inside the archive. Falls back to the archive name and repository name. |
-| `PLUGIN_MAIN_FILE`    | `"index.php"`                                                 | The name of the plugin main file                                                           |
-| `PLUGIN_VERSION`      | -                                                             | The plugin version                                                                         |
-| `PRE_SCRIPT`          | `""`                                                          | Run custom shell code before creating the release archive                                  |
-| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`                                             | Set of arguments passed to Composer Asset Compiler                                         |
+| Name                  | Default                                                       | Description                                                                                    |
+|-----------------------|---------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| `NODE_OPTIONS`        | `''`                                                          | Space-separated list of command-line Node options                                              |
+| `NODE_VERSION`        | `18`                                                          | Node version with which the assets will be compiled                                            |
+| `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                               | Domain of the private npm registry                                                             |
+| `PACKAGE_MANAGER`     | `"yarn"`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`)              |
+| `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                                            |
+| `PHP_VERSION`         | `"8.0"`                                                       | PHP version to use during packaging                                                            |
+| `ARCHIVE_NAME`        | `""`                                                          | The name of the zip archive (falls back to the repository name)                                |
+| `PLUGIN_MAIN_FILE`    | `"index.php"`                                                 | The name of the main plugin file                                                               |
+| `PLUGIN_FOLDER_NAME`  | `""`                                                          | The name of the plugin folder (falls back to the archive name, if set, or the repository name) |
+| `PLUGIN_VERSION`      | -                                                             | The new plugin version                                                                         |
+| `PRE_SCRIPT`          | `""`                                                          | Run custom shell code before creating the release archive                                      |
+| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`                                             | Set of arguments passed to Composer Asset Compiler                                             |
 
 #### A note on `PLUGIN_VERSION`
 

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -39,19 +39,21 @@ jobs:
 
 ### Inputs
 
-| Name                  | Default                                                       | Description                                                                       |
-|-----------------------|---------------------------------------------------------------|-----------------------------------------------------------------------------------|
-| `NODE_OPTIONS`        | `''`                                                          | Space-separated list of command-line Node options                                 |
-| `NODE_VERSION`        | `18`                                                          | Node version with which the assets will be compiled                               |
-| `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                               | Domain of the private npm registry                                                |
-| `PACKAGE_MANAGER`     | `"yarn"`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
-| `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                               |
-| `PHP_VERSION`         | `"8.0"`                                                       | PHP version to use during packaging                                               |
-| `ARCHIVE_NAME`        | `""`                                                          | The base name of the resulting zip archive. Falls back to the repository name     |
-| `PLUGIN_MAIN_FILE`    | `"index.php"`                                                 | The name of the plugin main file                                                  |
-| `PLUGIN_VERSION`      | -                                                             | The plugin version                                                                |
-| `PRE_SCRIPT`          | `""`                                                          | Run custom shell code before creating the release archive                         |
-| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`                                             | Set of arguments passed to Composer Asset Compiler                                |
+| Name                  | Default                                                       | Description                                                                                   |
+|-----------------------|---------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| `NODE_OPTIONS`        | `''`                                                          | Space-separated list of command-line Node options                                             |
+| `NODE_VERSION`        | `18`                                                          | Node version with which the assets will be compiled                                           |
+| `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                               | Domain of the private npm registry                                                            |
+| `PACKAGE_MANAGER`     | `"yarn"`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`)             |
+| `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                                           |
+| `PHP_VERSION`         | `"8.0"`                                                       | PHP version to use during packaging                                                           |
+| `ARCHIVE_NAME`        | `""`                                                          | The base name of the resulting zip archive. Falls back to the repository name                 |
+| `ARCHIVE_FULL_NAME`   | `""`                                                          | Desired full name of resulting archive. Falls back to ARCHIVE_NAME-PLUGIN_VERSION.            |
+| `PLUGIN_DIR_NAME`     | `""`                                                          | Name of the directory inside the archive. Falls back to the archive name and repository name. |
+| `PLUGIN_MAIN_FILE`    | `"index.php"`                                                 | The name of the plugin main file                                                              |
+| `PLUGIN_VERSION`      | -                                                             | The plugin version                                                                            |
+| `PRE_SCRIPT`          | `""`                                                          | Run custom shell code before creating the release archive                                     |
+| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`                                             | Set of arguments passed to Composer Asset Compiler                                            |
 
 #### A note on `PLUGIN_VERSION`
 

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -47,8 +47,7 @@ jobs:
 | `PACKAGE_MANAGER`     | `"yarn"`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`)             |
 | `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                                           |
 | `PHP_VERSION`         | `"8.0"`                                                       | PHP version to use during packaging                                                           |
-| `ARCHIVE_NAME`        | `""`                                                          | The base name of the resulting zip archive. Falls back to the repository name                 |
-| `ARCHIVE_FULL_NAME`   | `""`                                                          | Desired full name of resulting archive. Falls back to ARCHIVE_NAME-PLUGIN_VERSION.            |
+| `ARCHIVE_NAME`        | `""`                                                          | Desired full name of resulting archive. Falls back to repository name.                        |
 | `PLUGIN_DIR_NAME`     | `""`                                                          | Name of the directory inside the archive. Falls back to the archive name and repository name. |
 | `PLUGIN_MAIN_FILE`    | `"index.php"`                                                 | The name of the plugin main file                                                              |
 | `PLUGIN_VERSION`      | -                                                             | The plugin version                                                                            |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
`ARCHIVE_NAME` input is used for the plugin directory name and is used as a base for the resulting filename.
There is no way to get an artifact with the desired filename.


**What is the new behavior (if this is a feature change)?**
`ARCHIVE_NAME` optional input is used as-is now, without adding anything to it.
`PLUGIN_DIR_NAME` optional input is introduced. It is used for the plugin directory name inside the archive.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. The plugin version is not attached to the given `ARCHIVE_NAME` anymore. To save the previous archive name users should add `-{$VERSION_NAME}` to the archive name.

**Other information**:
Resolves #96.