### PR TITLE
Add support for signing commits with SSH key

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Set up signing commits
         if: ${{ env.GITHUB_USER_SSH_PUBLIC_KEY != '' }}
         run: |
+          : # Create empty SSH private key file so Git does not complain.
           touch "${{ runner.temp }}/signingkey"
           echo "${{ env.GITHUB_USER_SSH_PUBLIC_KEY }}" > "${{ runner.temp }}/signingkey.pub"
           git config --global commit.gpgsign true

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -9,7 +9,7 @@ on:
         description: Username for the GitHub user configuration.
         required: false
       GITHUB_USER_SSH_KEY:
-        description: Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`.
+        description: Private SSH key associated with the GitHub user for the token passed as `GITHUB_USER_TOKEN`.
         required: false
       GITHUB_USER_SSH_PUBLIC_KEY:
         description: Public SSH key associated with the GitHub user for the token passed as `GITHUB_USER_TOKEN`.

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -2,8 +2,20 @@ name: Automatic Release
 on:
   workflow_call:
     secrets:
+      GITHUB_USER_EMAIL:
+        description: Email address for the GitHub user configuration.
+        required: false
+      GITHUB_USER_NAME:
+        description: Username for the GitHub user configuration.
+        required: false
+      GITHUB_USER_SSH_KEY:
+        description: Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`.
+        required: false
+      GITHUB_USER_SSH_PUBLIC_KEY:
+        description: Public SSH key associated with the GitHub user for the token passed as `GITHUB_USER_TOKEN`.
+        required: false
       GITHUB_USER_TOKEN:
-        description: Authentication token with write permission needed by the release bot (falls back to GITHUB_TOKEN).
+        description: Authentication token with write permission needed by the release bot (falls back to `GITHUB_TOKEN`).
         required: false
 
 jobs:
@@ -13,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HAS_CONFIG: false
+      GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
+      GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}
     steps:
       - name: Fetch semantic-release Node version
         uses: actions/checkout@v4
@@ -40,7 +54,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          fetch-depth: 0
+          ssh-key: ${{ env.GITHUB_USER_SSH_KEY }}
+
+      - name: Set up SSH
+        if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ env.GITHUB_USER_SSH_KEY }}
+
+      - name: Set up signing commits
+        if: ${{ env.GITHUB_USER_SSH_PUBLIC_KEY != '' }}
+        run: |
+          touch "${{ runner.temp }}/signingkey"
+          echo "${{ env.GITHUB_USER_SSH_PUBLIC_KEY }}" > "${{ runner.temp }}/signingkey.pub"
+          git config --global commit.gpgsign true
+          git config --global gpg.format ssh
+          git config --global user.signingkey "${{ runner.temp }}/signingkey.pub"
 
       - name: Check presence of release.config.js
         run: |
@@ -67,7 +97,23 @@ jobs:
         run: |
           rm -rf workflow-repo
 
+      - name: Set up release environment variables
+        env:
+          GITHUB_USER_EMAIL: ${{ secrets.GITHUB_USER_EMAIL }}
+          GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
+        run: |
+          ${{ env.GITHUB_USER_EMAIL != '' }} && echo "GIT_AUTHOR_EMAIL=${{ env.GITHUB_USER_EMAIL }}" >> $GITHUB_ENV || true
+          ${{ env.GITHUB_USER_NAME != '' }} && echo "GIT_AUTHOR_NAME=${{ env.GITHUB_USER_NAME }}" >> $GITHUB_ENV || true
+          ${{ env.GITHUB_USER_EMAIL != '' }} && echo "GIT_COMMITTER_EMAIL=${{ env.GITHUB_USER_EMAIL }}" >> $GITHUB_ENV || true
+          ${{ env.GITHUB_USER_NAME != '' }} && echo "GIT_COMMITTER_NAME=${{ env.GITHUB_USER_NAME }}" >> $GITHUB_ENV || true
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_USER_TOKEN != '' && secrets.GITHUB_USER_TOKEN || secrets.GITHUB_TOKEN }}
         run: npx semantic-release
+
+      - name: Delete signing key files
+        if: ${{ always() && env.GITHUB_USER_SSH_PUBLIC_KEY != '' }}
+        run: |
+          rm "${{ runner.temp }}/signingkey"
+          rm "${{ runner.temp }}/signingkey.pub"

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -179,6 +179,7 @@ jobs:
       - name: Set up signing commits
         if: ${{ env.GITHUB_USER_SSH_PUBLIC_KEY != '' }}
         run: |
+          : # Create empty SSH private key file so Git does not complain.
           touch "${{ runner.temp }}/signingkey"
           echo "${{ env.GITHUB_USER_SSH_PUBLIC_KEY }}" > "${{ runner.temp }}/signingkey.pub"
           git config --global commit.gpgsign true

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -91,6 +91,9 @@ on:
       GITHUB_USER_SSH_KEY:
         description: Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`.
         required: false
+      GITHUB_USER_SSH_PUBLIC_KEY:
+        description: Public SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`.
+        required: false
       ENV_VARS:
         description: Additional environment variables as a JSON formatted object.
         required: false
@@ -142,6 +145,7 @@ jobs:
       GITHUB_USER_EMAIL: ${{ secrets.GITHUB_USER_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
+      GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}
       COMPILE_SCRIPT: ''
       TAG_NAME: ''                                     # we'll override if the push is for tag
       TAG_BRANCH_NAME: ''                              # we'll override if the push is for tag
@@ -171,6 +175,15 @@ jobs:
           git config --global user.name "${{ env.GITHUB_USER_NAME }}"
           git config --global advice.addIgnoredFile false
           git config --global push.autoSetupRemote true
+
+      - name: Set up signing commits
+        if: ${{ env.GITHUB_USER_SSH_PUBLIC_KEY != '' }}
+        run: |
+          touch "${{ runner.temp }}/signingkey"
+          echo "${{ env.GITHUB_USER_SSH_PUBLIC_KEY }}" > "${{ runner.temp }}/signingkey.pub"
+          git config --global commit.gpgsign true
+          git config --global gpg.format ssh
+          git config --global user.signingkey "${{ runner.temp }}/signingkey.pub"
 
       - name: Set up custom environment variables
         env:
@@ -297,3 +310,9 @@ jobs:
           git checkout --detach
           git branch -d ${{ env.TAG_BRANCH_NAME }}
           git push origin --delete ${{ env.TAG_BRANCH_NAME }}
+
+      - name: Delete signing key files
+        if: ${{ always() && env.GITHUB_USER_SSH_PUBLIC_KEY != '' }}
+        run: |
+          rm "${{ runner.temp }}/signingkey"
+          rm "${{ runner.temp }}/signingkey.pub"

--- a/docs/automatic-release.md
+++ b/docs/automatic-release.md
@@ -81,9 +81,9 @@ jobs:
   release:
     uses: inpsyde/reusable-workflows/.github/workflows/automatic-release.yml@main
     secrets:
-      GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
-      GITHUB_USER_NAME: ${{ secrets.INPSYDE_BOT_USER }}
-      GITHUB_USER_SSH_KEY: ${{ secrets.INPSYDE_BOT_SSH_PRIVATE_KEY }}
-      GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.INPSYDE_BOT_SSH_PUBLIC_KEY }}
+      GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
+      GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}
+      GITHUB_USER_SSH_KEY: ${{ secrets.DEPLOYBOT_SSH_PRIVATE_KEY }}
+      GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.DEPLOYBOT_SSH_PUBLIC_KEY }}
       GITHUB_USER_TOKEN: ${{ secrets.DEPLOYBOT_REPO_READ_WRITE_TOKEN }}
 ```

--- a/docs/automatic-release.md
+++ b/docs/automatic-release.md
@@ -44,9 +44,13 @@ jobs:
 
 ### Secrets
 
-| Name                | Required | Default | Description                                                                                       |
-|---------------------|----------|---------|---------------------------------------------------------------------------------------------------|
-| `GITHUB_USER_TOKEN` | false    | `''`    | Authentication token with write permission needed by the release bot (falls back to GITHUB_TOKEN) |
+| Name                         | Required | Default | Description                                                                                         |
+|------------------------------|----------|---------|-----------------------------------------------------------------------------------------------------|
+| `GITHUB_USER_EMAIL`          | false    | `''`    | Email address for the GitHub user configuration                                                     |
+| `GITHUB_USER_NAME`           | false    | `''`    | Username for the GitHub user configuration                                                          |
+| `GITHUB_USER_SSH_KEY`        | false    | `''`    | Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`                        |
+| `GITHUB_USER_SSH_PUBLIC_KEY` | false    | `''`    | Public SSH key associated with the GitHub user for the token passed as `GITHUB_USER_TOKEN`          |
+| `GITHUB_USER_TOKEN`          | false    | `''`    | Authentication token with write permission needed by the release bot (falls back to `GITHUB_TOKEN`) |
 
 **Example with configuration parameters:**
 
