### PR TITLE
Update workflows to use actions/upload-artifact@v4

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*  @tyrann0us @Chrico

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-      - "Chrico"
-      - "pablok34"
-      - "tyrann0us"

--- a/.github/workflows/build-assets-compilation.yml
+++ b/.github/workflows/build-assets-compilation.yml
@@ -156,11 +156,13 @@ jobs:
         run: composer compile-assets ${{ inputs.COMPILE_ASSETS_ARGS }}
 
       - name: Upload assets artifact [DEV]
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ !contains(github.ref, 'refs/tags/') }}
         with:
           name: assets-${{ env.ASSETS_HASH }}
           path: assets
+          overwrite: true
+          include-hidden-files: true
 
       - name: Zip assets folder [PROD]
         uses: montudor/action-zip@v1

--- a/.github/workflows/ddev-playwright.yml
+++ b/.github/workflows/ddev-playwright.yml
@@ -187,10 +187,12 @@ jobs:
         run: echo "artifact=playwright-report" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: ${{ steps.set-artifact-name.outputs.artifact }}
             path: |
                 ${{ inputs.PLAYWRIGHT_DIR }}/playwright-report/*
                 ${{ inputs.PLAYWRIGHT_DIR }}/test-results/*
                 ${{ inputs.PLAYWRIGHT_DIR }}/artifacts/test-results/*
+            overwrite: true
+            include-hidden-files: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @inpsyde/delivery-heroes


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
* Workflows use actions/upload-artifact@v3, which is deprecated (see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
* Potential issues with artifact name collisions due to immutable artifacts in v4
* Hidden files may not be included in artifact uploads


**What is the new behavior (if this is a feature change)?**
* Updated both `.github/workflows/build-assets-compilation.yml` and `.github/workflows/ddev-playwright.yml` to use `actions/upload-artifact@v4`
* Added `overwrite: true` to allow overwriting artifacts with the same name
* Set `include-hidden-files: true` to ensure hidden files are included in artifact uploads


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes are introduced. Existing workflows and processes should continue to function as before.

However, please test the PR branch in your calling workflows to double-check!


**Other information**:
For the Playwright workflow, an alternative would be to append `${{ github.run_id }}` to the artifact name to ensure uniqueness and prevent collisions. However, this could cause regressions in downstream processes dependent on a consistent artifact name. Therefore, I opted to use `overwrite: true` to maintain the existing artifact naming convention while accommodating the immutability changes in `actions/upload-artifact@v4`.

Also, as a Boy Scout rule, I aligned the `CODEOWNERS` and `dependabot.yml` files with https://github.com/inpsyde/actions.