### PR TITLE
Add archive check workflow

### DIFF
--- a/.github/workflows/check-plugin-archive.yml
+++ b/.github/workflows/check-plugin-archive.yml
@@ -1,0 +1,80 @@
+name: Check plugin package
+
+on:
+  workflow_call:
+    inputs:
+      ARTIFACT:
+        description: The name of the generated artifact, usually the output of the archive creation workflow.
+        required: true
+        type: string
+      PLUGIN_FOLDER_NAME:
+        description: The name of the plugin folder (falls back to the repository name).
+        default: ''
+        required: false
+        type: string
+      EXCLUDED_SNIFFS:
+        description: The comma-separated list of excluded sniffs.
+        default: 'WordPress.WP.AlternativeFunctions'
+        required: false
+        type: string
+      ADDITIONAL_WP_SNIFFS:
+        description: The comma-separated list of additional sniffs to run.
+        default: 'WordPress.WP.I18n'
+        required: false
+        type: string
+      COMPOSER_ARGS:
+        description: The arguments passed to Composer when installing dependencies.
+        default: '--no-dev --prefer-dist'
+        required: false
+        type: string
+      PHP_VERSION:
+        description: The PHP version to use.
+        default: '7.4'
+        required: false
+        type: string
+
+jobs:
+  check_archive:
+    name: Check plugin package
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    env:
+      PLUGIN_FOLDER_NAME: ${{ inputs.PLUGIN_FOLDER_NAME }}
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.ARTIFACT }}
+
+      - name: Set up plugin folder name
+        id: plugin-folder-name
+        run: echo "plugin-folder-name=${PLUGIN_FOLDER_NAME:-${{ github.event.repository.name }}}" >> $GITHUB_OUTPUT
+
+      - name: Setup PHP with tools
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.PHP_VERSION }}
+          tools: parallel-lint
+
+      - name: Run Parallel Lint
+        run: parallel-lint .
+
+      - name: Checkout Plugin Check repo
+        uses: actions/checkout@v4
+        with:
+          repository: WordPress/plugin-check
+          path: plugin-check
+      - name: Install Plugin Check deps
+        uses: ramsey/composer-install@v3
+        with:
+          working-directory: plugin-check
+          composer-options: ${{ inputs.COMPOSER_ARGS }}
+      - name: Run Plugin Check main rules
+        run: |
+          if [[ -z ${{ inputs.EXCLUDED_SNIFFS }} ]]; then exclude=''; else exclude="--exclude=${{ inputs.EXCLUDED_SNIFFS }}"; fi
+          vendor/bin/phpcs --standard=phpcs-rulesets/plugin-review.xml "${exclude}" --extensions=php "../${{ steps.plugin-folder-name.outputs.plugin-folder-name }}"
+        working-directory: plugin-check
+      - name: Run Plugin Check additional rules
+        if: ${{ inputs.ADDITIONAL_WP_SNIFFS != '' }}
+        run: vendor/bin/phpcs --standard=Wordpress --sniffs=${{ inputs.ADDITIONAL_WP_SNIFFS }} --extensions=php "../${{ steps.plugin-folder-name.outputs.plugin-folder-name }}"
+        working-directory: plugin-check

--- a/docs/archive-check.md
+++ b/docs/archive-check.md
@@ -1,0 +1,40 @@
+# Check plugin archive
+
+This workflow runs some checks on the plugin archive to make sure that everything is ok (especially important if processing the source code via php-scoper or Rector).
+
+Usually it should be run after the [archive creation workflow](/docs/archive-creation.md).
+
+It executes
+- [Parallel Lint](https://github.com/php-parallel-lint/PHP-Parallel-Lint) to check the PHP syntax
+- [Plugin Check](https://github.com/WordPress/plugin-check) PHP_CodeSniffer rules, as well as optionally other WordPress sniffs.
+
+
+## Simple usage example:
+
+```yml
+name: Create and check release package
+on:
+  workflow_dispatch:
+jobs:
+  create_archive:
+    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@main
+  check_archive:
+    uses: inpsyde/reusable-workflows/.github/workflows/check-plugin-archive.yml@main
+    needs: create_archive
+    with:
+      ARTIFACT: ${{ needs.create_archive.outputs.artifact }}
+      PHP_VERSION: '7.4'
+```
+
+## Configuration parameters
+
+### Inputs
+
+| Name                   | Default                                       | Description                                                                                    |
+|------------------------|-----------------------------------------------|------------------------------------------------------------------------------------------------|
+| `ARTIFACT`             |                                               | The name of the generated artifact, usually the output of the archive creation workflow.       |
+| `PLUGIN_FOLDER_NAME`   | `''`                                          | The name of the plugin folder (falls back to the repository name).                             |
+| `EXCLUDED_SNIFFS`      | `'WordPress.WP.AlternativeFunctions'`         | The comma-separated list of excluded sniffs.                                                   |
+| `ADDITIONAL_WP_SNIFFS` | `'WordPress.WP.I18n'`                         | The comma-separated list of additional sniffs to run.                                          |
+| `COMPOSER_ARGS`        | `'--no-dev --prefer-dist'`                    | The arguments passed to Composer when installing dependencies.                                 |
+| `PHP_VERSION`          | `'7.4'`                                       | The PHP version to use.                                                                        |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?**
 feature (new workflow)

The workflow runs some checks on the plugin archive to make sure that everything is ok (especially important if processing the source code via php-scoper or Rector).

It executes Parallel Lint to check the PHP syntax, and [Plugin Check](https://github.com/WordPress/plugin-check) phpcs ruleset, as well as other specified WP sniffs (by default `I18n`, because in some cases the `translators:` comments can be deleted by php-scoper).

It clones the Plugin Check repo and installs its composer deps, this seems to be the only quick way to use Plugin Check without WP and Docker, and it's a simple way to get `phpcs` and WP sniffs, since the plugin archive does not include the dev deps.

One issue here is that phpcs CLI is more limited than the config file. For example it’s not possible to ignore only the exception escaping errors when running the escaping sniff. But copying and maintaining the config for archive checking in each plugin seems like too much work, so for now trying like this.