### PR TITLE
Remove deprecated `PHP_MATRIX` input

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -8,10 +8,6 @@ on:
         default: '8.0'
         required: false
         type: string
-      PHP_MATRIX:
-        description: Matrix of PHP versions as a JSON formatted object (deprecated).
-        required: false
-        type: string
       COMPOSER_ARGS:
         description: Set of arguments passed to Composer.
         default: '--prefer-dist'
@@ -39,16 +35,9 @@ jobs:
   lint-php:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJson('["custom"]') }}
     env:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     steps:
-      - name: Deprecation warning
-        if: ${{ inputs.PHP_MATRIX }}
-        run: echo "::warning::The PHP_MATRIX input is deprecated and will be removed in the future. Please create a matrix in your caller workflow and pass it to the PHP_VERSION input."
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -66,10 +55,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          # This is necessary to support the deprecated PHP_MATRIX (executing the matrix
-          # inside this reusable workflow) while also supporting the new PHP_VERSION input
-          # (passed from a matrix in the caller workflow).
-          php-version: ${{ matrix.php-version != 'custom' && matrix.php-version || inputs.PHP_VERSION }}
+          php-version: ${{ inputs.PHP_VERSION }}
           tools: cs2pr, parallel-lint
           coverage: none
 

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -8,10 +8,6 @@ on:
         default: '8.0'
         required: false
         type: string
-      PHP_MATRIX:
-        description: Matrix of PHP versions as a JSON formatted object (deprecated).
-        required: false
-        type: string
       COMPOSER_ARGS:
         description: Set of arguments passed to Composer.
         default: '--prefer-dist'
@@ -34,16 +30,9 @@ jobs:
   tests-unit-php:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version: ${{ inputs.PHP_MATRIX && fromJSON(inputs.PHP_MATRIX) || fromJson('["custom"]') }}
     env:
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
     steps:
-      - name: Deprecation warning
-        if: ${{ inputs.PHP_MATRIX }}
-        run: echo "::warning::The PHP_MATRIX input is deprecated and will be removed in the future. Please create a matrix in your caller workflow and pass it to the PHP_VERSION input."
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -61,10 +50,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          # This is necessary to support the deprecated PHP_MATRIX (executing the matrix
-          # inside this reusable workflow) while also supporting the new PHP_VERSION input
-          # (passed from a matrix in the caller workflow).
-          php-version: ${{ matrix.php-version != 'custom' && matrix.php-version || inputs.PHP_VERSION }}
+          php-version: ${{ inputs.PHP_VERSION }}
 
       - name: Set up problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/docs/php.md
+++ b/docs/php.md
@@ -53,9 +53,9 @@ jobs:
       PHPCS_ARGS: '--report=summary'
 ```
 
-**Note**: Coding standards analysis can only be performed with a specific PHP version and not in a
-PHP matrix, as it should always be tested with the highest PHP version in use. To check
-compatibility with multiple PHP versions, use the [Lint PHP](#lint-php) workflow.
+**Note**: Coding _standards_ analysis should only be performed with the highest supported PHP
+version. Use the [Lint PHP](#lint-php) workflow to check code _compatibility_ with multiple PHP
+versions.
 
 ## Static code analysis
 

--- a/docs/php.md
+++ b/docs/php.md
@@ -53,8 +53,9 @@ jobs:
       PHPCS_ARGS: '--report=summary'
 ```
 
-**Note**: Coding standards analysis can only be performed with a specific PHP version and not in a PHP matrix, as it should always be tested with the highest PHP version in use. To check compatibility with multiple PHP versions, use the [Lint PHP](#lint-php) workflow.
-
+**Note**: Coding standards analysis can only be performed with a specific PHP version and not in a
+PHP matrix, as it should always be tested with the highest PHP version in use. To check
+compatibility with multiple PHP versions, use the [Lint PHP](#lint-php) workflow.
 
 ## Static code analysis
 
@@ -108,7 +109,9 @@ jobs:
       PSALM_ARGS: '--threads=3'
 ```
 
-**Note**: Static code analysis can only be performed with a specific PHP version and not in a PHP matrix, as it should always be tested with the highest PHP version in use. To check compatibility with multiple PHP versions, use the [Lint PHP](#lint-php) workflow.
+**Note**: Static code analysis can only be performed with a specific PHP version and not in a PHP
+matrix, as it should always be tested with the highest PHP version in use. To check compatibility
+with multiple PHP versions, use the [Lint PHP](#lint-php) workflow.
 
 ## Unit tests PHP
 
@@ -131,12 +134,11 @@ jobs:
 
 #### Inputs
 
-| Name            | Default             | Description                                                              |
-|-----------------|---------------------|--------------------------------------------------------------------------|
-| `PHP_MATRIX`    | `["8.0"]`           | :warning: deprecated - Matrix of PHP versions as a JSON formatted object |
-| `PHP_VERSION`   | `"8.0"`             | PHP version with which the scripts are executed                          |
-| `COMPOSER_ARGS` | `'--prefer-dist'`   | Set of arguments passed to Composer                                      |
-| `PHPUNIT_ARGS`  | `'--coverage-text'` | Set of arguments passed to PHPUnit                                       |
+| Name            | Default             | Description                                     |
+|-----------------|---------------------|-------------------------------------------------|
+| `PHP_VERSION`   | `"8.0"`             | PHP version with which the scripts are executed |
+| `COMPOSER_ARGS` | `'--prefer-dist'`   | Set of arguments passed to Composer             |
+| `PHPUNIT_ARGS`  | `'--coverage-text'` | Set of arguments passed to PHPUnit              |
 
 #### Secrets
 
@@ -154,38 +156,18 @@ on:
   pull_request:
 jobs:
   tests-unit-php:
-    uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@main
-    secrets:
-      COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
-      ENV_VARS: >-
-        [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
-    with:
-      PHP_MATRIX: >-
-        ["7.4", "8.0", "8.1"]
-      PHPUNIT_ARGS: '--coverage-text --debug'
-```
-
-**Example with `PHP_VERSION` in matrix:**
-
-```yml
-name: Unit tests PHP
-on:
-  push:
-  pull_request:
-jobs:
-  tests-unit-php:
     strategy:
       matrix:
-        php: ["7.4", "8.0", "8.1"]
+        php: [ "8.0", "8.1", "8.2" ]
     uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@main
     with:
       PHP_VERSION: ${{ matrix.php }}
+      PHPUNIT_ARGS: '--coverage-text --debug'
 ```
-
 
 ## Lint PHP
 
-This workflow runs [PHP Parallel Lint](https://github.com/php-parallel-lint/PHP-Parallel-Lint). 
+This workflow runs [PHP Parallel Lint](https://github.com/php-parallel-lint/PHP-Parallel-Lint).
 
 **Simplest possible example:**
 
@@ -203,13 +185,12 @@ jobs:
 
 #### Inputs
 
-| Name                    | Default                                 | Description                                                              |
-|-------------------------|-----------------------------------------|--------------------------------------------------------------------------|
-| `PHP_MATRIX`            | `["8.0"]`                               | :warning: deprecated - Matrix of PHP versions as a JSON formatted object |
-| `PHP_VERSION`           | `"8.0"`                                 | PHP version with which the scripts are executed                          |
-| `COMPOSER_ARGS`         | `'--prefer-dist'`                       | Set of arguments passed to Composer                                      |
-| `LINT_ARGS`             | `'-e php --colors --show-deprecated .'` | Set of arguments passed to PHP Parallel Lint                             |
-| `COMPOSER_DEPS_INSTALL` | `false`                                 | Whether or not to install Composer dependencies before linting           |
+| Name                    | Default                                 | Description                                                    |
+|-------------------------|-----------------------------------------|----------------------------------------------------------------|
+| `PHP_VERSION`           | `"8.0"`                                 | PHP version with which the scripts are executed                |
+| `COMPOSER_ARGS`         | `'--prefer-dist'`                       | Set of arguments passed to Composer                            |
+| `LINT_ARGS`             | `'-e php --colors --show-deprecated .'` | Set of arguments passed to PHP Parallel Lint                   |
+| `COMPOSER_DEPS_INSTALL` | `false`                                 | Whether or not to install Composer dependencies before linting |
 
 #### Secrets
 
@@ -249,7 +230,7 @@ jobs:
   lint-php:
     strategy:
       matrix:
-        php: ["7.4", "8.0", "8.1"]
+        php: [ "7.4", "8.0", "8.1" ]
     uses: inpsyde/reusable-workflows/.github/workflows/lint-php.yml@main
     with:
       PHP_VERSION: ${{ matrix.php }}

--- a/docs/php.md
+++ b/docs/php.md
@@ -230,7 +230,7 @@ jobs:
   lint-php:
     strategy:
       matrix:
-        php: [ "7.4", "8.0", "8.1" ]
+        php: [ "8.0", "8.1", "8.2" ]
     uses: inpsyde/reusable-workflows/.github/workflows/lint-php.yml@main
     with:
       PHP_VERSION: ${{ matrix.php }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
Until now, we have been using the `PHP_MATRIX` input when we wanted to run reusable workflows in a matrix, building matrix runs _inside_ the called workflow.
This is no longer necessary because reusable workflows can be called from a matrix in the _calling_ workflow for some time now.

* Blog post: https://github.blog/changelog/2022-08-22-github-actions-improvements-to-reusable-workflows-2/
* Documentation: https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-a-matrix-strategy-with-a-reusable-workflow


**What is the new behavior (if this is a feature change)?**
Removed the `PHP_MATRIX` input and all references to it. Calling workflows should use a matrix and pass its value to `PHP_VERSION`.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
**Yes.**
And several packages still use the now-removed input. However, migrating to `PHP_VERSION` is effortless and could be done whenever a package is worked on next. See #58 for the required changes.


**Other information**:
Closes #58.
I'm requesting reviews by people who I believe have affected packages in their teams.