### PR TITLE
Use npm as default package manager

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -146,6 +146,15 @@ jobs:
       TAG_BRANCH_NAME: ''                              # we'll override if the push is for tag
       NO_CHANGES: ''                                   # we'll override if no changes to commit
     steps:
+      - name: PACKAGE_MANAGER deprecation warning
+        if: ${{ inputs.PACKAGE_MANAGER != '' }}
+        run: |
+          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]; then
+            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please remove it. The workflow already uses npm by default."
+          else
+            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please update your workflow to use npm."          
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -20,7 +20,7 @@ on:
         type: string
       PACKAGE_MANAGER:
         description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
-        default: 'yarn'
+        default: 'npm'
         required: false
         type: string
       WORKING_DIRECTORY:

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -20,7 +20,7 @@ on:
         type: string
       PACKAGE_MANAGER:
         description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
-        default: 'yarn'
+        default: 'npm'
         required: false
         type: string
       PHP_VERSION:

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -71,6 +71,15 @@ jobs:
       GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
     steps:
+      - name: PACKAGE_MANAGER deprecation warning
+        if: ${{ inputs.PACKAGE_MANAGER != '' }}
+        run: |
+          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]; then
+            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please remove it. The workflow already uses npm by default."
+          else
+            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please update your workflow to use npm."          
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -20,7 +20,7 @@ on:
         type: string
       PACKAGE_MANAGER:
         description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
-        default: 'yarn'
+        default: 'npm'
         required: false
         type: string
       COMPOSER_ARGS:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -147,6 +147,15 @@ jobs:
     outputs:
       artifact: ${{ steps.set-artifact-name.outputs.artifact }}
     steps:
+      - name: PACKAGE_MANAGER deprecation warning
+        if: ${{ inputs.PACKAGE_MANAGER != '' }}
+        run: |
+          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]; then
+            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please remove it. The workflow already uses npm by default."
+          else
+            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please update your workflow to use npm."          
+          fi
+
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
@@ -229,7 +238,7 @@ jobs:
         if: steps.composer-tools.outputs.rector == '0'
         run: |
           rector
-          
+
       - name: Run PHP-Scoper
         if: steps.composer-tools.outputs.php-scoper == '0'
         run: |

--- a/.github/workflows/ddev-playwright.yml
+++ b/.github/workflows/ddev-playwright.yml
@@ -16,11 +16,11 @@ on:
         required: false
         type: string
       PLAYWRIGHT_INSTALL_CMD:
-        description: The command for installing Playwright and its dependencies, such as `yarn install && yarn playwright install --with-deps` or `ddev pw-install-host` from inpsyde/ddev-wordpress-plugin-template.
+        description: The command for installing Playwright and its dependencies, such as `npm install && npx playwright install --with-deps` or `ddev pw-install-host` from inpsyde/ddev-wordpress-plugin-template.
         required: true
         type: string
       PLAYWRIGHT_RUN_CMD:
-        description: The command for running Playwright tests, such as `yarn playwright test` or `ddev pw-host test` from inpsyde/ddev-wordpress-plugin-template.
+        description: The command for running Playwright tests, such as `npx playwright test` or `ddev pw-host test` from inpsyde/ddev-wordpress-plugin-template.
         required: true
         type: string
       PLAYWRIGHT_DIR:

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -57,6 +57,15 @@ jobs:
       GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
     steps:
+      - name: PACKAGE_MANAGER deprecation warning
+        if: ${{ inputs.PACKAGE_MANAGER != '' }}
+        run: |
+          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]; then
+            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please remove it. The workflow already uses npm by default."
+          else
+            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please update your workflow to use npm."          
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -20,7 +20,7 @@ on:
         type: string
       PACKAGE_MANAGER:
         description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
-        default: 'yarn'
+        default: 'npm'
         required: false
         type: string
       NODE_OPTIONS:

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -20,7 +20,7 @@ on:
         type: string
       PACKAGE_MANAGER:
         description: Package manager with which the dependencies should be installed (`npm` or `yarn`).
-        default: 'yarn'
+        default: 'npm'
         required: false
         type: string
       LINT_TOOLS:

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -78,6 +78,15 @@ jobs:
       GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
     steps:
