### PR TITLE
Feature/workflow outputs for archives

### DIFF
--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -72,6 +72,10 @@ on:
       ENV_VARS:
         description: Additional environment variables as a JSON formatted object.
         required: false
+    outputs:
+      artifact:
+        description: The name of the generated release artifact
+        value: ${{ jobs.create-plugin-archive.outputs.artifact }}
 
 jobs:
   create-plugin-archive:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -207,7 +207,7 @@ jobs:
         run: echo "artifact=${{ steps.plugin-data.outputs.archive-name }}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact }}
           path: dist/*


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
I had previously assumed that writing to the _job output_ would mean that calling workflows can consume the archive name for further handling (->downloading/extracting it again to make further changes).

However, I overlooked that for this to work, you must also define `workflow_call.outputs`


**What is the new behavior (if this is a feature change)?**
`workflow_call.outputs` are now defined to pass on the job output to the outside world.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



**Other information**:
