### PR TITLE
Feat/125 extend assets target path

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -49,7 +49,7 @@ on:
         required: false
         type: string
       ASSETS_TARGET_FILES:
-        description: Target file path(s) for compiled assets.
+        description: Space-separated list of target file paths for compiled assets.
         default: ''
         required: false
         type: string

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -45,7 +45,7 @@ on:
         type: string
       ASSETS_TARGET_PATHS:
         description: Target path(s) for compiled assets.
-        default: './assets'
+        default: './assets/'
         required: false
         type: string
       BUILT_BRANCH_SUFFIX:
@@ -214,9 +214,17 @@ jobs:
           git checkout -b bot/compiled-assets/${{ github.sha }}
           echo "TAG_BRANCH_NAME=bot/compiled-assets/${{ github.sha }}" >> $GITHUB_ENV
 
-      - name: Prepare directories
+      - name: Prepare directories and files
         run: |
-          mkdir -p ${{ inputs.ASSETS_TARGET_PATHS }}
+          declare -a TARGET_PATHS_ARRAY=(${{ inputs.ASSETS_TARGET_PATHS }})
+          for path in "${TARGET_PATHS_ARRAY[@]}"; do
+            if [[ "${path}" == */ ]]; then
+              mkdir -p "${path}"
+            else
+              touch "$path"
+            fi
+          done
+
 
       - name: Set up node cache mode
         run: |
@@ -254,7 +262,13 @@ jobs:
       - name: Git add, commit
         run: |
           declare -a TARGET_PATHS_ARRAY=(${{ inputs.ASSETS_TARGET_PATHS }})
-          for path in "${TARGET_PATHS_ARRAY[@]}"; do git add -f "${path}/*"; done
+          for path in "${TARGET_PATHS_ARRAY[@]}"; do
+            if [[ "${path}" == */ ]]; then
+              git add -f "${path}"/*
+            else
+              git add -f "$path"
+            fi
+          done
           git add -A
           git commit -m "[BOT] Add compiled assets for #${{ github.ref }}" --no-verify || ((echo "NO_CHANGES=yes" >> $GITHUB_ENV) && (echo "No changes to commit"))
 

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -44,7 +44,7 @@ on:
         required: false
         type: string
       ASSETS_TARGET_PATHS:
-        description: Target directory path(s) for compiled assets.
+        description: Space-separated list of target directory paths for compiled assets.
         default: './assets'
         required: false
         type: string

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -44,8 +44,13 @@ on:
         required: false
         type: string
       ASSETS_TARGET_PATHS:
-        description: Target path(s) for compiled assets.
-        default: './assets/'
+        description: Target directory path(s) for compiled assets.
+        default: './assets'
+        required: false
+        type: string
+      ASSETS_TARGET_FILES:
+        description: Target file path(s) for compiled assets.
+        default: ''
         required: false
         type: string
       BUILT_BRANCH_SUFFIX:
@@ -214,17 +219,9 @@ jobs:
           git checkout -b bot/compiled-assets/${{ github.sha }}
           echo "TAG_BRANCH_NAME=bot/compiled-assets/${{ github.sha }}" >> $GITHUB_ENV
 
-      - name: Prepare directories and files
+      - name: Prepare directories
         run: |
-          declare -a TARGET_PATHS_ARRAY=(${{ inputs.ASSETS_TARGET_PATHS }})
-          for path in "${TARGET_PATHS_ARRAY[@]}"; do
-            if [[ "${path}" == */ ]]; then
-              mkdir -p "${path}"
-            else
-              touch "$path"
-            fi
-          done
-
+          mkdir -p ${{ inputs.ASSETS_TARGET_PATHS }}
 
       - name: Set up node cache mode
         run: |
@@ -261,14 +258,10 @@ jobs:
 
       - name: Git add, commit
         run: |
