### PR TITLE
Multi step plugin archive

### DIFF
--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Install Composer Asset Compiler
         if: steps.composer-tools.outputs.assets-compiler == '0' && steps.check-for-package.outputs.has_package == 'true'
         run: |
-          composer global config --no-plugins allow-plugins.inpsyde/composer-assets-compiler
+          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/composer-assets-compiler true
           composer global require inpsyde/composer-assets-compiler
       - name: Run Composer Asset Compiler
         if: steps.composer-tools.outputs.assets-compiler == '0' && steps.check-for-package.outputs.has_package == 'true'
@@ -217,7 +217,7 @@ jobs:
       - name: Install WordPress Translation Downloader
         if: steps.composer-tools.outputs.translation-downloader == '0'
         run: |
-          composer global config --no-plugins allow-plugins.inpsyde/wp-translation-downloader
+          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/wp-translation-downloader true
           composer global require inpsyde/wp-translation-downloader
       - name: Run WordPress Translation Downloader
         if: steps.composer-tools.outputs.translation-downloader == '0'

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -24,12 +24,17 @@ on:
         required: false
         type: string
       COMPOSER_ARGS:
-        description: Set of arguments passed to Composer.
+        description: Set of arguments passed to Composer when gathering production dependencies.
         default: '--no-dev --prefer-dist --optimize-autoloader'
         required: false
         type: string
       PHP_VERSION:
-        description: PHP version to use during packaging.
+        description: PHP version to use when gathering production dependencies.
+        default: "8.0"
+        required: false
+        type: string
+      PHP_VERSION_BUILD:
+        description: PHP version to use when executing build tools.
         default: "8.0"
         required: false
         type: string
@@ -251,7 +256,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: ${{ inputs.PHP_VERSION_BUILD }}
           tools: wp-cli
 
       - name: Install dist-archive command

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -200,15 +200,13 @@ jobs:
           composer global require inpsyde/composer-assets-compiler
           composer compile-assets ${{ inputs.COMPILE_ASSETS_ARGS }}
 
-      - name: Install WordPress Translation Downloader
+      - name: Install and run WordPress Translation Downloader
         if: steps.composer-tools.outputs.translation-downloader == '0'
         run: |
           composer global config --no-plugins --no-interaction allow-plugins.composer/installers true
           composer global config --no-plugins --no-interaction allow-plugins.inpsyde/wp-translation-downloader true
           composer global require inpsyde/wp-translation-downloader
-      - name: Run WordPress Translation Downloader
-        if: steps.composer-tools.outputs.translation-downloader == '0'
-        run: composer wp-translation-downloader:download
+          composer wp-translation-downloader:download
 
       - name: Set artifact name
         id: set-artifact-name

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -139,6 +139,7 @@ jobs:
   run-build-tools:
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    needs: checkout-dependencies
     env:
       NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
@@ -206,6 +207,7 @@ jobs:
   create-plugin-archive:
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    needs: run-build-tools
     env:
       ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
     steps:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -79,6 +79,7 @@ on:
 
 jobs:
   checkout-dependencies:
+    name: Install production dependencies
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
@@ -131,6 +132,7 @@ jobs:
             !./.ddev
             !./.github
   run-build-tools:
+    name: Process build steps
     timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: checkout-dependencies
@@ -229,6 +231,7 @@ jobs:
             .
             !**/node_modules
   create-plugin-archive:
+    name: Create build archive
     timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: run-build-tools
@@ -282,3 +285,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact }}
+          path: ./dist/*

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -193,14 +193,12 @@ jobs:
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
           cache: ${{ env.NODE_CACHE_MODE }}
 
-      - name: Install Composer Asset Compiler
-        if: steps.composer-tools.outputs.assets-compiler == '0' && steps.check-for-package.outputs.has_package == 'true'
+      - name: Install and run Composer Asset Compiler
+        if: steps.composer-tools.outputs.assets-compiler == '0'
         run: |
           composer global config --no-plugins --no-interaction allow-plugins.inpsyde/composer-assets-compiler true
           composer global require inpsyde/composer-assets-compiler
-      - name: Run Composer Asset Compiler
-        if: steps.composer-tools.outputs.assets-compiler == '0' && steps.check-for-package.outputs.has_package == 'true'
-        run: composer compile-assets ${{ inputs.COMPILE_ASSETS_ARGS }}
+          composer compile-assets ${{ inputs.COMPILE_ASSETS_ARGS }}
 
       - name: Install WordPress Translation Downloader
         if: steps.composer-tools.outputs.translation-downloader == '0'

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -82,8 +82,6 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       PLUGIN_FOLDER_NAME: ${{ inputs.PLUGIN_FOLDER_NAME }}
       ENV_VARS: ${{ secrets.ENV_VARS }}
       GIT_SHA: ${{ github.sha }}
@@ -98,12 +96,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-
-
-      - name: Set up plugin folder name
-        id: plugin-folder-name
-        run: echo "plugin-folder-name=${PLUGIN_FOLDER_NAME:-${ARCHIVE_NAME:-${{ github.event.repository.name }}}}" >> $GITHUB_OUTPUT
 
       - name: Set up custom environment variables
         if: ${{ env.ENV_VARS }}
@@ -247,6 +239,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.run-build-tools.outputs.artifact }}
+
+      - name: Set up plugin folder name
+        id: plugin-folder-name
+        run: echo "plugin-folder-name=${PLUGIN_FOLDER_NAME:-${ARCHIVE_NAME:-${{ github.event.repository.name }}}}" >> $GITHUB_OUTPUT
 
       - name: Set up archive name
         id: plugin-data

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -83,7 +83,6 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
-      PLUGIN_FOLDER_NAME: ${{ inputs.PLUGIN_FOLDER_NAME }}
       ENV_VARS: ${{ secrets.ENV_VARS }}
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
       # Disables symlinking of local path repositories.
@@ -235,6 +234,7 @@ jobs:
     needs: run-build-tools
     env:
       ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
+      PLUGIN_FOLDER_NAME: ${{ inputs.PLUGIN_FOLDER_NAME }}
       GIT_SHA: ${{ github.sha }}
       PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}
     steps:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -181,17 +181,8 @@ jobs:
             echo "No lock files found or unknown package manager"
           fi
 
-      - name: Check for package.json
-        id: check-for-package
-        run: |
-          if [ -f package.json ]; then
-            echo "has_package=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_package=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Set up node
-        if: steps.check-for-package.outputs.has_package == 'true'
+        if: steps.composer-tools.outputs.assets-compiler == '0'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.NODE_VERSION }}

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -99,9 +99,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up archive name
-        id: plugin-data
-        run: echo "archive-name=${ARCHIVE_NAME:-${{ github.event.repository.name }}}" >> $GITHUB_OUTPUT
+
 
       - name: Set up plugin folder name
         id: plugin-folder-name
@@ -129,7 +127,7 @@ jobs:
 
       - name: Set artifact name
         id: set-artifact-name
-        run: echo "artifact=${{ steps.plugin-data.outputs.archive-name }}-deps" >> $GITHUB_OUTPUT
+        run: echo "artifact=interim-deps" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -139,6 +137,7 @@ jobs:
             ./*
             !./.git
             !./.ddev
+            !./.github
   run-build-tools:
     timeout-minutes: 5
     runs-on: ubuntu-latest
@@ -229,12 +228,14 @@ jobs:
 
       - name: Set artifact name
         id: set-artifact-name
-        run: echo "artifact=${{ needs.checkout-dependencies.outputs.artifact }}-built" >> $GITHUB_OUTPUT
+        run: echo "artifact=interim-built" >> $GITHUB_OUTPUT
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact }}
-          path: .
+          path: |
+            .
+            !**/node_modules
   create-plugin-archive:
     timeout-minutes: 5
     runs-on: ubuntu-latest
