### PR TITLE
Add option to select built branch name

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -143,6 +143,10 @@ jobs:
       LOCK_FILE: ''                                    # we'll override after checking files
       NO_CHANGES: ''                                   # we'll override if no changes to commit
     steps:
+      - name: Deprecation warning
+        if: ${{ inputs.BUILT_BRANCH_SUFFIX }}
+        run: "::warning::The BUILT_BRANCH_SUFFIX variable is deprecated and will be removed soon. If you use it, please update your workflow to use BUILT_BRANCH_NAME with ${{ github.ref_name }}-built."
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -145,7 +145,7 @@ jobs:
     steps:
       - name: Deprecation warning
         if: ${{ inputs.BUILT_BRANCH_SUFFIX }}
-        run: "::warning::The BUILT_BRANCH_SUFFIX variable is deprecated and will be removed soon. If you use it, please update your workflow to use BUILT_BRANCH_NAME with ${{ github.ref_name }}-built."
+        run: "::warning::The BUILT_BRANCH_SUFFIX variable is deprecated and will be removed soon. If you use it, please update your workflow to use BUILT_BRANCH_NAME with ${{ github.ref_name }}-built"
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Set branch environment variables
         if: ${{ github.ref_type == 'branch' }}
         run: |
-          echo "BUILT_BRANCH_NAME=${{ inputs.BUILT_BRANCH_NAME && inputs.BUILT_BRANCH_NAME || format({0}{1}, github.ref_name, inputs.BUILT_BRANCH_SUFFIX) }}" >> $GITHUB_ENV
+          echo "BUILT_BRANCH_NAME=${{ inputs.BUILT_BRANCH_NAME && inputs.BUILT_BRANCH_NAME || format('{0}{1}', github.ref_name, inputs.BUILT_BRANCH_SUFFIX) }}" >> $GITHUB_ENV
 
       - name: Set tag environment variables
         if: ${{ github.ref_type == 'tag' }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Deprecation warning
         if: ${{ inputs.BUILT_BRANCH_SUFFIX != '' }}
         run: |
-          echo '::warning::The BUILT_BRANCH_SUFFIX variable is deprecated and will be removed soon. Please update your workflow to use BUILT_BRANCH_NAME with ${{ github.ref_name }}-built'
+          echo '::warning::The BUILT_BRANCH_SUFFIX input is deprecated and will be removed soon. Please update your workflow to use BUILT_BRANCH_NAME with ${{ github.ref_name }}-built.'
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -49,7 +49,7 @@ on:
         required: false
         type: string
       BUILT_BRANCH_SUFFIX:
-        description: Suffix to calculate the target branch for pushing assets on the `branch` event.
+        description: Suffix to calculate the target branch for pushing assets on the `branch` event (deprecated).
         type: string
         default: ''
         required: false
@@ -144,8 +144,9 @@ jobs:
       NO_CHANGES: ''                                   # we'll override if no changes to commit
     steps:
       - name: Deprecation warning
-        if: ${{ inputs.BUILT_BRANCH_SUFFIX }}
-        run: "::warning::The BUILT_BRANCH_SUFFIX variable is deprecated and will be removed soon. If you use it, please update your workflow to use BUILT_BRANCH_NAME with ${{ github.ref_name }}-built"
+        if: ${{ inputs.BUILT_BRANCH_SUFFIX != '' }}
+        run: |
+          echo '::warning::The BUILT_BRANCH_SUFFIX variable is deprecated and will be removed soon. Please update your workflow to use BUILT_BRANCH_NAME with ${{ github.ref_name }}-built'
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -53,6 +53,11 @@ on:
         type: string
         default: ''
         required: false
+      BUILT_BRANCH_NAME:
+        description: Sets the target branch for pushing assets on the `branch` event.
+        type: string
+        default: ''
+        required: false
       RELEASE_BRANCH_NAME:
         description: On tag events, target branch where compiled assets are pushed and the tag is moved to.
         type: string
@@ -183,7 +188,7 @@ jobs:
       - name: Set branch environment variables
         if: ${{ github.ref_type == 'branch' }}
         run: |
-          echo "BUILT_BRANCH_NAME=${{ github.ref_name }}${{ inputs.BUILT_BRANCH_SUFFIX }}" >> $GITHUB_ENV
+          echo "BUILT_BRANCH_NAME=${{ inputs.BUILT_BRANCH_NAME && inputs.BUILT_BRANCH_NAME || format({0}{1}, github.ref_name, inputs.BUILT_BRANCH_SUFFIX) }}" >> $GITHUB_ENV
 
       - name: Set tag environment variables
         if: ${{ github.ref_type == 'tag' }}

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -285,7 +285,7 @@ you can use the branch name (i.e., `dev-main` for the `main` branch) as usual. I
 the built branch should be used. I.e., when `BUILT_BRANCH_SUFFIX` is `-built` and branch `main`,
 the `dev-main-built` branch should be used as the package version.
 
-If you defined `BUILT_BRANCH_NAME` then it wil depend on the logic in place. 
+For branches, If you defined `BUILT_BRANCH_NAME` then it will depend on the logic in place. 
 Read below for configuration examples.
 
 ---

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -10,11 +10,11 @@ To achieve that, the reusable workflow:
 
 ## Where are assets stored
 
-Two inputs can be used to define branches as assets storage - `BUILT_BRANCH_SUFFIX` and `RELEASE_BRANCH_NAME`.
+Two inputs can be used to define branches as assets storage - `BUILT_BRANCH_NAME` and `RELEASE_BRANCH_NAME`.
 
-`BUILT_BRANCH_SUFFIX` is used only for push-to-branch events. If defined, compiled assets
+`BUILT_BRANCH_NAME` is used only for push-to-branch events. If defined, compiled assets
 will be stored in the branch with name equals current branch plus suffix. For instance,
-if `BUILT_BRANCH_SUFFIX` equals `-built` for pushing to the `main` branch, compiled assets will be stored
+if `BUILT_BRANCH_NAME` equals `${{ github.ref_name }}-built` for pushing to the `main` branch, compiled assets will be stored
 in the `main-built` branch (a branch will be created if it does not exist).
 
 `RELEASE_BRANCH_NAME` is used only for tag events. If defined and the pushed tag points
@@ -23,7 +23,7 @@ to the release branch, and the tag will be moved there.
 If the input is undefined or the tag points to one of the previous commits,
 the compiled assets will be pushed to the detached commit, and the tag will be moved there.
 
-The main benefit of using `BUILT_BRANCH_SUFFIX` is not to pollute the main development branch
+The main benefit of using `BUILT_BRANCH_NAME` is not to pollute the main development branch
 with commits containing compiled assets. With `RELEASE_BRANCH_NAME`, you can gain linear tag history
 if you always tag just the last commit from the main development branch.
 
@@ -64,7 +64,7 @@ on:
   push:
     tags: ['*']
     branches: ['*']
-    # Don't include paths if BUILT_BRANCH_SUFFIX or RELEASE_BRANCH_NAME are defined
+    # Don't include paths if BUILT_BRANCH_NAME or RELEASE_BRANCH_NAME are defined
     paths:
       - '**workflows/build-and-push-assets.yml' # the workflow file itself
       - '**.ts'
@@ -81,7 +81,7 @@ jobs:
   build-assets:
     uses: inpsyde/reusable-workflows/.github/workflows/build-and-push-assets.yml@main
     with:
-      BUILT_BRANCH_SUFFIX: '-built' # Optionally, to push compiled assets to built branch
+      BUILT_BRANCH_NAME: "${{ github.ref_name }}-built" # Optionally, to push compiled assets to built branch
       RELEASE_BRANCH_NAME: 'release' # Optionally, to move tags to release branch
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
@@ -97,22 +97,22 @@ This is not the simplest possible example, but it showcases all the recommendati
 
 ### Inputs
 
-| Name                  | Default                       | Description                                                                                                                                               |
-|-----------------------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                                                                                         |
-| `NODE_VERSION`        | `18`                          | Node version with which the assets will be compiled                                                                                                       |
-| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                                                                                        |
-| `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`)                                                                         |
-| `WORKING_DIRECTORY`   | `'./'`                        | Working directory path                                                                                                                                    |
-| `COMPILE_SCRIPT_PROD` | `'build'`                     | Script added to `npm run` or `yarn` to build production assets                                                                                            |
-| `COMPILE_SCRIPT_DEV`  | `'build:dev'`                 | Script added to `npm run` or `yarn` to build development assets                                                                                           |
-| `MODE`                | `''`                          | Mode for compiling assets (`prod` or `dev`)                                                                                                               |
-| `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                                                                                        |
-| `BUILT_BRANCH_SUFFIX` | `''`                          | Suffix to calculate the target branch for pushing assets on the `branch` event                                                                            |
-| `BUILT_BRANCH_NAME`   | `''`                          | Sets the target branch for pushing assets on the `branch` event. Default is `github.ref_name``BUILT_BRANCH_SUFFIX`. Read below for configuration examples |
-| `RELEASE_BRANCH_NAME` | `''`                          | On tag events, target branch where compiled assets are pushed and the tag is moved to                                                                     |
-| `PHP_VERSION`         | `'8.0'`                       | PHP version with which the PHP tools are to be executed                                                                                                   |
-| `PHP_TOOLS`           | `''`                          | PHP tools supported by [shivammathur/setup-php](https://github.com/shivammathur/setup-php#wrench-tools-support) to be installed                           |
+| Name                  | Default                       | Description                                                                                                                     |
+|-----------------------|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                                                               |
+| `NODE_VERSION`        | `18`                          | Node version with which the assets will be compiled                                                                             |
+| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                                                              |
+| `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`)                                               |
+| `WORKING_DIRECTORY`   | `'./'`                        | Working directory path                                                                                                          |
+| `COMPILE_SCRIPT_PROD` | `'build'`                     | Script added to `npm run` or `yarn` to build production assets                                                                  |
+| `COMPILE_SCRIPT_DEV`  | `'build:dev'`                 | Script added to `npm run` or `yarn` to build development assets                                                                 |
+| `MODE`                | `''`                          | Mode for compiling assets (`prod` or `dev`)                                                                                     |
+| `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                                                              |
+| `BUILT_BRANCH_SUFFIX` | `''`                          | Suffix to calculate the target branch for pushing assets on the `branch` event (deprecated)                                     |
+| `BUILT_BRANCH_NAME`   | `''`                          | Sets the target branch for pushing assets on the `branch` event                                                                 |
+| `RELEASE_BRANCH_NAME` | `''`                          | On tag events, target branch where compiled assets are pushed and the tag is moved to                                           |
+| `PHP_VERSION`         | `'8.0'`                       | PHP version with which the PHP tools are to be executed                                                                         |
+| `PHP_TOOLS`           | `''`                          | PHP tools supported by [shivammathur/setup-php](https://github.com/shivammathur/setup-php#wrench-tools-support) to be installed |
 
 
 ## Secrets
@@ -196,7 +196,7 @@ jobs:
 
 ---
 
-> Will I have merge conflicts during PRs merging if I don't use `BUILT_BRANCH_SUFFIX`?
+> Will I have merge conflicts during PRs merging if I don't use `BUILT_BRANCH_NAME`?
 
 No, if you follow the recommendations in this document you shouldn't.
 
@@ -233,7 +233,7 @@ hash that triggered the compilation.
 As for the "noise", it will indeed be there. However, considering that all workflow commit messages
 start with the prefix `[BOT]`, it would be quite easy to ignore them without any cognitive effort.
 
-By defining `BUILT_BRANCH_SUFFIX` or `BUILT_BRANCH_NAME`, you keep commits containing compiled assets separated in the built branch.
+By defining `BUILT_BRANCH_NAME`, you keep commits containing compiled assets separated in the built branch.
 
 ---
 
@@ -280,13 +280,8 @@ _ad-hoc_ "bot" user with an _ad-hoc_ private SSH key used only for the scope.
 
 For tags, the pushed tag name is always used.
 
-For branches, it depends on the `BUILT_BRANCH_SUFFIX` input value. If the input is not provided,
-you can use the branch name (i.e., `dev-main` for the `main` branch) as usual. If a suffix was defined,
-the built branch should be used. I.e., when `BUILT_BRANCH_SUFFIX` is `-built` and branch `main`,
-the `dev-main-built` branch should be used as the package version.
-
-For branches, If you defined `BUILT_BRANCH_NAME` then it will depend on the logic in place. 
-Read below for configuration examples.
+For branches, it depends on the `BUILT_BRANCH_NAME` input value. I.e., when `BUILT_BRANCH_NAME` is `${{ github.ref_name}}-built` and the branch triggering the workflow is `main`,
+the built branch name will resolve to `main-built`, then in `composer.json` you can require it like this: `my-package":"dev-main-built"`.
 
 ---
 
@@ -297,8 +292,7 @@ BUILT_BRANCH_NAME: "${{ (github.ref_name == 'dev-main' && 'main' || (github.ref_
 ```
 
 The logic in the example above will behave like this:
-- If github.ref_name is equal to `dev-main`, the value of BUILT_BRANCH_NAME will be `main`.
-- If github.ref_name is equal to `dev-beta`, the value of BUILT_BRANCH_NAME will be `beta`.
-- If github.ref_name is equal to `dev-alpha`, the value of BUILT_BRANCH_NAME will be `alpha`.
-- If none of the above conditions are met, the value of BUILT_BRANCH_NAME will be `''`
-which is the default
+- If `github.ref_name` is equal to `dev-main`, the value of `BUILT_BRANCH_NAME` will be `main`
+- If `github.ref_name` is equal to `dev-beta`, the value of `BUILT_BRANCH_NAME` will be `beta`
+- If `github.ref_name` is equal to `dev-alpha`, the value of `BUILT_BRANCH_NAME` will be `alpha`
+- If none of the above conditions are met, the value of `BUILT_BRANCH_NAME` will be `''` which is the default

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -78,8 +78,8 @@ jobs:
   build-assets:
     uses: inpsyde/reusable-workflows/.github/workflows/build-and-push-assets.yml@main
     with:
-      BUILT_BRANCH_NAME: ${{ github.ref_name }}-built
-      RELEASE_BRANCH_NAME: release
+      BUILT_BRANCH_NAME: "${{ github.ref_name }}-built" # Optionally, to push compiled assets to built branch
+      RELEASE_BRANCH_NAME: 'release' # Optionally, to move tags to release branch
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.INPSYDE_BOT_USER }}

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -12,9 +12,13 @@ To achieve that, the reusable workflow:
 
 Two inputs can be used to define branches as assets storage: `BUILT_BRANCH_NAME` and `RELEASE_BRANCH_NAME`.
 
-`BUILT_BRANCH_NAME` is used only for `branch` events. If defined, compiled assets will be stored in the branch of this name. For example, if `BUILT_BRANCH_NAME` is set to `${{ github.ref_name }}-built`, when pushing to the `main` branch, compiled assets will be stored in the `main-built` branch (the branch will be created if it does not exist).
+`BUILT_BRANCH_NAME` is used only for `branch` events. If defined, compiled assets will be stored in the branch of this
+name. For example, if `BUILT_BRANCH_NAME` is set to `${{ github.ref_name }}-built`, when pushing to the `main` branch,
+compiled assets will be stored in the `main-built` branch (the branch will be created if it does not exist).
 
-`RELEASE_BRANCH_NAME` is only used for tag events. If defined and the tag being pushed points to the latest commit of the default branch of the GitHub repository, compiled assets will be pushed to the branch of this name, and the tag will be moved there (the branch will be created if it does not exist).
+`RELEASE_BRANCH_NAME` is only used for tag events. If defined and the tag being pushed points to the latest commit of
+the default branch of the GitHub repository, compiled assets will be pushed to the branch of this name, and the tag will
+be moved there (the branch will be created if it does not exist).
 
 The main benefit of using `BUILT_BRANCH_NAME` is not to pollute the main development branch
 with commits containing compiled assets. With `RELEASE_BRANCH_NAME`, you can gain linear tag history
@@ -55,8 +59,8 @@ name: Build and push assets
 on:
   workflow_dispatch:
   push:
-    tags: ['*']
-    branches: ['*']
+    tags: [ '*' ]
+    branches: [ '*' ]
     # Don't include paths if BUILT_BRANCH_NAME or RELEASE_BRANCH_NAME are defined
     paths:
       - '**workflows/build-and-push-assets.yml' # the workflow file itself
@@ -106,7 +110,6 @@ This is not the simplest possible example, but it showcases all the recommendati
 | `RELEASE_BRANCH_NAME` | `''`                          | On tag events, target branch where compiled assets are pushed and the tag is moved to                                           |
 | `PHP_VERSION`         | `'8.0'`                       | PHP version with which the PHP tools are to be executed                                                                         |
 | `PHP_TOOLS`           | `''`                          | PHP tools supported by [shivammathur/setup-php](https://github.com/shivammathur/setup-php#wrench-tools-support) to be installed |
-
 
 ## Secrets
 
@@ -273,17 +276,20 @@ _ad-hoc_ "bot" user with an _ad-hoc_ private SSH key used only for the scope.
 
 For tags, the pushed tag name is always used.
 
-For branches, it depends on the `BUILT_BRANCH_NAME` input value. For example, when `BUILT_BRANCH_NAME` is `${{ github.ref_name}}-built` and the branch triggering the workflow is `main`, the built branch name will resolve to `main-built`. In this case, require the `dev-main-built` branch in `composer.json`.
+For branches, it depends on the `BUILT_BRANCH_NAME` input value. For example, when `BUILT_BRANCH_NAME`
+is `${{ github.ref_name}}-built` and the branch triggering the workflow is `main`, the built branch name will resolve
+to `main-built`. In this case, require the `dev-main-built` branch in `composer.json`.
 
 ---
 
 > `BUILT_BRANCH_NAME` configuration example
- 
+
 ```yaml
 BUILT_BRANCH_NAME: "${{ (github.ref_name == 'dev-main' && 'main' || (github.ref_name == 'dev-beta' && 'beta' || (github.ref_name == 'dev-alpha' && 'alpha' || '') ) ) }}"
 ```
 
 The logic in the example above will behave like this:
+
 - If `github.ref_name` is equal to `dev-main`, the value of `BUILT_BRANCH_NAME` will be `main`
 - If `github.ref_name` is equal to `dev-beta`, the value of `BUILT_BRANCH_NAME` will be `beta`
 - If `github.ref_name` is equal to `dev-alpha`, the value of `BUILT_BRANCH_NAME` will be `alpha`

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -293,10 +293,12 @@ Read below for configuration examples.
 > `BUILT_BRANCH_NAME` configuration example
  
 ```yaml
-BUILT_BRANCH_NAME: "${{ (github.ref_name == 'dev-main' && 'main' || (github.ref_name == 'dev-beta' && 'beta' || (github.ref_name == 'dev-alpha' && 'alpha' || github.ref_name) ) ) }}"
+BUILT_BRANCH_NAME: "${{ (github.ref_name == 'dev-main' && 'main' || (github.ref_name == 'dev-beta' && 'beta' || (github.ref_name == 'dev-alpha' && 'alpha' || '') ) ) }}"
 ```
 
+The logic in the example above will behave like this:
 - If github.ref_name is equal to `dev-main`, the value of BUILT_BRANCH_NAME will be `main`.
 - If github.ref_name is equal to `dev-beta`, the value of BUILT_BRANCH_NAME will be `beta`.
 - If github.ref_name is equal to `dev-alpha`, the value of BUILT_BRANCH_NAME will be `alpha`.
-- If none of the above conditions are met, the value of BUILT_BRANCH_NAME will be the same as `github.ref_name`
+- If none of the above conditions are met, the value of BUILT_BRANCH_NAME will be `''`
+which is the default

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -78,8 +78,8 @@ jobs:
   build-assets:
     uses: inpsyde/reusable-workflows/.github/workflows/build-and-push-assets.yml@main
     with:
-      BUILT_BRANCH_NAME: "${{ github.ref_name }}-built" # Optionally, to push compiled assets to built branch
-      RELEASE_BRANCH_NAME: 'release' # Optionally, to move tags to release branch
+      BUILT_BRANCH_NAME: ${{ github.ref_name }}-built # Optionally, to push compiled assets to built branch
+      RELEASE_BRANCH_NAME: release # Optionally, to move tags to release branch
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.INPSYDE_BOT_USER }}

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -78,8 +78,8 @@ jobs:
   build-assets:
     uses: inpsyde/reusable-workflows/.github/workflows/build-and-push-assets.yml@main
     with:
-      BUILT_BRANCH_NAME: "${{ github.ref_name }}-built" # Optionally, to push compiled assets to built branch
-      RELEASE_BRANCH_NAME: 'release' # Optionally, to move tags to release branch
+      BUILT_BRANCH_NAME: ${{ github.ref_name }}-built
+      RELEASE_BRANCH_NAME: release
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.INPSYDE_BOT_USER }}

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -97,21 +97,22 @@ This is not the simplest possible example, but it showcases all the recommendati
 
 ### Inputs
 
-| Name                  | Default                       | Description                                                                                                                     |
-|-----------------------|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
-| `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                                                               |
-| `NODE_VERSION`        | `18`                          | Node version with which the assets will be compiled                                                                             |
-| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                                                              |
-| `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`)                                               |
-| `WORKING_DIRECTORY`   | `'./'`                        | Working directory path                                                                                                          |
-| `COMPILE_SCRIPT_PROD` | `'build'`                     | Script added to `npm run` or `yarn` to build production assets                                                                  |
-| `COMPILE_SCRIPT_DEV`  | `'build:dev'`                 | Script added to `npm run` or `yarn` to build development assets                                                                 |
-| `MODE`                | `''`                          | Mode for compiling assets (`prod` or `dev`)                                                                                     |
-| `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                                                              |
-| `BUILT_BRANCH_SUFFIX` | `''`                          | Suffix to calculate the target branch for pushing assets on the `branch` event                                                  |
-| `RELEASE_BRANCH_NAME` | `''`                          | On tag events, target branch where compiled assets are pushed and the tag is moved to                                           |
-| `PHP_VERSION`         | `'8.0'`                       | PHP version with which the PHP tools are to be executed                                                                         |
-| `PHP_TOOLS`           | `''`                          | PHP tools supported by [shivammathur/setup-php](https://github.com/shivammathur/setup-php#wrench-tools-support) to be installed |
+| Name                  | Default                       | Description                                                                                                                                               |
+|-----------------------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                                                                                         |
+| `NODE_VERSION`        | `18`                          | Node version with which the assets will be compiled                                                                                                       |
+| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                                                                                        |
+| `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`)                                                                         |
+| `WORKING_DIRECTORY`   | `'./'`                        | Working directory path                                                                                                                                    |
+| `COMPILE_SCRIPT_PROD` | `'build'`                     | Script added to `npm run` or `yarn` to build production assets                                                                                            |
+| `COMPILE_SCRIPT_DEV`  | `'build:dev'`                 | Script added to `npm run` or `yarn` to build development assets                                                                                           |
+| `MODE`                | `''`                          | Mode for compiling assets (`prod` or `dev`)                                                                                                               |
+| `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                                                                                        |
+| `BUILT_BRANCH_SUFFIX` | `''`                          | Suffix to calculate the target branch for pushing assets on the `branch` event                                                                            |
+| `BUILT_BRANCH_NAME`   | `''`                          | Sets the target branch for pushing assets on the `branch` event. Default is `github.ref_name``BUILT_BRANCH_SUFFIX`. Read below for configuration examples |
+| `RELEASE_BRANCH_NAME` | `''`                          | On tag events, target branch where compiled assets are pushed and the tag is moved to                                                                     |
+| `PHP_VERSION`         | `'8.0'`                       | PHP version with which the PHP tools are to be executed                                                                                                   |
+| `PHP_TOOLS`           | `''`                          | PHP tools supported by [shivammathur/setup-php](https://github.com/shivammathur/setup-php#wrench-tools-support) to be installed                           |
 
 
 ## Secrets
@@ -232,7 +233,7 @@ hash that triggered the compilation.
 As for the "noise", it will indeed be there. However, considering that all workflow commit messages
 start with the prefix `[BOT]`, it would be quite easy to ignore them without any cognitive effort.
 
-By defining `BUILT_BRANCH_SUFFIX`, you keep commits containing compiled assets separated in the built branch.
+By defining `BUILT_BRANCH_SUFFIX` or `BUILT_BRANCH_NAME`, you keep commits containing compiled assets separated in the built branch.
 
 ---
 
@@ -283,3 +284,19 @@ For branches, it depends on the `BUILT_BRANCH_SUFFIX` input value. If the input 
 you can use the branch name (i.e., `dev-main` for the `main` branch) as usual. If a suffix was defined,
 the built branch should be used. I.e., when `BUILT_BRANCH_SUFFIX` is `-built` and branch `main`,
 the `dev-main-built` branch should be used as the package version.
+
+If you defined `BUILT_BRANCH_NAME` then it wil depend on the logic in place. 
+Read below for configuration examples.
+
+---
+
+> `BUILT_BRANCH_NAME` configuration example
+ 
+```yaml
+BUILT_BRANCH_NAME: "${{ (github.ref_name == 'dev-main' && 'main' || (github.ref_name == 'dev-beta' && 'beta' || (github.ref_name == 'dev-alpha' && 'alpha' || github.ref_name) ) ) }}"
+```
+
+- If github.ref_name is equal to `dev-main`, the value of BUILT_BRANCH_NAME will be `main`.
+- If github.ref_name is equal to `dev-beta`, the value of BUILT_BRANCH_NAME will be `beta`.
+- If github.ref_name is equal to `dev-alpha`, the value of BUILT_BRANCH_NAME will be `alpha`.
+- If none of the above conditions are met, the value of BUILT_BRANCH_NAME will be the same as `github.ref_name`

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -10,22 +10,15 @@ To achieve that, the reusable workflow:
 
 ## Where are assets stored
 
-Two inputs can be used to define branches as assets storage - `BUILT_BRANCH_NAME` and `RELEASE_BRANCH_NAME`.
+Two inputs can be used to define branches as assets storage: `BUILT_BRANCH_NAME` and `RELEASE_BRANCH_NAME`.
 
-`BUILT_BRANCH_NAME` is used only for push-to-branch events. If defined, compiled assets
-will be stored in the branch with name equals current branch plus suffix. For instance,
-if `BUILT_BRANCH_NAME` equals `${{ github.ref_name }}-built` for pushing to the `main` branch, compiled assets will be stored
-in the `main-built` branch (a branch will be created if it does not exist).
+`BUILT_BRANCH_NAME` is used only for `branch` events. If defined, compiled assets will be stored in the branch of this name. For example, if `BUILT_BRANCH_NAME` is set to `${{ github.ref_name }}-built`, when pushing to the `main` branch, compiled assets will be stored in the `main-built` branch (the branch will be created if it does not exist).
 
-`RELEASE_BRANCH_NAME` is used only for tag events. If defined and the pushed tag points
-to the last commit of the default branch of the GitHub repository, compiled assets will be pushed
-to the release branch, and the tag will be moved there.
-If the input is undefined or the tag points to one of the previous commits,
-the compiled assets will be pushed to the detached commit, and the tag will be moved there.
+`RELEASE_BRANCH_NAME` is only used for tag events. If defined and the tag being pushed points to the latest commit of the default branch of the GitHub repository, compiled assets will be pushed to the branch of this name, and the tag will be moved there (the branch will be created if it does not exist).
 
 The main benefit of using `BUILT_BRANCH_NAME` is not to pollute the main development branch
 with commits containing compiled assets. With `RELEASE_BRANCH_NAME`, you can gain linear tag history
-if you always tag just the last commit from the main development branch.
+by always tagging only the latest commit from the main development branch.
 
 ## Build script
 
@@ -280,8 +273,7 @@ _ad-hoc_ "bot" user with an _ad-hoc_ private SSH key used only for the scope.
 
 For tags, the pushed tag name is always used.
 
-For branches, it depends on the `BUILT_BRANCH_NAME` input value. I.e., when `BUILT_BRANCH_NAME` is `${{ github.ref_name}}-built` and the branch triggering the workflow is `main`,
-the built branch name will resolve to `main-built`, then in `composer.json` you can require it like this: `my-package":"dev-main-built"`.
+For branches, it depends on the `BUILT_BRANCH_NAME` input value. For example, when `BUILT_BRANCH_NAME` is `${{ github.ref_name}}-built` and the branch triggering the workflow is `main`, the built branch name will resolve to `main-built`. In this case, require the `dev-main-built` branch in `composer.json`.
 
 ---
 
@@ -295,4 +287,4 @@ The logic in the example above will behave like this:
 - If `github.ref_name` is equal to `dev-main`, the value of `BUILT_BRANCH_NAME` will be `main`
 - If `github.ref_name` is equal to `dev-beta`, the value of `BUILT_BRANCH_NAME` will be `beta`
 - If `github.ref_name` is equal to `dev-alpha`, the value of `BUILT_BRANCH_NAME` will be `alpha`
-- If none of the above conditions are met, the value of `BUILT_BRANCH_NAME` will be `''` which is the default
+- If none of the above conditions are met, the value of `BUILT_BRANCH_NAME` will be `''`, which is the default


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR aims to provide more flexibility in how the BUILT_BRANCH_NAME is calculated.


**What is the current behavior?** (You can also link to an open issue here)
The current behavior is limited to use a suffix or a release branch name, there are more use cases where we might want to set the name based on the specific branch name triggering the workflow or to add a prefix.


**What is the new behavior (if this is a feature change)?**
The new behavior is:
We are deprecating the usage of BUILT_BRANCH_SUFFIX. 
We are introducing a BUILT_BRANCH_NAME variable so we can put some conditional logic to define its value.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
