### PR TITLE
Add main file name customization on automatic release

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ env.HAS_CONFIG == 'false' }}
         run: |
           cp ${GITHUB_WORKSPACE}/workflow-repo/templates/automatic-release/release.config.js .
-          FILE=$(find . -maxdepth 1 -type f -name '*.php' -exec grep -l 'Plugin Name:' {} + | xargs -I{} basename {}) || true
+          FILE=$(find . -maxdepth 1 -type f -name '*.php' -exec grep -l 'Plugin Name:' {} + | xargs -I{} basename {}) || false
           [ -n "$FILE" ] && sed "s/index\.php/$FILE/g" -i release.config.js
 
       - name: Remove the workflow repository

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -58,8 +58,8 @@ jobs:
         if: ${{ env.HAS_CONFIG == 'false' }}
         run: |
           cp ${GITHUB_WORKSPACE}/workflow-repo/templates/automatic-release/release.config.js .
-          FILE=$(find . -maxdepth 1 -type f -name '*.php' -exec grep -l 'Plugin Name:' {} + | xargs -I{} basename {})
-          [ -n "$FILE" ] && sed "s/index\.php/$FILE/g" -i release.config.js
+          FILE=$(find . -maxdepth 1 -type f -name '*.php' -exec grep -l 'Plugin Name:' {} + | xargs -I{} basename {}) || false
+          [ "$FILE" != false ] && sed "s/index\.php/$FILE/g" -i release.config.js
 
       - name: Remove the workflow repository
         if: ${{ env.HAS_CONFIG == 'false' }}

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -1,6 +1,12 @@
 name: Automatic Release
 on:
   workflow_call:
+    inputs:
+      MAIN_FILENAME:
+        description: Main file name where the WordPress plugin header is present
+        required: false
+        default: 'index.php'
+        type: string
     secrets:
       GITHUB_USER_TOKEN:
         description: Authentication token with write permission needed by the release bot (falls back to GITHUB_TOKEN).
@@ -54,10 +60,11 @@ jobs:
           repository: inpsyde/reusable-workflows
           path: workflow-repo
 
-      - name: Add release.config.js file if not provided
+      - name: Add release.config.js file if not provided and customize it
         if: ${{ env.HAS_CONFIG == 'false' }}
         run: |
           cp ${GITHUB_WORKSPACE}/workflow-repo/templates/automatic-release/release.config.js .
+          sed -i 's/index\.php/${{inputs.MAIN_FILENAME}}/g' release.config.js
 
       - name: Remove the workflow repository
         if: ${{ env.HAS_CONFIG == 'false' }}

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -58,8 +58,8 @@ jobs:
         if: ${{ env.HAS_CONFIG == 'false' }}
         run: |
           cp ${GITHUB_WORKSPACE}/workflow-repo/templates/automatic-release/release.config.js .
-          FILE=$(find . -maxdepth 1 -type f -name '*.php' -exec grep -l 'Plugin Name:' {} + | xargs -I{} basename {}) || false
-          [ -n "$FILE" ] && sed "s/index\.php/$FILE/g" -i release.config.js
+          FILE=$(find . -maxdepth 1 -type f -name '*.php' -exec grep -l 'Plugin Name:' {} + | xargs -I{} basename {}) || true
+          [ -n "$FILE" ] && sed "s/index\.php/$FILE/g" -i release.config.js || true
 
       - name: Remove the workflow repository
         if: ${{ env.HAS_CONFIG == 'false' }}

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -58,8 +58,8 @@ jobs:
         if: ${{ env.HAS_CONFIG == 'false' }}
         run: |
           cp ${GITHUB_WORKSPACE}/workflow-repo/templates/automatic-release/release.config.js .