+      - name: PACKAGE_MANAGER deprecation warning
+        if: ${{ inputs.PACKAGE_MANAGER != '' }}
+        run: |
+          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]; then
+            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please remove it. The workflow already uses npm by default."
+          else
+            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please update your workflow to use npm."          
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -48,7 +48,6 @@ jobs:
 | `NODE_OPTIONS`        | `''`                                                          | Space-separated list of command-line Node options                                              |
 | `NODE_VERSION`        | `18`                                                          | Node version with which the assets will be compiled                                            |
 | `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                               | Domain of the private npm registry                                                             |
-| `PACKAGE_MANAGER`     | `'yarn'`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`)              |
 | `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer when gathering production dependencies                     |
 | `PHP_VERSION`         | `'8.0'`                                                       | PHP version to use when gathering production dependencies                                      |
 | `PHP_VERSION_BUILD`   | `'8.0'`                                                       | PHP version to use when executing build tools                                                  |

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -39,21 +39,21 @@ jobs:
 
 ### Inputs
 
-| Name                  | Default                                                       | Description                                                                                    |
-|-----------------------|---------------------------------------------------------------|------------------------------------------------------------------------------------------------|
-| `NODE_OPTIONS`        | `''`                                                          | Space-separated list of command-line Node options                                              |
-| `NODE_VERSION`        | `18`                                                          | Node version with which the assets will be compiled                                            |
-| `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                               | Domain of the private npm registry                                                             |
-| `PACKAGE_MANAGER`     | `"yarn"`                                                      | Package manager with which the dependencies should be installed (`npm` or `yarn`)              |
+| Name                  | Default                                                      | Description                                                                                    |
+|-----------------------|--------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| `NODE_OPTIONS`        | `''`                                                         | Space-separated list of command-line Node options                                              |
+| `NODE_VERSION`        | `18`                                                         | Node version with which the assets will be compiled                                            |
+| `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                              | Domain of the private npm registry                                                             |
+| `PACKAGE_MANAGER`     | `"npm"`                                                       | Package manager with which the dependencies should be installed (`npm` or `yarn`)              |
 | `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer when gathering production dependencies |
-| `PHP_VERSION`         | `"8.0"`                                                       | PHP version to use when gathering production dependencies                                      |
-| `PHP_VERSION_BUILD`   | `"8.0"`                                                       | PHP version to use when executing build tools                                                  |
-| `ARCHIVE_NAME`        | `""`                                                          | The name of the zip archive (falls back to the repository name)                                |
-| `PLUGIN_MAIN_FILE`    | `"index.php"`                                                 | The name of the main plugin file                                                               |
-| `PLUGIN_FOLDER_NAME`  | `""`                                                          | The name of the plugin folder (falls back to the archive name, if set, or the repository name) |
-| `PLUGIN_VERSION`      | -                                                             | The new plugin version                                                                         |
-| `PRE_SCRIPT`          | `""`                                                          | Run custom shell code before creating the release archive                                      |
-| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`                                             | Set of arguments passed to Composer Asset Compiler                                             |
+| `PHP_VERSION`         | `"8.0"`                                                      | PHP version to use when gathering production dependencies                                      |
+| `PHP_VERSION_BUILD`   | `"8.0"`                                                      | PHP version to use when executing build tools                                                  |
+| `ARCHIVE_NAME`        | `""`                                                         | The name of the zip archive (falls back to the repository name)                                |
+| `PLUGIN_MAIN_FILE`    | `"index.php"`                                                | The name of the main plugin file                                                               |
+| `PLUGIN_FOLDER_NAME`  | `""`                                                         | The name of the plugin folder (falls back to the archive name, if set, or the repository name) |
+| `PLUGIN_VERSION`      | -                                                            | The new plugin version                                                                         |
+| `PRE_SCRIPT`          | `""`                                                         | Run custom shell code before creating the release archive                                      |
+| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`                                            | Set of arguments passed to Composer Asset Compiler                                             |
 
 #### A note on `PLUGIN_VERSION`
 

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -46,7 +46,6 @@ jobs:
 | `NODE_OPTIONS`        | `''`                                                         | Space-separated list of command-line Node options                                              |
 | `NODE_VERSION`        | `18`                                                         | Node version with which the assets will be compiled                                            |
 | `NPM_REGISTRY_DOMAIN` | `"https://npm.pkg.github.com/"`                              | Domain of the private npm registry                                                             |