@@ -246,6 +247,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.run-build-tools.outputs.artifact }}
+
+      - name: Set up archive name
+        id: plugin-data
+        run: echo "archive-name=${ARCHIVE_NAME:-${{ github.event.repository.name }}}" >> $GITHUB_OUTPUT
+
       - name: Add commit hash to plugin header
         run: 'sed -Ei "s/SHA: .*/SHA: ${GIT_SHA}/g" ${{ inputs.PLUGIN_MAIN_FILE }}'
 

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -25,7 +25,7 @@ on:
         type: string
       COMPOSER_ARGS:
         description: Set of arguments passed to Composer.
-        default: '--no-dev --no-scripts --prefer-dist --optimize-autoloader'
+        default: '--no-dev --prefer-dist --optimize-autoloader'
         required: false
         type: string
       PHP_VERSION:
@@ -78,14 +78,12 @@ on:
         value: ${{ jobs.create-plugin-archive.outputs.artifact }}
 
 jobs:
-  create-plugin-archive:
+  checkout-dependencies:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
-      NODE_CACHE_MODE: ''
-      ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
       PLUGIN_FOLDER_NAME: ${{ inputs.PLUGIN_FOLDER_NAME }}
       ENV_VARS: ${{ secrets.ENV_VARS }}
       GIT_SHA: ${{ github.sha }}
@@ -118,28 +116,40 @@ jobs:
               .parse(process.env.ENV_VARS)
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
-      - name: Set up node cache mode
-        run: |
-          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
-            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
-          elif [ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ]; then
-            echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
-          else
-            echo "No lock files found or unknown package manager"
-          fi
-
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           tools: wp-cli
 
-      - name: Install Composer dependencies
-        # ⬑ The idea is to ensure we have non-production tools like Composer Asset Compiler and WordPress Translation Downloader available
+      - name: Install Composer dependencies without dev dependencies
         uses: ramsey/composer-install@v2
         with:
-          composer-options: --prefer-dist
+          composer-options: ${{ inputs.COMPOSER_ARGS }}
 
+      - name: Set artifact name
+        id: set-artifact-name
+        run: echo "artifact=${{ steps.plugin-data.outputs.archive-name }}" >> $GITHUB_OUTPUT
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set-artifact-name.outputs.artifact }}
+          path: dist/*
+  run-build-tools:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      NODE_CACHE_MODE: ''
+    outputs:
+      artifact: ${{ steps.set-artifact-name.outputs.artifact }}
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.checkout-dependencies.outputs.artifact }}
       - name: Check optional Composer build tools
         id: composer-tools
         run: |
@@ -150,6 +160,16 @@ jobs:
           }
           echo "assets-compiler=$( hasDep inpsyde/composer-assets-compiler )" >> $GITHUB_OUTPUT
           echo "translation-downloader=$( hasDep inpsyde/wp-translation-downloader )" >> $GITHUB_OUTPUT
+
+      - name: Set up node cache mode
+        run: |
+          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
+            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
+          elif [ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ]; then
+            echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
+          else
+            echo "No lock files found or unknown package manager"
+          fi
 
       - name: Check for package.json
         id: check-for-package
@@ -175,13 +195,24 @@ jobs:
       - name: Run WordPress Translation Downloader
         if: steps.composer-tools.outputs.translation-downloader == '0'
         run: composer wp-translation-downloader:download
-
-      - name: Install Composer dependencies without dev dependencies
-        # ⬑ Now we want to get rid of dev dependencies and most probably skip composer scripts
-        uses: ramsey/composer-install@v2
+      - name: Set artifact name
+        id: set-artifact-name
+        run: echo "artifact=${{ needs.checkout-dependencies.outputs.artifact }}-built" >> $GITHUB_OUTPUT
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
-          composer-options: ${{ inputs.COMPOSER_ARGS }}
-
+          name: ${{ needs.create_archive.outputs.artifact }}-dist
+          path: .
+  create-plugin-archive:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    env:
+      ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.checkout-dependencies.outputs.artifact }}
       - name: Add commit hash to plugin header
         run: 'sed -Ei "s/SHA: .*/SHA: ${GIT_SHA}/g" ${{ inputs.PLUGIN_MAIN_FILE }}'
 