-          FILE=$(find . -maxdepth 1 -type f -name '*.php' -exec grep -l 'Plugin Name:' {} + | xargs -I{} basename {}) || false
-          [ "$FILE" != false ] && sed "s/index\.php/$FILE/g" -i release.config.js
+          FILE=$(find . -maxdepth 1 -type f -name '*.php' -exec grep -l 'Plugin Name:' {} + | xargs -I{} basename {}) || true
+          [ -n "$FILE" ] && sed "s/index\.php/$FILE/g" -i release.config.js
 
       - name: Remove the workflow repository
         if: ${{ env.HAS_CONFIG == 'false' }}

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -1,12 +1,6 @@
 name: Automatic Release
 on:
   workflow_call:
-    inputs:
-      PLUGIN_MAIN_FILENAME:
-        description: Main file name where the WordPress plugin header is present
-        required: false
-        default: 'index.php'
-        type: string
     secrets:
       GITHUB_USER_TOKEN:
         description: Authentication token with write permission needed by the release bot (falls back to GITHUB_TOKEN).
@@ -64,7 +58,8 @@ jobs:
         if: ${{ env.HAS_CONFIG == 'false' }}
         run: |
           cp ${GITHUB_WORKSPACE}/workflow-repo/templates/automatic-release/release.config.js .
-          sed -i 's/index\.php/${{inputs.PLUGIN_MAIN_FILENAME}}/g' release.config.js
+          FILE=$(find . -maxdepth 1 -type f -name '*.php' -exec grep -l 'Plugin Name:' {} + | xargs -I{} basename {})
+          [ -n "$FILE" ] && sed "s/index\.php/$FILE/g" -i release.config.js
 
       - name: Remove the workflow repository
         if: ${{ env.HAS_CONFIG == 'false' }}

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -54,7 +54,7 @@ jobs:
           repository: inpsyde/reusable-workflows
           path: workflow-repo
 
-      - name: Add release.config.js file if not provided and customize it
+      - name: Add and customize release.config.js file if not provided
         if: ${{ env.HAS_CONFIG == 'false' }}
         run: |
           cp ${GITHUB_WORKSPACE}/workflow-repo/templates/automatic-release/release.config.js .

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -2,7 +2,7 @@ name: Automatic Release
 on:
   workflow_call:
     inputs:
-      MAIN_FILENAME:
+      PLUGIN_MAIN_FILENAME:
         description: Main file name where the WordPress plugin header is present
         required: false
         default: 'index.php'
@@ -64,7 +64,7 @@ jobs:
         if: ${{ env.HAS_CONFIG == 'false' }}
         run: |
           cp ${GITHUB_WORKSPACE}/workflow-repo/templates/automatic-release/release.config.js .
-          sed -i 's/index\.php/${{inputs.MAIN_FILENAME}}/g' release.config.js
+          sed -i 's/index\.php/${{inputs.PLUGIN_MAIN_FILENAME}}/g' release.config.js
 
       - name: Remove the workflow repository
         if: ${{ env.HAS_CONFIG == 'false' }}

--- a/docs/automatic-release.md
+++ b/docs/automatic-release.md
@@ -19,7 +19,7 @@ following files:
 - `composer.json`
 - `package-lock.json`
 - `package.json`
-- `style.css`, `index.php` or your custom main file provided as input to the workflow
+- `style.css`, `index.php` or your custom main file which will be automatically discovered by the workflow
 
 By default, every push to the `main` and `next` branches will release a stable version, and every push to the `alpha`
 and `beta` branches will create a pre-release version.
@@ -42,14 +42,6 @@ jobs:
 
 ## Configuration parameters
 
-### Inputs
-
-| Name                   | Required | Default       | Description                                                 |
-|------------------------|----------|---------------|-------------------------------------------------------------|
-| `PLUGIN_MAIN_FILENAME` | false    | `'index.php'` | Main file name where the WordPress plugin header is present |
-
-
-
 ### Secrets
 
 | Name                | Required | Default | Description                                                                                       |
@@ -68,8 +60,6 @@ on:
 jobs:
   release:
     uses: inpsyde/reusable-workflows/.github/workflows/automatic-release.yml@main