-| `PACKAGE_MANAGER`     | `"npm"`                                                       | Package manager with which the dependencies should be installed (`npm` or `yarn`)              |
 | `COMPOSER_ARGS`       | `'--no-dev --no-scripts --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer when gathering production dependencies |
 | `PHP_VERSION`         | `"8.0"`                                                      | PHP version to use when gathering production dependencies                                      |
 | `PHP_VERSION_BUILD`   | `"8.0"`                                                      | PHP version to use when executing build tools                                                  |

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -25,7 +25,6 @@ jobs:
 | `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                 |
 | `NODE_VERSION`        | `18`                          | Node version with which the assets will be compiled                               |
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                |
-| `PACKAGE_MANAGER`     | `npm`                         | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `PHP_VERSION`         | `"8.0"`                       | PHP version with which the assets compilation is to be executed                   |
 | `COMPOSER_ARGS`       | `'--prefer-dist'`             | Set of arguments passed to Composer                                               |
 | `COMPILE_ASSETS_ARGS` | `'-v --env=root'`             | Set of arguments passed to Composer Asset Compiler                                |

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -21,15 +21,14 @@ jobs:
 
 ### Inputs
 
-| Name                  | Default                         | Description                                                                       |
-|-----------------------|---------------------------------|-----------------------------------------------------------------------------------|
-| `NODE_OPTIONS`        | `''`                            | Space-separated list of command-line Node options                                 |
-| `NODE_VERSION`        | `18`                            | Node version with which the assets will be compiled                               |
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                |
-| `PACKAGE_MANAGER`     | `'yarn'`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
-| `PHP_VERSION`         | `'8.0'`                         | PHP version with which the assets compilation is to be executed                   |
-| `COMPOSER_ARGS`       | `'--prefer-dist'`               | Set of arguments passed to Composer                                               |
-| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`               | Set of arguments passed to Composer Asset Compiler                                |
+| Name                  | Default                         | Description                                                     |
+|-----------------------|---------------------------------|-----------------------------------------------------------------|
+| `NODE_OPTIONS`        | `''`                            | Space-separated list of command-line Node options               |
+| `NODE_VERSION`        | `18`                            | Node version with which the assets will be compiled             |
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                              |
+| `PHP_VERSION`         | `'8.0'`                         | PHP version with which the assets compilation is to be executed |
+| `COMPOSER_ARGS`       | `'--prefer-dist'`               | Set of arguments passed to Composer                             |
+| `COMPILE_ASSETS_ARGS` | `'-v --env=root'`               | Set of arguments passed to Composer Asset Compiler              |
 
 ### Secrets
 

--- a/docs/assets-compilation.md
+++ b/docs/assets-compilation.md
@@ -25,7 +25,7 @@ jobs:
 | `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                 |
 | `NODE_VERSION`        | `18`                          | Node version with which the assets will be compiled                               |
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                |
-| `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
+| `PACKAGE_MANAGER`     | `npm`                         | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `PHP_VERSION`         | `"8.0"`                       | PHP version with which the assets compilation is to be executed                   |
 | `COMPOSER_ARGS`       | `'--prefer-dist'`             | Set of arguments passed to Composer                                               |
 | `COMPILE_ASSETS_ARGS` | `'-v --env=root'`             | Set of arguments passed to Composer Asset Compiler                                |

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -103,7 +103,6 @@ the workflow.
 | `NODE_OPTIONS`        | `''`                            | Space-separated list of command-line Node options                                                                               |
 | `NODE_VERSION`        | `18`                            | Node version with which the assets will be compiled                                                                             |
 | `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                                                              |