-          declare -a TARGET_PATHS_ARRAY=(${{ inputs.ASSETS_TARGET_PATHS }})
-          for path in "${TARGET_PATHS_ARRAY[@]}"; do
-            if [[ "${path}" == */ ]]; then
-              git add -f "${path}"/*
-            else
-              git add -f "$path"
-            fi
-          done
+          declare -a TARGET_DIRECTORY_PATHS_ARRAY=(${{ inputs.ASSETS_TARGET_PATHS }})
+          for path in "${TARGET_DIRECTORY_PATHS_ARRAY[@]}"; do git add -f "${path}/*"; done
+          declare -a TARGET_FILES_PATHS_ARRAY=(${{ inputs.ASSETS_TARGET_FILES }})
+          for path in "${TARGET_FILES_PATHS_ARRAY[@]}"; do [[ -f "$path" ]] && git add -f "${path}"; done
           git add -A
           git commit -m "[BOT] Add compiled assets for #${{ github.ref }}" --no-verify || ((echo "NO_CHANGES=yes" >> $GITHUB_ENV) && (echo "No changes to commit"))
 

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -174,7 +174,7 @@ jobs:
       MODE: ${{ github.ref_type == 'branch' && github.ref_name == 'production' && 'prod' || '' }}
 ```
 
-> Can I have multiple output folders for my package?, and what about files?
+> Can I have multiple output folders for my package? What about files?
 
 Yes, `inputs.ASSETS_TARGET_PATHS` and `inputs.ASSETS_TARGET_FILES` accept multiple space-separated paths for directories and files, respectively.
 

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -107,8 +107,8 @@ This is not the simplest possible example, but it showcases all the recommendati
 | `COMPILE_SCRIPT_PROD` | `'build'`                     | Script added to `npm run` or `yarn` to build production assets                                                                  |
 | `COMPILE_SCRIPT_DEV`  | `'build:dev'`                 | Script added to `npm run` or `yarn` to build development assets                                                                 |
 | `MODE`                | `''`                          | Mode for compiling assets (`prod` or `dev`)                                                                                     |
-| `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target directory path(s) for compiled assets                                                                                    |
-| `ASSETS_TARGET_FILES` | `''`                          | Target file path(s) for compiled assets                                                                                         |
+| `ASSETS_TARGET_PATHS` | `'./assets'`                  | Space-separated list of target directory paths for compiled assets                                                              |
+| `ASSETS_TARGET_FILES` | `''`                          | Space-separated list of target file paths for compiled assets                                                                   |
 | `BUILT_BRANCH_SUFFIX` | `''`                          | Suffix to calculate the target branch for pushing assets on the `branch` event                                                  |
 | `RELEASE_BRANCH_NAME` | `''`                          | On tag events, target branch where compiled assets are pushed and the tag is moved to                                           |
 | `PHP_VERSION`         | `'8.0'`                       | PHP version with which the PHP tools are to be executed                                                                         |

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -176,9 +176,7 @@ jobs:
 
 > Can I have multiple output folders for my package?, and what about files?
 
-Yes, 
-- The `inputs.ASSETS_TARGET_PATHS` accepts multiple space-separated paths for **directories**
-- The `inputs.ASSETS_TARGET_FILES` accepts multiple space-separated paths for **files**
+Yes, `inputs.ASSETS_TARGET_PATHS` and `inputs.ASSETS_TARGET_FILES` accept multiple space-separated paths for directories and files, respectively.
 
 ```yaml
 name: Build and push assets

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -107,7 +107,7 @@ This is not the simplest possible example, but it showcases all the recommendati
 | `COMPILE_SCRIPT_PROD` | `'build'`                     | Script added to `npm run` or `yarn` to build production assets                                                                  |
 | `COMPILE_SCRIPT_DEV`  | `'build:dev'`                 | Script added to `npm run` or `yarn` to build development assets                                                                 |
 | `MODE`                | `''`                          | Mode for compiling assets (`prod` or `dev`)                                                                                     |
-| `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target path(s) for compiled assets                                                                                              |
+| `ASSETS_TARGET_PATHS` | `'./assets/'`                 | Target path(s) for compiled assets. Read more below                                                                             |
 | `BUILT_BRANCH_SUFFIX` | `''`                          | Suffix to calculate the target branch for pushing assets on the `branch` event                                                  |
 | `RELEASE_BRANCH_NAME` | `''`                          | On tag events, target branch where compiled assets are pushed and the tag is moved to                                           |
 | `PHP_VERSION`         | `'8.0'`                       | PHP version with which the PHP tools are to be executed                                                                         |
@@ -173,9 +173,11 @@ jobs:
       MODE: ${{ github.ref_type == 'branch' && github.ref_name == 'production' && 'prod' || '' }}
 ```
 
-> Can I have multiple output folders for my package?
+> Can I have multiple output folders for my package, and what about files?
 
-Yes, the `inputs.ASSETS_TARGET_PATHS` accepts multiple space-separated paths:
+Yes, the `inputs.ASSETS_TARGET_PATHS` accepts multiple space-separated paths: 
+- If the path ends with a slash is treated as a folder. We will create it if it doesn't exist.
+- If the path **do not** end with a slash is treated as a file. We will create it if it doesn't exist.
 
 ```yaml
 name: Build and push assets
@@ -185,7 +187,7 @@ jobs:
   build-assets:
     uses: inpsyde/reusable-workflows/.github/workflows/build-and-push-assets.yml@main
     with:
-      ASSETS_TARGET_PATHS: "./assets ./modules/Foo/assets ./modules/Bar/assets"
+      ASSETS_TARGET_PATHS: "./assets/ ./modules/Foo/assets/ ./modules/Bar/assets/ ./my-file.txt"
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.INPSYDE_BOT_USER }}

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -107,7 +107,8 @@ This is not the simplest possible example, but it showcases all the recommendati
 | `COMPILE_SCRIPT_PROD` | `'build'`                     | Script added to `npm run` or `yarn` to build production assets                                                                  |
 | `COMPILE_SCRIPT_DEV`  | `'build:dev'`                 | Script added to `npm run` or `yarn` to build development assets                                                                 |
 | `MODE`                | `''`                          | Mode for compiling assets (`prod` or `dev`)                                                                                     |
-| `ASSETS_TARGET_PATHS` | `'./assets/'`                 | Target path(s) for compiled assets. Read more below                                                                             |
+| `ASSETS_TARGET_PATHS` | `'./assets'`                  | Target directory path(s) for compiled assets                                                                                    |
+| `ASSETS_TARGET_FILES` | `''`                          | Target file path(s) for compiled assets                                                                                         |
 | `BUILT_BRANCH_SUFFIX` | `''`                          | Suffix to calculate the target branch for pushing assets on the `branch` event                                                  |
 | `RELEASE_BRANCH_NAME` | `''`                          | On tag events, target branch where compiled assets are pushed and the tag is moved to                                           |
 | `PHP_VERSION`         | `'8.0'`                       | PHP version with which the PHP tools are to be executed                                                                         |
@@ -173,11 +174,11 @@ jobs:
       MODE: ${{ github.ref_type == 'branch' && github.ref_name == 'production' && 'prod' || '' }}
 ```
 
-> Can I have multiple output folders for my package, and what about files?
+> Can I have multiple output folders for my package?, and what about files?
 
-Yes, the `inputs.ASSETS_TARGET_PATHS` accepts multiple space-separated paths: 
-- If the path ends with a slash is treated as a folder. We will create it if it doesn't exist.
-- If the path **do not** end with a slash is treated as a file. We will create it if it doesn't exist.
+Yes, 
+- The `inputs.ASSETS_TARGET_PATHS` accepts multiple space-separated paths for **directories**
+- The `inputs.ASSETS_TARGET_FILES` accepts multiple space-separated paths for **files**
 
 ```yaml
 name: Build and push assets
@@ -187,7 +188,8 @@ jobs:
   build-assets:
     uses: inpsyde/reusable-workflows/.github/workflows/build-and-push-assets.yml@main
     with:
-      ASSETS_TARGET_PATHS: "./assets/ ./modules/Foo/assets/ ./modules/Bar/assets/ ./my-file.txt"
+      ASSETS_TARGET_PATHS: "./assets ./modules/Foo/assets ./modules/Bar/assets"
+      ASSETS_TARGET_FILES: "./my-generated-file.txt ./LICENSE"
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.INPSYDE_BOT_USER }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes #125  


**What is the current behavior?** (You can also link to an open issue here)
`ASSETS_TARGET_PATHS` do not allow file paths, only directory paths.


**What is the new behavior (if this is a feature change)?**
We can refer to files using a new input.

Example:
```
ASSETS_TARGET_FILES: './a-file.txt ./another-file.txt'
```

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