@@ -61,5 +65,25 @@ jobs:
   release:
     uses: inpsyde/reusable-workflows/.github/workflows/automatic-release.yml@main
     secrets:
-      GITHUB_USER_TOKEN: ${{ secrets.WRITE_TOKEN }}
+      GITHUB_USER_TOKEN: ${{ secrets.DEPLOYBOT_REPO_READ_WRITE_TOKEN }}
+```
+
+**Example with custom GitHub user and signed commits using SSH key:**
+
+```yml
+name: Release
+on:
+  push:
+    branches:
+      - main
+      - alpha
+jobs:
+  release:
+    uses: inpsyde/reusable-workflows/.github/workflows/automatic-release.yml@main
+    secrets:
+      GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
+      GITHUB_USER_NAME: ${{ secrets.INPSYDE_BOT_USER }}
+      GITHUB_USER_SSH_KEY: ${{ secrets.INPSYDE_BOT_SSH_PRIVATE_KEY }}
+      GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.INPSYDE_BOT_SSH_PUBLIC_KEY }}
+      GITHUB_USER_TOKEN: ${{ secrets.DEPLOYBOT_REPO_READ_WRITE_TOKEN }}
 ```

--- a/docs/automatic-release.md
+++ b/docs/automatic-release.md
@@ -48,7 +48,7 @@ jobs:
 |------------------------------|----------|---------|-----------------------------------------------------------------------------------------------------|
 | `GITHUB_USER_EMAIL`          | false    | `''`    | Email address for the GitHub user configuration                                                     |
 | `GITHUB_USER_NAME`           | false    | `''`    | Username for the GitHub user configuration                                                          |
-| `GITHUB_USER_SSH_KEY`        | false    | `''`    | Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`                        |
+| `GITHUB_USER_SSH_KEY`        | false    | `''`    | Private SSH key associated with the GitHub user for the token passed as `GITHUB_USER_TOKEN`         |
 | `GITHUB_USER_SSH_PUBLIC_KEY` | false    | `''`    | Public SSH key associated with the GitHub user for the token passed as `GITHUB_USER_TOKEN`          |
 | `GITHUB_USER_TOKEN`          | false    | `''`    | Authentication token with write permission needed by the release bot (falls back to `GITHUB_TOKEN`) |
 

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -114,13 +114,51 @@ This is not the simplest possible example, but it showcases all the recommendati
 
 ## Secrets
 