-| `PACKAGE_MANAGER`     | `'yarn'`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`)                                               |
 | `WORKING_DIRECTORY`   | `'./'`                          | Working directory path                                                                                                          |
 | `COMPILE_SCRIPT_PROD` | `'build'`                       | Script added to `npm run` or `yarn` to build production assets                                                                  |
 | `COMPILE_SCRIPT_DEV`  | `'build:dev'`                   | Script added to `npm run` or `yarn` to build development assets                                                                 |

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -68,8 +68,8 @@ on:
       - '**.scss'
       - '**.js'
       - '**package.json'
+      - '**package-lock.json'
       - '**tsconfig.json'
-      - '**yarn.lock'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -99,7 +99,7 @@ This is not the simplest possible example, but it showcases all the recommendati
 | `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                                                               |
 | `NODE_VERSION`        | `18`                          | Node version with which the assets will be compiled                                                                             |
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                                                              |
-| `PACKAGE_MANAGER`     | `yarn`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`)                                               |
+| `PACKAGE_MANAGER`     | `npm`                         | Package manager with which the dependencies should be installed (`npm` or `yarn`)                                               |
 | `WORKING_DIRECTORY`   | `'./'`                        | Working directory path                                                                                                          |
 | `COMPILE_SCRIPT_PROD` | `'build'`                     | Script added to `npm run` or `yarn` to build production assets                                                                  |
 | `COMPILE_SCRIPT_DEV`  | `'build:dev'`                 | Script added to `npm run` or `yarn` to build development assets                                                                 |
@@ -140,8 +140,8 @@ on:
       - '**.scss'
       - '**.js'
       - '**package.json'
+      - '**package-lock.json'
       - '**tsconfig.json'
-      - '**yarn.lock'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -94,21 +94,20 @@ This is not the simplest possible example, but it showcases all the recommendati
 
 ### Inputs
 
-| Name                  | Default                       | Description                                                                                                                     |
-|-----------------------|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
-| `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                                                               |
-| `NODE_VERSION`        | `18`                          | Node version with which the assets will be compiled                                                                             |
-| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                                                              |
-| `PACKAGE_MANAGER`     | `npm`                         | Package manager with which the dependencies should be installed (`npm` or `yarn`)                                               |
-| `WORKING_DIRECTORY`   | `'./'`                        | Working directory path                                                                                                          |
-| `COMPILE_SCRIPT_PROD` | `'build'`                     | Script added to `npm run` or `yarn` to build production assets                                                                  |
-| `COMPILE_SCRIPT_DEV`  | `'build:dev'`                 | Script added to `npm run` or `yarn` to build development assets                                                                 |
-| `MODE`                | `''`                          | Mode for compiling assets (`prod` or `dev`)                                                                                     |
-| `ASSETS_TARGET_PATHS` | `'./assets'`                  | Space-separated list of target directory paths for compiled assets                                                              |
-| `ASSETS_TARGET_FILES` | `''`                          | Space-separated list of target file paths for compiled assets                                                                   |
-| `BUILT_BRANCH_NAME`   | `''`                          | Sets the target branch for pushing assets on the `branch` event                                                                 |
-| `RELEASE_BRANCH_NAME` | `''`                          | On tag events, target branch where compiled assets are pushed and the tag is moved to                                           |
-| `PHP_VERSION`         | `'8.0'`                       | PHP version with which the PHP tools are to be executed                                                                         |
+| Name                  | Default                       | Description                                                                                                                    |
+|-----------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `NODE_OPTIONS`        | `''`                          | Space-separated list of command-line Node options                                                                              |
+| `NODE_VERSION`        | `18`                          | Node version with which the assets will be compiled                                                                            |
+| `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/` | Domain of the private npm registry                                                                                             |
+| `WORKING_DIRECTORY`   | `'./'`                        | Working directory path                                                                                                         |
+| `COMPILE_SCRIPT_PROD` | `'build'`                     | Script added to `npm run` to build production assets                                                                  |
+| `COMPILE_SCRIPT_DEV`  | `'build:dev'`                 | Script added to `npm run` to build development assets                                                                 |
+| `MODE`                | `''`                          | Mode for compiling assets (`prod` or `dev`)                                                                                    |
+| `ASSETS_TARGET_PATHS` | `'./assets'`                  | Space-separated list of target directory paths for compiled assets                                                             |
+| `ASSETS_TARGET_FILES` | `''`                          | Space-separated list of target file paths for compiled assets                                                                  |
+| `BUILT_BRANCH_NAME`   | `''`                          | Sets the target branch for pushing assets on the `branch` event                                                                |
+| `RELEASE_BRANCH_NAME` | `''`                          | On tag events, target branch where compiled assets are pushed and the tag is moved to                                          |
+| `PHP_VERSION`         | `'8.0'`                       | PHP version with which the PHP tools are to be executed                                                                        |
 | `PHP_TOOLS`           | `''`                          | PHP tools supported by [shivammathur/setup-php](https://github.com/shivammathur/setup-php#wrench-tools-support) to be installed |
 
 ## Secrets

--- a/docs/ddev-playwright.md
+++ b/docs/ddev-playwright.md
@@ -7,8 +7,8 @@ This reusable workflow:
 3. If the Ngrok auth token is provided, it sets up Ngrok. Ngrok can be needed if some third-party service, e.g., webhooks, must access the website.
    1. Launches Ngrok, using `vendor/bin/ddev-share` from [inpsyde/ddev-tools](https://github.com/inpsyde/ddev-tools) by default.
    2. Saves the URL to the specified env variable, `BASEURL` by default.
-4. Installs Playwright and its dependencies via the provided command, such as `yarn install && yarn playwright install --with-deps` or `ddev pw-install-host` from [inpsyde/ddev-wordpress-plugin-template](https://github.com/inpsyde/ddev-wordpress-plugin-template).
-5. Runs Playwright tests via the provided command, such as `yarn playwright test` or `ddev pw-host test` from [inpsyde/ddev-wordpress-plugin-template](https://github.com/inpsyde/ddev-wordpress-plugin-template).
+4. Installs Playwright and its dependencies via the provided command, such as `npm install && npx playwright install --with-deps` or `ddev pw-install-host` from [inpsyde/ddev-wordpress-plugin-template](https://github.com/inpsyde/ddev-wordpress-plugin-template).
+5. Runs Playwright tests via the provided command, such as `npx playwright test` or `ddev pw-host test` from [inpsyde/ddev-wordpress-plugin-template](https://github.com/inpsyde/ddev-wordpress-plugin-template).
 
 It is possible to add any env variables for the "host" and for DDEV.
 
@@ -54,16 +54,16 @@ jobs:
 
 ### Inputs
 
-| Name                     | Default                   | Description                                                                                                                                                                                                                                          |
-|--------------------------|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `PHP_VERSION`            | `""`                      | PHP version which will override the version set in the DDEV config                                                                                                                                                                                   |
-| `NODE_VERSION`           | `""`                      | Node version which will override the version set in the DDEV config                                                                                                                                                                                  |
-| `DDEV_ORCHESTRATE_CMD`   | `""`                      | The command for setting up the DDEV website, such as `ddev orchestrate` from [inpsyde/ddev-wordpress-plugin-template](https://github.com/inpsyde/ddev-wordpress-plugin-template)                                                                     |
-| `PLAYWRIGHT_INSTALL_CMD` | `""`                      | The command for installing Playwright and its deps, such as `yarn install && yarn playwright install --with-deps` or `ddev pw-install-host` from [inpsyde/ddev-wordpress-plugin-template](https://github.com/inpsyde/ddev-wordpress-plugin-template) |
-| `PLAYWRIGHT_RUN_CMD`     | `""`                      | The command for running Playwright tests, such as `yarn playwright test` or `ddev pw-host test` from [inpsyde/ddev-wordpress-plugin-template](https://github.com/inpsyde/ddev-wordpress-plugin-template)                                             |
-| `PLAYWRIGHT_DIR`         | `"tests/Playwright"`      | The path to the Playwright project                                                                                                                                                                                                                   | 
-| `NGROK_START_CMD`        | `"vendor/bin/ddev-share"` | The command for starting Ngrok, such as `ddev-share` from [inpsyde/ddev-tools](https://github.com/inpsyde/ddev-tools)                                                                                                                                |
-| `BASEURL_ENV_NAME`       | `"BASEURL"`               | The name of the env variable with the base URL for Playwright, used for overwriting it with the URL from Ngrok                                                                                                                                       |
+| Name                     | Default                   | Description                                                                                                                                                                                                                                        |
+|--------------------------|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `PHP_VERSION`            | `""`                      | PHP version which will override the version set in the DDEV config                                                                                                                                                                                 |
+| `NODE_VERSION`           | `""`                      | Node version which will override the version set in the DDEV config                                                                                                                                                                                |
+| `DDEV_ORCHESTRATE_CMD`   | `""`                      | The command for setting up the DDEV website, such as `ddev orchestrate` from [inpsyde/ddev-wordpress-plugin-template](https://github.com/inpsyde/ddev-wordpress-plugin-template)                                                                   |
+| `PLAYWRIGHT_INSTALL_CMD` | `""`                      | The command for installing Playwright and its deps, such as `npm install && npx playwright install --with-deps` or `ddev pw-install-host` from [inpsyde/ddev-wordpress-plugin-template](https://github.com/inpsyde/ddev-wordpress-plugin-template) |
+| `PLAYWRIGHT_RUN_CMD`     | `""`                      | The command for running Playwright tests, such as `npx playwright test` or `ddev pw-host test` from [inpsyde/ddev-wordpress-plugin-template](https://github.com/inpsyde/ddev-wordpress-plugin-template)                                            |
+| `PLAYWRIGHT_DIR`         | `"tests/Playwright"`      | The path to the Playwright project                                                                                                                                                                                                                 | 
+| `NGROK_START_CMD`        | `"vendor/bin/ddev-share"` | The command for starting Ngrok, such as `ddev-share` from [inpsyde/ddev-tools](https://github.com/inpsyde/ddev-tools)                                                                                                                              |
+| `BASEURL_ENV_NAME`       | `"BASEURL"`               | The name of the env variable with the base URL for Playwright, used for overwriting it with the URL from Ngrok                                                                                                                                     |
 
 ## Secrets
 

--- a/docs/js.md
+++ b/docs/js.md
@@ -25,7 +25,7 @@ jobs:
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/`                      | Domain of the private npm registry                                                |
 | `NODE_VERSION`        | `18`                                               | Node version with which the unit tests are to be executed                         |
 | `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                                                   |
-| `PACKAGE_MANAGER`     | `yarn`                                             | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
+| `PACKAGE_MANAGER`     | `npm`                                              | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 
 **Note**: The default `github-actions` reporter requires Jest 28 or higher.
 

--- a/docs/js.md
+++ b/docs/js.md
@@ -25,7 +25,6 @@ jobs:
 | `NPM_REGISTRY_DOMAIN` | `https://npm.pkg.github.com/`                      | Domain of the private npm registry                                                |
 | `NODE_VERSION`        | `18`                                               | Node version with which the unit tests are to be executed                         |
 | `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                                                   |
-| `PACKAGE_MANAGER`     | `npm`                                              | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 
 **Note**: The default `github-actions` reporter requires Jest 28 or higher.
 

--- a/docs/js.md
+++ b/docs/js.md
@@ -20,12 +20,11 @@ jobs:
 
 #### Inputs
 
-| Name                  | Default                                            | Description                                                                       |
-|-----------------------|----------------------------------------------------|-----------------------------------------------------------------------------------|
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                    | Domain of the private npm registry                                                |
-| `NODE_VERSION`        | `18`                                               | Node version with which the unit tests are to be executed                         |
-| `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                                                   |
-| `PACKAGE_MANAGER`     | `'yarn'`                                           | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
+| Name                  | Default                                            | Description                                               |
+|-----------------------|----------------------------------------------------|-----------------------------------------------------------|
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                    | Domain of the private npm registry                        |
+| `NODE_VERSION`        | `18`                                               | Node version with which the unit tests are to be executed |
+| `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                           |
 
 **Note**: The default `github-actions` reporter requires Jest 28 or higher.
 

--- a/docs/wp-scripts.md
+++ b/docs/wp-scripts.md
@@ -26,7 +26,7 @@ jobs:
 | `NODE_OPTIONS`          | `''`                           | Space-separated list of command-line Node options                                 |
 | `NODE_VERSION`          | `18`                           | Node version with which the assets will be compiled                               |
 | `NPM_REGISTRY_DOMAIN`   | `https://npm.pkg.github.com/`  | Domain of the private npm registry                                                |
-| `PACKAGE_MANAGER`       | `yarn`                         | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
+| `PACKAGE_MANAGER`       | `npm`                          | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `LINT_TOOLS`            | `'["js", "style", "md-docs"]'` | Array of checks to be executed by @wordpress/scripts                              |
 | `ESLINT_ARGS`           | `''`                           | Set of arguments passed to `wp-script lint-js`                                    |
 | `STYLELINT_ARGS`        | `''`                           | Set of arguments passed to `wp-script lint-style`                                 |

--- a/docs/wp-scripts.md
+++ b/docs/wp-scripts.md
@@ -26,7 +26,6 @@ jobs:
 | `NODE_OPTIONS`          | `''`                           | Space-separated list of command-line Node options                                 |
 | `NODE_VERSION`          | `18`                           | Node version with which the assets will be compiled                               |
 | `NPM_REGISTRY_DOMAIN`   | `https://npm.pkg.github.com/`  | Domain of the private npm registry                                                |
-| `PACKAGE_MANAGER`       | `npm`                          | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
 | `LINT_TOOLS`            | `'["js", "style", "md-docs"]'` | Array of checks to be executed by @wordpress/scripts                              |
 | `ESLINT_ARGS`           | `''`                           | Set of arguments passed to `wp-script lint-js`                                    |
 | `STYLELINT_ARGS`        | `''`                           | Set of arguments passed to `wp-script lint-style`                                 |

--- a/docs/wp-scripts.md
+++ b/docs/wp-scripts.md
@@ -22,17 +22,16 @@ jobs:
 
 #### Inputs
 
-| Name                    | Default                         | Description                                                                       |
-|-------------------------|---------------------------------|-----------------------------------------------------------------------------------|
-| `NODE_OPTIONS`          | `''`                            | Space-separated list of command-line Node options                                 |
-| `NODE_VERSION`          | `18`                            | Node version with which the assets will be compiled                               |
-| `NPM_REGISTRY_DOMAIN`   | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                |
-| `PACKAGE_MANAGER`       | `'yarn'`                        | Package manager with which the dependencies should be installed (`npm` or `yarn`) |
-| `LINT_TOOLS`            | `'["js", "style", "md-docs"]'`  | Array of checks to be executed by @wordpress/scripts                              |
-| `ESLINT_ARGS`           | `''`                            | Set of arguments passed to `wp-script lint-js`                                    |
-| `STYLELINT_ARGS`        | `''`                            | Set of arguments passed to `wp-script lint-style`                                 |
-| `MARKDOWNLINT_ARGS`     | `''`                            | Set of arguments passed to `wp-script lint-md-docs`                               |
-| `PACKAGE_JSONLINT_ARGS` | `''`                            | Set of arguments passed to `wp-scripts lint-pkg-json`                             |
+| Name                    | Default                         | Description                                           |
+|-------------------------|---------------------------------|-------------------------------------------------------|
+| `NODE_OPTIONS`          | `''`                            | Space-separated list of command-line Node options     |
+| `NODE_VERSION`          | `18`                            | Node version with which the assets will be compiled   |
+| `NPM_REGISTRY_DOMAIN`   | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                    |
+| `LINT_TOOLS`            | `'["js", "style", "md-docs"]'`  | Array of checks to be executed by @wordpress/scripts  |
+| `ESLINT_ARGS`           | `''`                            | Set of arguments passed to `wp-script lint-js`        |
+| `STYLELINT_ARGS`        | `''`                            | Set of arguments passed to `wp-script lint-style`     |
+| `MARKDOWNLINT_ARGS`     | `''`                            | Set of arguments passed to `wp-script lint-md-docs`   |
+| `PACKAGE_JSONLINT_ARGS` | `''`                            | Set of arguments passed to `wp-scripts lint-pkg-json` |
 
 > :information_source: **By default, "pkg-json" is not part of the `LINT_TOOLS` input.**  
 > :information_source: **The `--formatter github` flag is hardcoded into the `wp-script lint-style`


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Refactor

**What is the current behavior?** (You can also link to an open issue here)
Yarn is used as the default package manager.

**What is the new behavior (if this is a feature change)?**
Npm is used as the default package manager. A deprecation warning is displayed for those using the `PACKAGE_MANAGER` input.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
There may be instances where this can cause issues since Yarn and npm are not fully interchangeable.
In such cases, the users can choose to explicitly set the `PACKAGE_MANAGER` to `yarn`.

**Other information**:
Based on the AT decision.