### PR TITLE
Update build-and-push-assets.md - fix basic usage

### DIFF
--- a/docs/build-and-push-assets.md
+++ b/docs/build-and-push-assets.md
@@ -63,7 +63,10 @@ on:
   workflow_dispatch:
   push:
     tags: [ '*' ]
-    branches: [ '*' ]
+    branches:
+      - '*'
+      - '!*-built'
+    
     # Don't include paths if BUILT_BRANCH_NAME or RELEASE_BRANCH_NAME are defined
     paths:
       - '**workflows/build-and-push-assets.yml' # the workflow file itself


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

The basic usage contains `push.branches` with wildcard `*`. This will cause an endless loop because for `main` a `main-built` is created which creates a `main-built-built`. By updating the basic example we still listen to all branches via `*` but now exclude all `*-built` branches for re-triggering the workflow and creating a loop