-    with:
-      PLUGIN_MAIN_FILENAME: 'foobar.php'
     secrets:
       GITHUB_USER_TOKEN: ${{ secrets.WRITE_TOKEN }}
 ```

--- a/docs/automatic-release.md
+++ b/docs/automatic-release.md
@@ -44,9 +44,9 @@ jobs:
 
 ### Inputs
 
-| Name            | Required | Default       | Description                                                 |
-|-----------------|----------|---------------|-------------------------------------------------------------|
-| `MAIN_FILENAME` | false    | `'index.php'` | Main file name where the WordPress plugin header is present |
+| Name                   | Required | Default       | Description                                                 |
+|------------------------|----------|---------------|-------------------------------------------------------------|
+| `PLUGIN_MAIN_FILENAME` | false    | `'index.php'` | Main file name where the WordPress plugin header is present |
 
 
 
@@ -69,7 +69,7 @@ jobs:
   release:
     uses: inpsyde/reusable-workflows/.github/workflows/automatic-release.yml@main
     with:
-      MAIN_FILENAME: 'foobar.php'
+      PLUGIN_MAIN_FILENAME: 'foobar.php'
     secrets:
       GITHUB_USER_TOKEN: ${{ secrets.WRITE_TOKEN }}
 ```

--- a/docs/automatic-release.md
+++ b/docs/automatic-release.md
@@ -68,7 +68,7 @@ on:
 jobs:
   release:
     uses: inpsyde/reusable-workflows/.github/workflows/automatic-release.yml@main
-    inputs:
+    with:
       MAIN_FILENAME: 'foobar.php'
     secrets:
       GITHUB_USER_TOKEN: ${{ secrets.WRITE_TOKEN }}

--- a/docs/automatic-release.md
+++ b/docs/automatic-release.md
@@ -19,7 +19,7 @@ following files:
 - `composer.json`
 - `package-lock.json`
 - `package.json`
-- `style.css` or `index.php`
+- `style.css`, `index.php` or your custom main file provided as input to the workflow
 
 By default, every push to the `main` and `next` branches will release a stable version, and every push to the `alpha`
 and `beta` branches will create a pre-release version.
@@ -40,9 +40,17 @@ jobs:
     uses: inpsyde/reusable-workflows/.github/workflows/automatic-release.yml@main
 ```
 
-### Configuration parameters
+## Configuration parameters
 
-#### Secrets
+### Inputs
+
+| Name            | Required | Default       | Description                                                 |
+|-----------------|----------|---------------|-------------------------------------------------------------|
+| `MAIN_FILENAME` | false    | `'index.php'` | Main file name where the WordPress plugin header is present |
+
+
+
+### Secrets
 
 | Name                | Required | Default | Description                                                                                       |
 |---------------------|----------|---------|---------------------------------------------------------------------------------------------------|
@@ -60,6 +68,8 @@ on:
 jobs:
   release:
     uses: inpsyde/reusable-workflows/.github/workflows/automatic-release.yml@main
+    inputs:
+      MAIN_FILENAME: 'foobar.php'
     secrets:
       GITHUB_USER_TOKEN: ${{ secrets.WRITE_TOKEN }}
 ```

--- a/docs/automatic-release.md
+++ b/docs/automatic-release.md
@@ -19,7 +19,7 @@ following files:
 - `composer.json`
 - `package-lock.json`
 - `package.json`
-- `style.css`, `index.php` or your custom main file which will be automatically discovered by the workflow
+- `style.css` or the main plugin file (automatically discovered by the workflow)
 
 By default, every push to the `main` and `next` branches will release a stable version, and every push to the `alpha`
 and `beta` branches will create a pre-release version.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
The automatic release feature can be added only on plugins where the main plugin file is `index.php`.


**What is the new behavior (if this is a feature change)?**
The main file name is customizable.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
This feature opens the possibility of using this automation for plugins built with different standards on file names (like the WordPress standard).