### PR TITLE
Set timeout for lint-workflows

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   actionlint:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Set a timeout for the `lint-workflows` workflow.

**What is the current behavior?** (You can also link to an open issue here)

No timeout set for the `lint-workflows` workflow.

**What is the new behavior (if this is a feature change)?**

The `lint-workflows` workflow now has a timeout of 5 minutes, just like several other simple softwre quality tooling workflows.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



**Other information**:
