### PR TITLE
Default to PHP 8.2

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -60,7 +60,7 @@ on:
         required: false
       PHP_VERSION:
         description: PHP version with which the PHP tools are to be executed.
-        default: '8.0'
+        default: '8.2'
         required: false
         type: string
       PHP_TOOLS:

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -25,7 +25,7 @@ on:
         type: string
       PHP_VERSION:
         description: PHP version with which the assets compilation is to be executed.
-        default: "8.0"
+        default: '8.2'
         required: false
         type: string
       COMPOSER_ARGS:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -30,7 +30,7 @@ on:
         type: string
       PHP_VERSION:
         description: PHP version to use during packaging.
-        default: "8.0"
+        default: '8.2'
         required: false
         type: string
       ARCHIVE_NAME:

--- a/.github/workflows/coding-standards-php.yml
+++ b/.github/workflows/coding-standards-php.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       PHP_VERSION:
         description: PHP version with which the scripts are executed.
-        default: "8.0"
+        default: '8.2'
         required: false
         type: string
       COMPOSER_ARGS:

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       PHP_VERSION:
         description: PHP version with which the scripts are executed.
-        default: '8.0'
+        default: '8.2'
         required: false
         type: string
       COMPOSER_ARGS:

--- a/.github/workflows/static-analysis-php.yml
+++ b/.github/workflows/static-analysis-php.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       PHP_VERSION:
         description: PHP version with which the scripts are executed.
-        default: "8.0"
+        default: '8.2'
         required: false
         type: string
       COMPOSER_ARGS:

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       PHP_VERSION:
         description: PHP version with which the scripts are executed.
-        default: '8.0'
+        default: '8.2'
         required: false
         type: string
       COMPOSER_ARGS:

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -43,15 +43,15 @@ jobs:
 |-----------------------|---------------------------------------------------------------|------------------------------------------------------------------------------------------------|
 | `NODE_OPTIONS`        | `''`                                                          | Space-separated list of command-line Node options                                              |
 | `NODE_VERSION`        | `18`                                                          | Node version with which the assets will be compiled                                            |
-| `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                               | Domain of the private npm registry                                                             |
-| `PACKAGE_MANAGER`     | `"yarn"`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`)              |
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                               | Domain of the private npm registry                                                             |
+| `PACKAGE_MANAGER`     | `'yarn'`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`)              |
 | `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                                            |
-| `PHP_VERSION`         | `"8.0"`                                                       | PHP version to use during packaging                                                            |
-| `ARCHIVE_NAME`        | `""`                                                          | The name of the zip archive (falls back to the repository name)                                |
-| `PLUGIN_MAIN_FILE`    | `"index.php"`                                                 | The name of the main plugin file                                                               |
-| `PLUGIN_FOLDER_NAME`  | `""`                                                          | The name of the plugin folder (falls back to the archive name, if set, or the repository name) |
+| `PHP_VERSION`         | `'8.2'`                                                       | PHP version to use during packaging                                                            |
+| `ARCHIVE_NAME`        | `''`                                                          | The name of the zip archive (falls back to the repository name)                                |
+| `PLUGIN_MAIN_FILE`    | `'index.php'`                                                 | The name of the main plugin file                                                               |
+| `PLUGIN_FOLDER_NAME`  | `''`                                                          | The name of the plugin folder (falls back to the archive name, if set, or the repository name) |
 | `PLUGIN_VERSION`      | -                                                             | The new plugin version                                                                         |
-| `PRE_SCRIPT`          | `""`                                                          | Run custom shell code before creating the release archive                                      |
+| `PRE_SCRIPT`          | `''`                                                          | Run custom shell code before creating the release archive                                      |
 | `COMPILE_ASSETS_ARGS` | `'-v --env=root'`                                             | Set of arguments passed to Composer Asset Compiler                                             |
 
 #### A note on `PLUGIN_VERSION`

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -49,8 +49,8 @@ jobs:
 | `NODE_VERSION`        | `18`                                                          | Node version with which the assets will be compiled                                            |
 | `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                               | Domain of the private npm registry                                                             |
 | `PACKAGE_MANAGER`     | `'yarn'`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`)              |
-| `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                                            |
-| `PHP_VERSION`         | `'8.2'`                                                       | PHP version to use during packaging                                                            |
+| `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer when gathering production dependencies                     |
+| `PHP_VERSION`         | `'8.2'`                                                       | PHP version to use when gathering production dependencies                                      |
 | `PHP_VERSION_BUILD`   | `'8.2'`                                                       | PHP version to use when executing build tools                                                  |
 | `ARCHIVE_NAME`        | `''`                                                          | The name of the zip archive (falls back to the repository name)                                |
 | `PLUGIN_MAIN_FILE`    | `'index.php'`                                                 | The name of the main plugin file                                                               |

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -26,7 +26,7 @@ jobs:
 | `NODE_VERSION`        | `18`                          | Node version with which the assets will be compiled                               |
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                |
 | `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
-| `PHP_VERSION`         | `"8.0"`                       | PHP version with which the assets compilation is to be executed                   |
+| `PHP_VERSION`         | `'8.2'`                       | PHP version with which the assets compilation is to be executed                   |
 | `COMPOSER_ARGS`       | `'--prefer-dist'`             | Set of arguments passed to Composer                                               |
 | `COMPILE_ASSETS_ARGS` | `'-v --env=root'`             | Set of arguments passed to Composer Asset Compiler                                |
 

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -109,7 +109,7 @@ This is not the simplest possible example, but it showcases all the recommendati
 | `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                                                              |
 | `BUILT_BRANCH_SUFFIX` | `''`                          | Suffix to calculate the target branch for pushing assets on the `branch` event                                                  |
 | `RELEASE_BRANCH_NAME` | `''`                          | On tag events, target branch where compiled assets are pushed and the tag is moved to                                           |
-| `PHP_VERSION`         | `'8.0'`                       | PHP version with which the PHP tools are to be executed                                                                         |
+| `PHP_VERSION`         | `'8.2'`                       | PHP version with which the PHP tools are to be executed                                                                         |
 | `PHP_TOOLS`           | `''`                          | PHP tools supported by [shivammathur/setup-php](https://github.com/shivammathur/setup-php#wrench-tools-support) to be installed |
 
 

--- a/docs/php.md
+++ b/docs/php.md
@@ -23,7 +23,7 @@ jobs:
 
 | Name            | Default                                                  | Description                                     |
 |-----------------|----------------------------------------------------------|-------------------------------------------------|
-| `PHP_VERSION`   | `"8.0"`                                                  | PHP version with which the scripts are executed |
+| `PHP_VERSION`   | `'8.2'`                                                  | PHP version with which the scripts are executed |
 | `COMPOSER_ARGS` | `'--prefer-dist'`                                        | Set of arguments passed to Composer             |
 | `PHPCS_ARGS`    | `'--report-full --report-checkstyle=./phpcs-report.xml'` | Set of arguments passed to PHP_CodeSniffer      |
 | `CS2PR_ARGS`    | `'--graceful-warnings ./phpcs-report.xml'`               | Set of arguments passed to cs2pr                |
@@ -80,7 +80,7 @@ jobs:
 
 | Name            | Default                               | Description                                     |
 |-----------------|---------------------------------------|-------------------------------------------------|
-| `PHP_VERSION`   | `"8.0"`                               | PHP version with which the scripts are executed |
+| `PHP_VERSION`   | `'8.2'`                               | PHP version with which the scripts are executed |
 | `COMPOSER_ARGS` | `'--prefer-dist'`                     | Set of arguments passed to Composer             |
 | `PSALM_ARGS`    | `'--output-format=github --no-cache'` | Set of arguments passed to Psalm                |
 
@@ -136,7 +136,7 @@ jobs:
 
 | Name            | Default             | Description                                     |
 |-----------------|---------------------|-------------------------------------------------|
-| `PHP_VERSION`   | `"8.0"`             | PHP version with which the scripts are executed |
+| `PHP_VERSION`   | `'8.2'`             | PHP version with which the scripts are executed |
 | `COMPOSER_ARGS` | `'--prefer-dist'`   | Set of arguments passed to Composer             |
 | `PHPUNIT_ARGS`  | `'--coverage-text'` | Set of arguments passed to PHPUnit              |
 
@@ -187,7 +187,7 @@ jobs:
 
 | Name                    | Default                                 | Description                                                    |
 |-------------------------|-----------------------------------------|----------------------------------------------------------------|
-| `PHP_VERSION`           | `"8.0"`                                 | PHP version with which the scripts are executed                |
+| `PHP_VERSION`           | `'8.2'`                                 | PHP version with which the scripts are executed                |
 | `COMPOSER_ARGS`         | `'--prefer-dist'`                       | Set of arguments passed to Composer                            |
 | `LINT_ARGS`             | `'-e php --colors --show-deprecated .'` | Set of arguments passed to PHP Parallel Lint                   |
 | `COMPOSER_DEPS_INSTALL` | `false`                                 | Whether or not to install Composer dependencies before linting |

--- a/docs/php.md
+++ b/docs/php.md
@@ -158,7 +158,7 @@ jobs:
   tests-unit-php:
     strategy:
       matrix:
-        php: [ "8.0", "8.1", "8.2" ]
+        php: [ "8.1", "8.2", "8.3" ]
     uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@main
     with:
       PHP_VERSION: ${{ matrix.php }}
@@ -230,7 +230,7 @@ jobs:
   lint-php:
     strategy:
       matrix:
-        php: [ "8.0", "8.1", "8.2" ]
+        php: [ "8.1", "8.2", "8.3" ]
     uses: inpsyde/reusable-workflows/.github/workflows/lint-php.yml@main
     with:
       PHP_VERSION: ${{ matrix.php }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Refactor


**What is the current behavior?** (You can also link to an open issue here)
All PHP-based reusable workflows default to PHP 8.0, which reached EOL on 2023-11-26.


**What is the new behavior (if this is a feature change)?**
Default all PHP-based reusable workflows to PHP 8.2, which will reach EOL on 2025-12-08.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. All calling workflows not specifying a PHP version with the `PHP_VERSION` input will run on PHP 8.2, potentially causing the workflow to fail.


**Other information**:
Closes #44.