@@ -193,7 +224,7 @@ jobs:
 
       - name: Execute custom code before archive creation
         run: |
-            ${{ inputs.PRE_SCRIPT }}
+          ${{ inputs.PRE_SCRIPT }}
 
       - name: Run WP-CLI command
         run: wp dist-archive . ./archive.zip --plugin-dirname=${{ steps.plugin-folder-name.outputs.plugin-folder-name }}
@@ -210,4 +241,3 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact }}
-          path: dist/*

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -72,6 +72,10 @@ on:
       ENV_VARS:
         description: Additional environment variables as a JSON formatted object.
         required: false
+    outputs:
+      artifact:
+        description: The name of the generated release artifact
+        value: ${{ jobs.create-plugin-archive.outputs.artifact }}
 
 jobs:
   create-plugin-archive:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -207,14 +207,18 @@ jobs:
 
       - name: Install Composer Asset Compiler
         if: steps.composer-tools.outputs.assets-compiler == '0' && steps.check-for-package.outputs.has_package == 'true'
-        run: composer global require inpsyde/composer-assets-compiler
+        run: |
+          composer global config --no-plugins allow-plugins.inpsyde/composer-assets-compiler
+          composer global require inpsyde/composer-assets-compiler
       - name: Run Composer Asset Compiler
         if: steps.composer-tools.outputs.assets-compiler == '0' && steps.check-for-package.outputs.has_package == 'true'
         run: composer compile-assets ${{ inputs.COMPILE_ASSETS_ARGS }}
 
       - name: Install WordPress Translation Downloader
         if: steps.composer-tools.outputs.translation-downloader == '0'
-        run: composer global require inpsyde/wp-translation-downloader
+        run: |
+          composer global config --no-plugins allow-plugins.inpsyde/wp-translation-downloader
+          composer global require inpsyde/wp-translation-downloader
       - name: Run WordPress Translation Downloader
         if: steps.composer-tools.outputs.translation-downloader == '0'
         run: composer wp-translation-downloader:download

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Set artifact name
         id: set-artifact-name
-        run: echo "artifact=${{ steps.plugin-data.outputs.archive-name }}" >> $GITHUB_OUTPUT
+        run: echo "artifact=${{ steps.plugin-data.outputs.archive-name }}-deps" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -225,7 +225,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ needs.create_archive.outputs.artifact }}-dist
+          name: ${{ steps.set-artifact-name.outputs.artifact }}
           path: .
   create-plugin-archive:
     timeout-minutes: 5
@@ -237,7 +237,7 @@ jobs:
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.checkout-dependencies.outputs.artifact }}
+          name: ${{ needs.run-build-tools.outputs.artifact }}
       - name: Add commit hash to plugin header
         run: 'sed -Ei "s/SHA: .*/SHA: ${GIT_SHA}/g" ${{ inputs.PLUGIN_MAIN_FILE }}'
 

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -135,7 +135,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact }}
-          path: dist/*
+          path: ./*
   run-build-tools:
     timeout-minutes: 5
     runs-on: ubuntu-latest

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -85,8 +85,6 @@ jobs:
     env:
       PLUGIN_FOLDER_NAME: ${{ inputs.PLUGIN_FOLDER_NAME }}
       ENV_VARS: ${{ secrets.ENV_VARS }}
-      GIT_SHA: ${{ github.sha }}
-      PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}
       COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
       # Disables symlinking of local path repositories.
       # During development, symlinking is preferable.
@@ -237,6 +235,8 @@ jobs:
     needs: run-build-tools
     env:
       ARCHIVE_NAME: ${{ inputs.ARCHIVE_NAME }}
+      GIT_SHA: ${{ github.sha }}
+      PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -249,6 +249,12 @@ jobs:
       - name: Set plugin version header
         run: 'sed -Ei "s/Version: .*/Version: ${PLUGIN_VERSION}/g" ${{ inputs.PLUGIN_MAIN_FILE }}'
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: wp-cli
+
       - name: Install dist-archive command
         run: wp package install wp-cli/dist-archive-command
 

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -163,11 +163,6 @@ jobs:
             local EXIT=$?
             echo "$EXIT"
           }
