### PR TITLE
Defensive git

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -228,7 +228,7 @@ jobs:
 
       - name: Git pull on re-run
         if: ${{ (github.run_attempt > 1) && (github.ref_type != 'tag') }}
-        run: git show-ref -q refs/remotes/origin/$(git branch --show-current) && git pull
+        run: git show-ref -q refs/remotes/origin/$(git branch --show-current) && git pull || true
 
       - name: Checkout and merge the release branch
         if: ${{ github.ref_type == 'tag' && env.RELEASE_BRANCH_ENABLED == 'yes' }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -223,18 +223,18 @@ jobs:
       - name: Checkout and merge the built branch
         if: ${{ github.ref_type == 'branch' }}
         run: |
-          git checkout ${{ env.BUILT_BRANCH_NAME }} || git checkout -b ${{ env.BUILT_BRANCH_NAME }}
+          git show-ref -q refs/remotes/origin/${{ env.BUILT_BRANCH_NAME }} && git checkout ${{ env.BUILT_BRANCH_NAME }} || git checkout -b ${{ env.BUILT_BRANCH_NAME }}
           git merge ${{ github.ref_name }}
 
       - name: Git pull on re-run
         if: ${{ (github.run_attempt > 1) && (github.ref_type != 'tag') }}
-        run: git pull
+        run: git show-ref -q refs/remotes/origin/$(git branch --show-current) && git pull
 
       - name: Checkout and merge the release branch
         if: ${{ github.ref_type == 'tag' && env.RELEASE_BRANCH_ENABLED == 'yes' }}
         run: |
           git checkout ${{ github.event.repository.default_branch }}
-          git checkout ${{ inputs.RELEASE_BRANCH_NAME }} || git checkout -b ${{ inputs.RELEASE_BRANCH_NAME }}
+          git show-ref -q refs/remotes/origin/${{ inputs.RELEASE_BRANCH_NAME }} && git checkout ${{ inputs.RELEASE_BRANCH_NAME }} || git checkout -b ${{ inputs.RELEASE_BRANCH_NAME }}
           git merge ${{ github.event.repository.default_branch }}
 
       - name: Checkout temporary tag branch


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Be more defensive when attempting to checkout or pull a potentially non-existing remote branch.
- Instead of doing `git checkout <BRANCH> || git checkout -b <BRANCH>`, which pollutes the workflow log, check if the branch exists (and then check it out), or create it in the CI.
- Only pull a branch that exists (on the remote).

**What is the current behavior?** (You can also link to an open issue here)

- The `Git pull on re-run` step fails in case the target branch does not exist yet.
- The logic in the `Checkout and merge the built branch` and `Checkout and merge the release branch` steps is not straightforward and will print warnings to the terminal if the target branch does nto exist yet.

**What is the new behavior (if this is a feature change)?**

- Everything works without warnings or errors/failures.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



**Other information**:

Closes #140.