-| Name                  | Description                                                                  |
-|-----------------------|------------------------------------------------------------------------------|
-| `NPM_REGISTRY_TOKEN`  | Authentication for the private npm registry                                  |
-| `GITHUB_USER_EMAIL`   | Email address for the GitHub user configuration                              |
-| `GITHUB_USER_NAME`    | Username for the GitHub user configuration                                   |
-| `GITHUB_USER_SSH_KEY` | Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME` |
-| `ENV_VARS`            | Additional environment variables as a JSON formatted object                  |
+| Name                         | Description                                                                  |
+|------------------------------|------------------------------------------------------------------------------|
+| `NPM_REGISTRY_TOKEN`         | Authentication for the private npm registry                                  |
+| `GITHUB_USER_EMAIL`          | Email address for the GitHub user configuration                              |
+| `GITHUB_USER_NAME`           | Username for the GitHub user configuration                                   |
+| `GITHUB_USER_SSH_KEY`        | Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME` |
+| `GITHUB_USER_SSH_PUBLIC_KEY` | Public SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`  |
+| `ENV_VARS`                   | Additional environment variables as a JSON formatted object                  |
+
+**Example with signed commits using SSH key:**
+
+```yml
+name: Build and push assets
+
+on:
+  workflow_dispatch:
+  push:
+    tags: [ '*' ]
+    branches: [ '*' ]
+    # Don't include paths if BUILT_BRANCH_NAME or RELEASE_BRANCH_NAME are defined
+    paths:
+      - '**workflows/build-and-push-assets.yml' # the workflow file itself
+      - '**.ts'
+      - '**.scss'
+      - '**.js'
+      - '**package.json'
+      - '**tsconfig.json'
+      - '**yarn.lock'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  build-assets:
+    uses: inpsyde/reusable-workflows/.github/workflows/build-and-push-assets.yml@main
+    with:
+      BUILT_BRANCH_NAME: ${{ github.ref_name }}-built # Optionally, to push compiled assets to built branch
+      RELEASE_BRANCH_NAME: release # Optionally, to move tags to release branch
+    secrets:
+      GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
+      GITHUB_USER_NAME: ${{ secrets.INPSYDE_BOT_USER }}
+      GITHUB_USER_SSH_KEY: ${{ secrets.INPSYDE_BOT_SSH_PRIVATE_KEY }}
+      GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.INPSYDE_BOT_SSH_PUBLIC_KEY }}
+      NPM_REGISTRY_TOKEN: ${{ secrets.DEPLOYBOT_PACKAGES_READ_ACCESS_TOKEN }}
+```
 
 ## FAQ
 

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -81,8 +81,8 @@ jobs:
       BUILT_BRANCH_NAME: ${{ github.ref_name }}-built # Optionally, to push compiled assets to built branch
       RELEASE_BRANCH_NAME: release # Optionally, to move tags to release branch
     secrets:
-      GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
-      GITHUB_USER_NAME: ${{ secrets.INPSYDE_BOT_USER }}
+      GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
+      GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}
       NPM_REGISTRY_TOKEN: ${{ secrets.DEPLOYBOT_PACKAGES_READ_ACCESS_TOKEN }}
 ```
 
@@ -153,10 +153,10 @@ jobs:
       BUILT_BRANCH_NAME: ${{ github.ref_name }}-built # Optionally, to push compiled assets to built branch
       RELEASE_BRANCH_NAME: release # Optionally, to move tags to release branch
     secrets:
-      GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
-      GITHUB_USER_NAME: ${{ secrets.INPSYDE_BOT_USER }}
-      GITHUB_USER_SSH_KEY: ${{ secrets.INPSYDE_BOT_SSH_PRIVATE_KEY }}
-      GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.INPSYDE_BOT_SSH_PUBLIC_KEY }}
+      GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
+      GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}
+      GITHUB_USER_SSH_KEY: ${{ secrets.DEPLOYBOT_SSH_PRIVATE_KEY }}
+      GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.DEPLOYBOT_SSH_PUBLIC_KEY }}
       NPM_REGISTRY_TOKEN: ${{ secrets.DEPLOYBOT_PACKAGES_READ_ACCESS_TOKEN }}
 ```
 
@@ -224,8 +224,8 @@ jobs:
       ASSETS_TARGET_PATHS: "./assets ./modules/Foo/assets ./modules/Bar/assets"
       ASSETS_TARGET_FILES: "./my-generated-file.txt ./LICENSE"
     secrets:
-      GITHUB_USER_EMAIL: ${{ secrets.INPSYDE_BOT_EMAIL }}
-      GITHUB_USER_NAME: ${{ secrets.INPSYDE_BOT_USER }}
+      GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
+      GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}
       ENV_VARS: >-
         [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
 ```


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Update the `automatic-release` and the `build-and-push-assets` workflows to allow for sining commits with an SSH key (pair).

**What is the current behavior?** (You can also link to an open issue here)

Git commits made during the `automatic-release` or the `build-and-push-assets` workflow are not signed.

**What is the new behavior (if this is a feature change)?**

Git commits made during the `automatic-release` or the `build-and-push-assets` workflow **can** be signed with an optional SSH key. See the updated docs for examples.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:
