### PR TITLE
feat: add preset support for automatic-release.yml

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -1,11 +1,12 @@
 name: Automatic Release
 on:
   workflow_call:
-    ADDITIONAL_DEPENDENCIES:
-      description: Will be installed with NPM globally.
-      type: string
-      default: ''
-      required: false
+    inputs:
+      ADDITIONAL_DEPENDENCIES:
+        description: Will be installed with NPM globally.
+        type: string
+        default: ''
+        required: false
     secrets:
       GITHUB_USER_TOKEN:
         description: Authentication token with write permission needed by the release bot (falls back to GITHUB_TOKEN).

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -1,6 +1,11 @@
 name: Automatic Release
 on:
   workflow_call:
+    ADDITIONAL_DEPENDENCIES:
+      description: Will be installed with NPM globally.
+      type: string
+      default: ''
+      required: false
     secrets:
       GITHUB_USER_TOKEN:
         description: Authentication token with write permission needed by the release bot (falls back to GITHUB_TOKEN).
@@ -35,6 +40,11 @@ jobs:
             @semantic-release/npm \
             @semantic-release/exec \
             semantic-release
+
+      - name: Install additional dependencies
+        if: ${{ inputs.ADDITIONAL_DEPENDENCIES != '' }}
+        run: |
+          npm i -g ${{ inputs.ADDITIONAL_DEPENDENCIES }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -1,12 +1,11 @@
 name: Automatic Release
 on:
   workflow_call:
-    inputs:
-      ADDITIONAL_DEPENDENCIES:
-        description: Will be installed with NPM globally.
-        type: string
-        default: ''
-        required: false
+    ADDITIONAL_DEPENDENCIES:
+      description: Will be installed with NPM globally.
+      type: string
+      default: ''
+      required: false
     secrets:
       GITHUB_USER_TOKEN:
         description: Authentication token with write permission needed by the release bot (falls back to GITHUB_TOKEN).

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -34,7 +34,8 @@ jobs:
             @semantic-release/git \
             @semantic-release/npm \
             @semantic-release/exec \
-            semantic-release
+            semantic-release \
+            conventional-changelog-conventionalcommits
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -1,11 +1,6 @@
 name: Automatic Release
 on:
   workflow_call:
-    ADDITIONAL_DEPENDENCIES:
-      description: Will be installed with NPM globally.
-      type: string
-      default: ''
-      required: false
     secrets:
       GITHUB_USER_TOKEN:
         description: Authentication token with write permission needed by the release bot (falls back to GITHUB_TOKEN).
@@ -40,11 +35,6 @@ jobs:
             @semantic-release/npm \
             @semantic-release/exec \
             semantic-release
-
-      - name: Install additional dependencies
-        if: ${{ inputs.ADDITIONAL_DEPENDENCIES != '' }}
-        run: |
-          npm i -g ${{ inputs.ADDITIONAL_DEPENDENCIES }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/automatic-release.md
+++ b/docs/automatic-release.md
@@ -42,6 +42,12 @@ jobs:
 
 ## Configuration parameters
 
+### Inputs
+
+| Name                      | Default | Description                          |
+|---------------------------|---------|--------------------------------------|
+| `ADDITIONAL_DEPENDENCIES` | `''`    | Will be installed with NPM globally. |
+
 ### Secrets
 
 | Name                | Required | Default | Description                                                                                       |
@@ -60,6 +66,8 @@ on:
 jobs:
   release:
     uses: inpsyde/reusable-workflows/.github/workflows/automatic-release.yml@main
+    with:
+      ADDITIONAL_DEPENDENCIES: "conventional-changelog-conventionalcommits@^7.0"
     secrets:
       GITHUB_USER_TOKEN: ${{ secrets.WRITE_TOKEN }}
 ```

--- a/docs/automatic-release.md
+++ b/docs/automatic-release.md
@@ -42,12 +42,6 @@ jobs:
 
 ## Configuration parameters
 
-### Inputs
-
-| Name                      | Default | Description                          |
-|---------------------------|---------|--------------------------------------|
-| `ADDITIONAL_DEPENDENCIES` | `''`    | Will be installed with NPM globally. |
-
 ### Secrets
 
 | Name                | Required | Default | Description                                                                                       |
@@ -66,8 +60,6 @@ on:
 jobs:
   release:
     uses: inpsyde/reusable-workflows/.github/workflows/automatic-release.yml@main
-    with:
-      ADDITIONAL_DEPENDENCIES: "conventional-changelog-conventionalcommits@^7.0"
     secrets:
       GITHUB_USER_TOKEN: ${{ secrets.WRITE_TOKEN }}
 ```


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.


**What is the current behavior?** (You can also link to an open issue here)
There is no option to add a preset. We can use `release.config.js` from the consumer repo but can't add new dependencies.


**What is the new behavior (if this is a feature change)?**
Add `ADDITIONAL_DEPENDENCIES` input to install additional dependencies like plugins and presets.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
I've tested `conventionalcommits` preset. It works almost the same as `angular` regarding bumping calculation. But it contains an important feature - issue link generation.
With the following configuration:

```js
"preset": "conventionalcommits",
"presetConfig": {
  "issuePrefixes": ["PROJECT-"],
  "issueUrlFormat": "https://jira.com/{{prefix}}{{id}}"
},
```
and the commit like (`Refs:` is an optional part):
```
feat: new feature

Refs: PROJECT-123
```
we get changelog entry under Features section:
```md
* new feature, closes [PROJECT-123](https://jira.com/PROJECT-123)
```

I think it could even be the mainstream approach. The problem is that `semantic-release` and `conventional-changelog` are different projects. They are technically unrelated (no  `peerDependencies` even :man_shrugging: ). See https://github.com/semantic-release/semantic-release/issues/3292 and https://github.com/semantic-release/release-notes-generator/issues/633#issuecomment-2099445072.

So the state is the last `semantic-release` and is not compatible with the last `conventional-changelog`. The suggestion https://github.com/semantic-release/semantic-release/issues/3292#issuecomment-2099434430 looks reasonable to stick at least with majors.

So, the alternative change could be:
```patch
Index: .github/workflows/automatic-release.yml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/.github/workflows/automatic-release.yml b/.github/workflows/automatic-release.yml
--- a/.github/workflows/automatic-release.yml	(revision a125297465a741e1267afcb0fb6c95420cb799ce)
+++ b/.github/workflows/automatic-release.yml	(date 1716536668083)
@@ -35,11 +35,12 @@
 
       - name: Install dependencies
         run: |
-          npm i -g @semantic-release/changelog \
-            @semantic-release/git \
-            @semantic-release/npm \
-            @semantic-release/exec \
-            semantic-release
+          npm i -g @semantic-release/changelog@^6.0 \
+            @semantic-release/git@^10.0 \
+            @semantic-release/npm@^12.0 \
+            @semantic-release/exec@^6.0 \
+            semantic-release@^23.1 \
+            conventional-changelog-conventionalcommits@^7.0
 
       - name: Install additional dependencies
         if: ${{ inputs.ADDITIONAL_DEPENDENCIES != '' }}

``
