### PR TITLE
Remove deprecated `BUILT_BRANCH_SUFFIX` input

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -202,7 +202,7 @@ jobs:
       - name: Set branch environment variables
         if: ${{ github.ref_type == 'branch' }}
         run: |
-          echo "BUILT_BRANCH_NAME=${{ inputs.BUILT_BRANCH_NAME && inputs.BUILT_BRANCH_NAME }}" >> $GITHUB_ENV
+          echo "BUILT_BRANCH_NAME=${{ inputs.BUILT_BRANCH_NAME && inputs.BUILT_BRANCH_NAME || github.ref_name }}" >> $GITHUB_ENV
 
       - name: Set tag environment variables
         if: ${{ github.ref_type == 'tag' }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -279,8 +279,11 @@ jobs:
           git add -A
           git commit -m "[BOT] Add compiled assets for #${{ github.ref }}" --no-verify || ((echo "NO_CHANGES=yes" >> $GITHUB_ENV) && (echo "No changes to commit"))
 
+#      The logic should be like the following:
+#      If we have changes in our assets we commit and push them.
+#      If we push not to the same branch, we always push commits (because they originated from the development branch).
       - name: Git push for branch
-        if: ${{ github.ref_type == 'branch' && (env.NO_CHANGES != 'yes' || inputs.BUILT_BRANCH_NAME != '') }}
+        if: ${{ github.ref_type == 'branch' && (env.NO_CHANGES != 'yes') }}
         run: git push
 
       - name: Git push for tag

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -279,11 +279,8 @@ jobs:
           git add -A
           git commit -m "[BOT] Add compiled assets for #${{ github.ref }}" --no-verify || ((echo "NO_CHANGES=yes" >> $GITHUB_ENV) && (echo "No changes to commit"))
 
-#      The logic should be like the following:
-#      If we have changes in our assets we commit and push them.
-#      If we push not to the same branch, we always push commits (because they originated from the development branch).
       - name: Git push for branch
-        if: ${{ github.ref_type == 'branch' && (env.NO_CHANGES != 'yes') }}
+        if: ${{ github.ref_type == 'branch' && (env.NO_CHANGES != 'yes' || inputs.BUILT_BRANCH_NAME != '') }}
         run: git push
 
       - name: Git push for tag

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -53,11 +53,6 @@ on:
         default: ''
         required: false
         type: string
-      BUILT_BRANCH_SUFFIX:
-        description: Suffix to calculate the target branch for pushing assets on the `branch` event (deprecated).
-        type: string
-        default: ''
-        required: false
       BUILT_BRANCH_NAME:
         description: Sets the target branch for pushing assets on the `branch` event.
         type: string
@@ -152,11 +147,6 @@ jobs:
       LOCK_FILE: ''                                    # we'll override after checking files
       NO_CHANGES: ''                                   # we'll override if no changes to commit
     steps:
-      - name: Deprecation warning
-        if: ${{ inputs.BUILT_BRANCH_SUFFIX != '' }}
-        run: |
-          echo '::warning::The BUILT_BRANCH_SUFFIX input is deprecated and will be removed soon. Please update your workflow to use BUILT_BRANCH_NAME with ${{ github.ref_name }}-built.'
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -212,7 +202,7 @@ jobs:
       - name: Set branch environment variables
         if: ${{ github.ref_type == 'branch' }}
         run: |
-          echo "BUILT_BRANCH_NAME=${{ inputs.BUILT_BRANCH_NAME && inputs.BUILT_BRANCH_NAME || format('{0}{1}', github.ref_name, inputs.BUILT_BRANCH_SUFFIX) }}" >> $GITHUB_ENV
+          echo "BUILT_BRANCH_NAME=${{ inputs.BUILT_BRANCH_NAME && inputs.BUILT_BRANCH_NAME }}" >> $GITHUB_ENV
 
       - name: Set tag environment variables
         if: ${{ github.ref_type == 'tag' }}
@@ -290,7 +280,7 @@ jobs:
           git commit -m "[BOT] Add compiled assets for #${{ github.ref }}" --no-verify || ((echo "NO_CHANGES=yes" >> $GITHUB_ENV) && (echo "No changes to commit"))
 
       - name: Git push for branch
-        if: ${{ github.ref_type == 'branch' && (env.NO_CHANGES != 'yes' || inputs.BUILT_BRANCH_SUFFIX != '' || inputs.BUILT_BRANCH_NAME != '') }}
+        if: ${{ github.ref_type == 'branch' && (env.NO_CHANGES != 'yes' || inputs.BUILT_BRANCH_NAME != '') }}
         run: git push
 
       - name: Git push for tag

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -106,7 +106,6 @@ This is not the simplest possible example, but it showcases all the recommendati
 | `MODE`                | `''`                          | Mode for compiling assets (`prod` or `dev`)                                                                                     |
 | `ASSETS_TARGET_PATHS` | `'./assets'`                  | Space-separated list of target directory paths for compiled assets                                                              |
 | `ASSETS_TARGET_FILES` | `''`                          | Space-separated list of target file paths for compiled assets                                                                   |
-| `BUILT_BRANCH_SUFFIX` | `''`                          | :warning: deprecated - Suffix to calculate the target branch for pushing assets on the `branch` event                           |
 | `BUILT_BRANCH_NAME`   | `''`                          | Sets the target branch for pushing assets on the `branch` event                                                                 |
 | `RELEASE_BRANCH_NAME` | `''`                          | On tag events, target branch where compiled assets are pushed and the tag is moved to                                           |
 | `PHP_VERSION`         | `'8.0'`                       | PHP version with which the PHP tools are to be executed                                                                         |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature
Closes #146 


**What is the current behavior?** (You can also link to an open issue here)
The deprecated `BUILT_BRANCH_SUFFIX` input is present. All calling workflows have been updated to use the newer `BUILT_BRANCH_NAME`.


**What is the new behavior (if this is a feature change)?**
The `BUILT_BRANCH_SUFFIX` input is removed.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, but no package uses the deprecated input anymore.


**Other information**:
I haven't tested this, so I'd appreciate it if one of you could give this a spin. Thanks!