### PR TITLE
docs(build-and-push-assets): `cancel-in-progress` usage is discouraged

### DIFF
--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -76,7 +76,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Don't enable `cancel-in-progress` because it interrupts the workflow
+  cancel-in-progress: false
 
 jobs:
   build-assets:

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -76,7 +76,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Don't enable `cancel-in-progress` because it interrupts the workflow
 
 jobs:
   build-assets:
@@ -91,6 +90,8 @@ jobs:
 ```
 
 This is not the simplest possible example, but it showcases all the recommendations.
+
+**Note**: Do not set `cancel-in-progress: true` to the `concurrency` setting because it interrupts the workflow.
 
 ## Configuration parameters
 

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -77,7 +77,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # Don't enable `cancel-in-progress` because it interrupts the workflow
-  cancel-in-progress: false
 
 jobs:
   build-assets:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Documentation.


**What is the current behavior?** (You can also link to an open issue here)
We suggest using `concurrency.cancel-in-progress` in the consuming workflow for the `build-and-push` assets approach.


**What is the new behavior (if this is a feature change)?**
The problem here is the workflow run push at the same moment. It causes the next workflow run. But the original workflow may have to do some job after pushing (for instance, remove a temporary branch after tag moving). So, the safest way is to allow the original job to be completed and run the second job after.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.



**Other information**:
