### PR TITLE
Pre-install `sniccowp/php-scoper-wordpress-excludes`

### DIFF
--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -165,7 +165,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.PHP_VERSION_BUILD }}
-          tools: humbug/php-scoper, rector
+          tools: humbug/php-scoper, sniccowp/php-scoper-wordpress-excludes, rector
 
       - name: Check optional Composer build tools
         id: composer-tools

--- a/docs/archive-creation.md
+++ b/docs/archive-creation.md
@@ -6,10 +6,12 @@ GitHub Actions.
 To achieve that, the reusable workflow:
 
 1. Installs dependencies (including dev-dependencies) defined in `composer.json`
-2. Executes `inpsyde/composer-assets-compiler` if required & configured by the package
-3. Executes `inpsyde/wp-translation-downloader` if required & configured by the package
-4. Executes PHP-Scoper if configured by the package
-5. Executes Rector if configured by the package
+2. Executes [Composer Asset Compiler](https://github.com/inpsyde/composer-asset-compiler) if
+   configured by the package
+3. Executes [WordPress Translation Downloader](https://github.com/inpsyde/wp-translation-downloader)
+   if configured by the package
+4. Executes [PHP-Scoper](https://github.com/humbug/php-scoper) if configured by the package
+5. Executes [Rector](https://github.com/rectorphp/rector) if configured by the package
 6. Re-installs dependencies without dev-dependencies
 7. Sets current commit hash and plugin version in the plugin's main file
 8. Runs `wp dist-archive` to create the final archive (with builtin support for a `.distignore`


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
The "Create plugin archive" [workflow](https://github.com/inpsyde/reusable-workflows/blob/main/.github/workflows/build-plugin-archive.yml), where [PHP-Scoper](https://github.com/humbug/php-scoper) is run if `scoper.inc.php` is present, runs `composer install --no-dev` (understandably). However, this requires the helper library [`sniccowp/php-scoper-wordpress-excludes`](https://github.com/snicco/php-scoper-wordpress-excludes) to be installed as a regular dependency to be available in the build process while it clearly is a dev "sub" dependency.


**What is the new behavior (if this is a feature change)?**
Since we already [install](https://github.com/inpsyde/reusable-workflows/blob/main/.github/workflows/build-plugin-archive.yml#L168) `humbug/php-scoper` with [`shivammathur/setup-php`](https://github.com/shivammathur/setup-php) in the release workflow and `sniccowp/php-scoper-wordpress-exclude` is a hard requirement for all our packages where we scope namespaces, we add it to the list of tools for `shivammathur/setup-php` to install. This allows us to remove the tool from the regular dependencies of packages using this workflow.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No. Existing packages requiring `sniccowp/php-scoper-wordpress-exclude` and referencing local `vendor/` paths to the list of excluded WordPress symbols (see documentation: https://github.com/humbug/php-scoper/blob/main/docs/further-reading.md#example-for-wordpress-core) continue to work.


**Other information**:
As part of the Boy Scout rule, I linked the tools used in the workflow in the documentation and removed the false claim that Composer Asset Compiler and WordPress Translation Downloader are installed when "required and configured by the package". They are installed when the workflow finds their configuration in the calling package, even when they are not _required_.