-          hasDep(){
-            composer show -i -N -D --strict "${1}" >/dev/null 2>&1
-            local EXIT=$?
-            echo "$EXIT"
-          }
           echo "assets-compiler=$( hasAssetConfig )" >> $GITHUB_OUTPUT
           echo "translation-downloader=$( hasTranslateConfig )" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -217,6 +217,7 @@ jobs:
       - name: Install WordPress Translation Downloader
         if: steps.composer-tools.outputs.translation-downloader == '0'
         run: |
+          composer global config --no-plugins --no-interaction allow-plugins.composer/installers true
           composer global config --no-plugins --no-interaction allow-plugins.inpsyde/wp-translation-downloader true
           composer global require inpsyde/wp-translation-downloader
       - name: Run WordPress Translation Downloader

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -135,7 +135,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact }}
-          path: ./*
+          path: |
+            ./*
+            !./.git
+            !./.ddev
   run-build-tools:
     timeout-minutes: 5
     runs-on: ubuntu-latest

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -154,13 +154,29 @@ jobs:
       - name: Check optional Composer build tools
         id: composer-tools
         run: |
+          hasAssetConfig(){
+            test -f assets-compiler.json
+            local EXIT=$?
+            if [ ! $EXIT ]; then
+              echo "$EXIT"
+              exit 0
+            fi
+            jq '.extra | has("composer-asset-compiler")' < composer.json >/dev/null 2>&1
+            local EXIT=$?
+            echo "$EXIT"
+          }
+          hasTranslateConfig(){
+            jq '.extra | has("wp-translation-downloader")' < composer.json >/dev/null 2>&1
+            local EXIT=$?
+            echo "$EXIT"
+          }
           hasDep(){
             composer show -i -N -D --strict "${1}" >/dev/null 2>&1
             local EXIT=$?
             echo "$EXIT"
           }
-          echo "assets-compiler=$( hasDep inpsyde/composer-assets-compiler )" >> $GITHUB_OUTPUT
-          echo "translation-downloader=$( hasDep inpsyde/wp-translation-downloader )" >> $GITHUB_OUTPUT
+          echo "assets-compiler=$( hasAssetConfig )" >> $GITHUB_OUTPUT
+          echo "translation-downloader=$( hasTranslateConfig )" >> $GITHUB_OUTPUT
 
       - name: Set up node cache mode
         run: |
@@ -189,13 +205,20 @@ jobs:
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
           cache: ${{ env.NODE_CACHE_MODE }}
 
+      - name: Install Composer Asset Compiler
+        if: steps.composer-tools.outputs.assets-compiler == '0' && steps.check-for-package.outputs.has_package == 'true'
+        run: composer global require inpsyde/composer-assets-compiler
       - name: Run Composer Asset Compiler
         if: steps.composer-tools.outputs.assets-compiler == '0' && steps.check-for-package.outputs.has_package == 'true'
         run: composer compile-assets ${{ inputs.COMPILE_ASSETS_ARGS }}
 
+      - name: Install WordPress Translation Downloader
+        if: steps.composer-tools.outputs.translation-downloader == '0'
+        run: composer global require inpsyde/wp-translation-downloader
       - name: Run WordPress Translation Downloader
         if: steps.composer-tools.outputs.translation-downloader == '0'
         run: composer wp-translation-downloader:download
+
       - name: Set artifact name
         id: set-artifact-name
         run: echo "artifact=${{ needs.checkout-dependencies.outputs.artifact }}-built" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -207,7 +207,7 @@ jobs:
         run: echo "artifact=${{ steps.plugin-data.outputs.archive-name }}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact }}
           path: dist/*

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -45,7 +45,7 @@ jobs:
 | `NODE_VERSION`        | `18`                                                          | Node version with which the assets will be compiled                                            |
 | `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                               | Domain of the private npm registry                                                             |
 | `PACKAGE_MANAGER`     | `"yarn"`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`)              |
-| `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                                            |
+| `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer when gathering production dependencies |
 | `PHP_VERSION`         | `"8.0"`                                                       | PHP version to use when gathering production dependencies                                      |
 | `PHP_VERSION_BUILD`   | `"8.0"`                                                       | PHP version to use when executing build tools                                                  |
 | `ARCHIVE_NAME`        | `""`                                                          | The name of the zip archive (falls back to the repository name)                                |

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -46,7 +46,8 @@ jobs:
 | `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                               | Domain of the private npm registry                                                             |
 | `PACKAGE_MANAGER`     | `"yarn"`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`)              |
 | `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer                                                            |
-| `PHP_VERSION`         | `"8.0"`                                                       | PHP version to use during packaging                                                            |
+| `PHP_VERSION`         | `"8.0"`                                                       | PHP version to use when gathering production dependencies                                      |
+| `PHP_VERSION_BUILD`   | `"8.0"`                                                       | PHP version to use when executing build tools                                                  |
 | `ARCHIVE_NAME`        | `""`                                                          | The name of the zip archive (falls back to the repository name)                                |
 | `PLUGIN_MAIN_FILE`    | `"index.php"`                                                 | The name of the main plugin file                                                               |
 | `PLUGIN_FOLDER_NAME`  | `""`                                                          | The name of the plugin folder (falls back to the archive name, if set, or the repository name) |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Refactoring


**What is the current behavior?** (You can also link to an open issue here)
`build-plugin-archive.yml` uses a single php version for bundling dependencies and executing build tools.
WP's committment to supporting php down to 7.0 makes it increasingly cumbersome to support **"one"** *php platform requirement* for production AND development/building.

We have been accepting this limitation in order to streamline our packaging across most of our projects - and it's been a very solid base. But the fact remains that the php ecosystem is moving on while the php7 support requirement for WP packages is not going anywhere. Since this gap is only getting wider, we need to find a better approach


**What is the new behavior (if this is a feature change)?**
The logic of the workflow has been split into 3 parts:

1. **Production dependencies** - checkout the repo and `composer install` using the ancient PHP version
2. **Build steps** - execute all relevant build tools using a much more modern php version. We also no longer expect these to be present in dev dependencies: If we find a config, we install the tool globally. 
3. **Archive creation** - add final touches and create the resulting archive

Note: There is no strict technical requirement for step 3 to be in a separate job. It adds a little overhead, but I think at this point, it adds a nice separation of concerns in that it keeps a few environment variables and data handling out of the other steps.

The individual jobs each produce their own "interim" artifact which is then picked up by the next one. This makes it easy to spot and debug where something went wrong:

![screenshot_2024-03-20-120520](https://github.com/inpsyde/reusable-workflows/assets/4208996/39d5c921-a90e-4240-9b48-d943084dcef9)


---

This change frees us from having to use EOL versions of common tools and also paves the way for modernization of our own tools, for example [dropping PHP 7 in Composer Asset Compiler](https://github.com/inpsyde/composer-asset-compiler/pull/23). It also allows us to introduce third-party tools like *php-scoper* with ease since we are no longer subject to the php version constraints of individual projects.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
