### PR TITLE
Feat/153 make build and push always sync

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -284,11 +284,11 @@ jobs:
         run: git push
 
       - name: Git push for tag
-        if: ${{ github.ref_type == 'tag' && ((env.NO_CHANGES != 'yes' && env.RELEASE_BRANCH_ENABLED == 'no') || (env.RELEASE_BRANCH_ENABLED == 'yes')) }}
+        if: ${{ github.ref_type == 'tag' && (env.NO_CHANGES != 'yes' || env.RELEASE_BRANCH_ENABLED == 'yes') }}
         run: git push
 
       - name: Move tag
-        if: ${{ github.ref_type == 'tag' && ((env.NO_CHANGES != 'yes' && env.RELEASE_BRANCH_ENABLED == 'no') || (env.RELEASE_BRANCH_ENABLED == 'yes')) }}
+        if: ${{ github.ref_type == 'tag' && (env.NO_CHANGES != 'yes' || env.RELEASE_BRANCH_ENABLED == 'yes') }}
         run: |
           git tag -d ${{ env.TAG_NAME }}
           git push origin :refs/tags/${{ env.TAG_NAME }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -284,11 +284,11 @@ jobs:
         run: git push
 
       - name: Git push for tag
-        if: ${{ github.ref_type == 'tag' }}
+        if: ${{ github.ref_type == 'tag' && ((env.NO_CHANGES != 'yes' && env.RELEASE_BRANCH_ENABLED == 'no') || (env.RELEASE_BRANCH_ENABLED == 'yes')) }}
         run: git push
 
       - name: Move tag
-        if: ${{ github.ref_type == 'tag' }}
+        if: ${{ github.ref_type == 'tag' && ((env.NO_CHANGES != 'yes' && env.RELEASE_BRANCH_ENABLED == 'no') || (env.RELEASE_BRANCH_ENABLED == 'yes')) }}
         run: |
           git tag -d ${{ env.TAG_NAME }}
           git push origin :refs/tags/${{ env.TAG_NAME }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -284,11 +284,11 @@ jobs:
         run: git push
 
       - name: Git push for tag
-        if: ${{ github.ref_type == 'tag' && env.RELEASE_BRANCH_ENABLED == 'yes' }}
+        if: ${{ github.ref_type == 'tag' }}
         run: git push
 
       - name: Move tag
-        if: ${{ github.ref_type == 'tag' && env.RELEASE_BRANCH_ENABLED == 'yes' }}
+        if: ${{ github.ref_type == 'tag' }}
         run: |
           git tag -d ${{ env.TAG_NAME }}
           git push origin :refs/tags/${{ env.TAG_NAME }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -280,7 +280,7 @@ jobs:
           git commit -m "[BOT] Add compiled assets for #${{ github.ref }}" --no-verify || ((echo "NO_CHANGES=yes" >> $GITHUB_ENV) && (echo "No changes to commit"))
 
       - name: Git push for branch
-        if: ${{ github.ref_type == 'branch' && (env.NO_CHANGES != 'yes' || inputs.BUILT_BRANCH_NAME != '') }}
+        if: ${{ github.ref_type == 'branch' }}
         run: git push
 
       - name: Git push for tag

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -296,7 +296,7 @@ jobs:
           git push origin --tags
 
       - name: Delete temporary tag branch
-        if: ${{ always() && env.TAG_BRANCH_NAME != '' && (env.NO_CHANGES != 'yes' || env.RELEASE_BRANCH_ENABLED == 'yes') }}
+        if: ${{ always() && env.TAG_BRANCH_NAME != '' && env.NO_CHANGES != 'yes' }}
         run: |
           git checkout --detach
           git branch -d ${{ env.TAG_BRANCH_NAME }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -284,11 +284,11 @@ jobs:
         run: git push
 
       - name: Git push for tag
-        if: ${{ github.ref_type == 'tag' && (env.NO_CHANGES != 'yes' || env.RELEASE_BRANCH_ENABLED == 'yes') }}
+        if: ${{ github.ref_type == 'tag' && env.RELEASE_BRANCH_ENABLED == 'yes' }}
         run: git push
 
       - name: Move tag
-        if: ${{ github.ref_type == 'tag' && (env.NO_CHANGES != 'yes' || env.RELEASE_BRANCH_ENABLED == 'yes') }}
+        if: ${{ github.ref_type == 'tag' && env.RELEASE_BRANCH_ENABLED == 'yes' }}
         run: |
           git tag -d ${{ env.TAG_NAME }}
           git push origin :refs/tags/${{ env.TAG_NAME }}
@@ -296,7 +296,7 @@ jobs:
           git push origin --tags
 
       - name: Delete temporary tag branch
-        if: ${{ always() && (env.TAG_BRANCH_NAME != '' && env.NO_CHANGES != 'yes') }}
+        if: ${{ always() && env.TAG_BRANCH_NAME != '' }}
         run: |
           git checkout --detach
           git branch -d ${{ env.TAG_BRANCH_NAME }}

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -144,7 +144,6 @@ jobs:
       COMPILE_SCRIPT: ''
       TAG_NAME: ''                                     # we'll override if the push is for tag
       TAG_BRANCH_NAME: ''                              # we'll override if the push is for tag
-      LOCK_FILE: ''                                    # we'll override after checking files
       NO_CHANGES: ''                                   # we'll override if no changes to commit
     steps:
       - name: Checkout

--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -296,7 +296,7 @@ jobs:
           git push origin --tags
 
       - name: Delete temporary tag branch
-        if: ${{ always() && env.TAG_BRANCH_NAME != '' }}
+        if: ${{ always() && env.TAG_BRANCH_NAME != '' && (env.NO_CHANGES != 'yes' || env.RELEASE_BRANCH_ENABLED == 'yes') }}
         run: |
           git checkout --detach
           git branch -d ${{ env.TAG_BRANCH_NAME }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR changes a bit the concept of build and push by adding "sync". 
Closes #153 


**What is the current behavior?** (You can also link to an open issue here)
We have realized that we prefer to always push the latest changes to the targeted branch/tag. 
When we introduced a change in the development branch but didn't generate a difference in the build, the workflow was not updating the release branch because the push was not happening due to a condition. This is a problem when trying to create a version that doesn't change any assets. 


**What is the new behavior (if this is a feature change)?**
This change will run the git push when the workflow is triggered on a branch, ensuring we have the latest changes in the release branch.

When it comes to the tag workflow it behaves a bit differently. We are avoiding moving the tag too much times by checking if there are assets changes. 


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It is hard to say, I would say no, it just behaves differently.


**Other information**:
