### PR TITLE
Do not persist credentials for release workflow

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
           ssh-key: ${{ env.GITHUB_USER_SSH_KEY }}
 
       - name: Set up SSH


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This fixes a regression where the new config for signed commits has accidentally removed the `persist-credentials: false` config that is contextually required by `semantic-release`.

**What is the current behavior?** (You can also link to an open issue here)

Depending on branch restrictions and secrets passed to the `automatic-release` workflow, the commits attempted by the release bot may be blocked, and thus the worklow/release fails.

**What is the new behavior (if this is a feature change)?**

Regardless of the way you authenticate, and also for signed and unsigned commits, the release will "just work".

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:
