### PR TITLE
Update WordPress JS dependencies

### DIFF
--- a/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
+++ b/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
@@ -54,7 +54,7 @@ jobs:
         unique_packages=$(echo "${packages[@]}" | tr ' ' '\n' | sort -u)
 
 
-        for package in "unique_packages"; do
+        for package in ${unique_packages[@]}; do
           echo "Processing package: $package"
           
           curl -L \

--- a/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
+++ b/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      GH_API_TOKEN: ${{ secrets.DEPLOYBOT_REPO_READ_WRITE_TOKEN }}
+      GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
       WP_SCRIPT_DIST_TAG: ${{ inputs.WP_SCRIPT_DIST_TAG }}
       PACKAGES: ${{ inputs.PACKAGES }}
 

--- a/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
+++ b/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
@@ -1,4 +1,4 @@
-name: Update WordPress JS Dependencies
+name: Update WordPress JS Dependencies Orchestrator
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
+++ b/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Read composer.json and specified packages and call the workflows
+    - name: Gather packages and call the individual workflows.
       run: |
         # Initialize an array for packages
         packages=()
@@ -52,10 +52,8 @@ jobs:
         # Process all unique packages
         unique_packages=$(echo "${packages[@]}" | tr ' ' '\n' | sort -u)
 
-
         for package in ${unique_packages[@]}; do
           echo "Processing package: $package"
-          
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
@@ -64,4 +62,3 @@ jobs:
             https://api.github.com/repos/$package/dispatches \
             -d '{"event_type":"update_wp_dependencies","client_payload":{"wp_version":"${{ env.WP_SCRIPT_DIST_TAG }}"}}'
         done
-        

--- a/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
+++ b/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
@@ -1,0 +1,68 @@
+name: Update WordPress JS Dependencies
+on:
+  workflow_call:
+    inputs:
+      WP_SCRIPT_DIST_TAG:
+        description: The tag to use for updating the dependencies. e.g. wp-6.7
+        default: wp-6.7
+        required: true
+        type: string
+      PACKAGES:
+        description: Comma separated list of packages to call the update js wordpress dependencies.
+        required: false
+        type: string
+    secrets:
+      GH_API_TOKEN:
+        description: An GH API Token capable of triggering repository_dispatch.
+        required: true
+      
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_API_TOKEN: ${{ secrets.DEPLOYBOT_REPO_READ_WRITE_TOKEN }}
+      WP_SCRIPT_DIST_TAG: ${{ inputs.WP_SCRIPT_DIST_TAG }}
+      PACKAGES: ${{ inputs.PACKAGES }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Read composer.json and specified packages and call the workflows
+      run: |
+        # Initialize an array for packages
+        packages=()
+
+        # Add packages from composer.json if it exists
+        if [ -f composer.json ]; then
+          composer_packages=$(cat composer.json | jq -r '.require | keys[]')
+          for pkg in $composer_packages; do
+            packages+=("$pkg")
+          done
+        fi
+
+        # Add packages from the PACKAGES environment variable
+        IFS=',' read -r -a env_packages <<< "$PACKAGES"
+        for pkg in "${env_packages[@]}"; do
+          packages+=("$pkg")
+        done
+
+        # Process all unique packages
+        unique_packages=$(echo "${packages[@]}" | tr ' ' '\n' | sort -u)
+
+
+        for package in "unique_packages"; do
+          echo "Processing package: $package"
+          
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ env.GH_API_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$package/dispatches \
+            -d '{"event_type":"update_wp_dependencies","client_payload":{"wp_version":"${{ env.WP_SCRIPT_DIST_TAG }}"}}'
+        done
+        

--- a/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
+++ b/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       WP_DIST_TAG:
-        description: The dist tag to update the dependencies to, e.g., `wp-6.7`
+        description: The dist tag to update the dependencies to, e.g., `wp-6.7`.
         required: true
         type: string
       PACKAGES:

--- a/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
+++ b/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       WP_DIST_TAG:
-        description: The dist-tag to update the dependencies to, e.g., `wp-6.7`
+        description: The dist tag to update the dependencies to, e.g., `wp-6.7`
         required: true
         type: string
       PACKAGES:
@@ -62,3 +62,4 @@ jobs:
             https://api.github.com/repos/$package/dispatches \
             -d '{"event_type":"update_wp_dependencies","client_payload":{"wp_version":"${{ env.WP_DIST_TAG }}"}}'
         done
+        

--- a/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
+++ b/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
@@ -2,7 +2,7 @@ name: Update WordPress JS Dependencies Orchestrator
 on:
   workflow_call:
     inputs:
-      WP_SCRIPT_DIST_TAG:
+      WP_DIST_TAG:
         description: The dist-tag to update the dependencies to, e.g., `wp-6.7`
         required: true
         type: string
@@ -11,8 +11,8 @@ on:
         required: false
         type: string
     secrets:
-      GH_API_TOKEN:
-        description: An GH API Token capable of triggering repository_dispatch.
+      GH_TOKEN:
+        description: A personal access token (classic) with `repo` and `workflow` permissions, used to authenticate when calling GitHub APIs in target repositories.
         required: true
       
 jobs:
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
-      WP_SCRIPT_DIST_TAG: ${{ inputs.WP_SCRIPT_DIST_TAG }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      WP_DIST_TAG: ${{ inputs.WP_DIST_TAG }}
       PACKAGES: ${{ inputs.PACKAGES }}
 
     steps:
@@ -57,8 +57,8 @@ jobs:
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ env.GH_API_TOKEN }}" \
+            -H "Authorization: Bearer ${{ env.GH_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$package/dispatches \
-            -d '{"event_type":"update_wp_dependencies","client_payload":{"wp_version":"${{ env.WP_SCRIPT_DIST_TAG }}"}}'
+            -d '{"event_type":"update_wp_dependencies","client_payload":{"wp_version":"${{ env.WP_DIST_TAG }}"}}'
         done

--- a/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
+++ b/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       WP_DIST_TAG:
-        description: The dist tag to update the dependencies to, e.g., `wp-6.7`.
+        description: The dist tag to update the dependencies to, e.g., `wp-6.7`
         required: true
         type: string
       PACKAGES:

--- a/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
+++ b/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
@@ -59,7 +59,7 @@ jobs:
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: Bearer ${{ env.GH_API_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$package/dispatches \
             -d '{"event_type":"update_wp_dependencies","client_payload":{"wp_version":"${{ env.WP_SCRIPT_DIST_TAG }}"}}'

--- a/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
+++ b/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
@@ -54,12 +54,7 @@ jobs:
 
         for package in ${unique_packages[@]}; do
           echo "Processing package: $package"
-          curl -L \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ env.GH_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/$package/dispatches \
-            -d '{"event_type":"update_wp_dependencies","client_payload":{"wp_version":"${{ env.WP_DIST_TAG }}"}}'
+          gh workflow run update-wordpress-js-dependencies.yml \
+            --repo $package \
+            --field WP_DIST_TAG=${{ env.WP_DIST_TAG }}
         done
-        

--- a/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
+++ b/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
@@ -3,11 +3,11 @@ on:
   workflow_call:
     inputs:
       WP_SCRIPT_DIST_TAG:
-        description: The tag to use for updating the dependencies. e.g. wp-6.7
+        description: The dist-tag to update the dependencies to, e.g., `wp-6.7`
         required: true
         type: string
       PACKAGES:
-        description: Comma separated list of packages to call the update js wordpress dependencies.
+        description: Comma-separated list of additional `owner/repo`s to be updated.
         required: false
         type: string
     secrets:
@@ -16,7 +16,7 @@ on:
         required: true
       
 jobs:
-  update-dependencies:
+  update-dependencies-orchestrator:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -59,7 +59,7 @@ jobs:
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ env.GH_API_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$package/dispatches \
             -d '{"event_type":"update_wp_dependencies","client_payload":{"wp_version":"${{ env.WP_SCRIPT_DIST_TAG }}"}}'

--- a/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
+++ b/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml
@@ -4,7 +4,6 @@ on:
     inputs:
       WP_SCRIPT_DIST_TAG:
         description: The tag to use for updating the dependencies. e.g. wp-6.7
-        default: wp-6.7
         required: true
         type: string
       PACKAGES:

--- a/.github/workflows/update-wordpress-js-dependencies.yml
+++ b/.github/workflows/update-wordpress-js-dependencies.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       WP_SCRIPT_DIST_TAG:
-        description: The tag to use for updating the dependencies. e.g. wp-6.7
+        description: The dist-tag to update the dependencies to, e.g., `wp-6.7`
         required: true
         type: string
       NPM_REGISTRY_DOMAIN:
@@ -85,8 +85,6 @@ jobs:
       run: |
         if [ "${{ env.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
           echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
-        elif [ "${{ env.PACKAGE_MANAGER }}" == 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ]; then
-          echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
         else
           echo "No lock files found or unknown package manager"
         fi
@@ -101,26 +99,25 @@ jobs:
 
     - name: Install dependencies
       env:
-        ARGS: ${{ env.NODE_CACHE_MODE == 'yarn' && '--frozen-lockfile' || env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
+        ARGS: ${{ env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
       run: ${{ format('{0} {1} --ignore-scripts', env.PACKAGE_MANAGER, env.ARGS) }}
     
     - name: Running the update
       env:
-        SCRIPT_START: ${{ env.PACKAGE_MANAGER == 'yarn' && 'yarn' || env.PACKAGE_MANAGER == 'npm' && 'npm run' }}
+        SCRIPT_START: ${{ env.PACKAGE_MANAGER == 'npm' && 'npm run' }}
       run: |
         ./node_modules/.bin/wp-scripts packages-update --dist-tag=${{ env.WP_SCRIPT_DIST_TAG }}
 
-    - name: Git add and commit
+    - name: Git add, commit
       run: |
         git add -A
-        git commit -m "[BOT] Add dependencies changes for #${{ github.ref }}" --no-verify || ((echo "HAS_GIT_CHANGES=no" >> $GITHUB_ENV) && (echo "No changes to commit"))
+        git commit -m "[BOT] Add dependencies changes for #${{ github.ref }}" --no-verify || ((echo "NO_CHANGES=yes" >> $GITHUB_ENV) && (echo "No changes to commit"))
 
     - name: Git push
-      if: ${{ env.HAS_GIT_CHANGES != 'no' }}
+      if: ${{ env.NO_CHANGES != 'yes' }}
       run: git push
       
-
-    - name: Create Pull Request
+    - name: Create pull request
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/.github/workflows/update-wordpress-js-dependencies.yml
+++ b/.github/workflows/update-wordpress-js-dependencies.yml
@@ -7,6 +7,11 @@ on:
         default: wp-6.6
         required: true
         type: string
+      NPM_REGISTRY_DOMAIN:
+        description: Domain of the private npm registry.
+        default: https://npm.pkg.github.com/
+        required: false
+        type: string
     secrets:
       GITHUB_USER_EMAIL:
         description: Email address for the GitHub user configuration.
@@ -20,6 +25,9 @@ on:
       GITHUB_USER_SSH_PUBLIC_KEY:
         description: Public SSH key associated with the GitHub user for the token passed as `GITHUB_USER_TOKEN`.
         required: false
+      NPM_REGISTRY_TOKEN:
+        description: Authentication for the private npm registry.
+        required: false
       
 jobs:
   update-dependencies:
@@ -32,6 +40,8 @@ jobs:
       GITHUB_USER_SSH_KEY: ${{ secrets.DEPLOYBOT_SSH_PRIVATE_KEY }}
       GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.DEPLOYBOT_SSH_PUBLIC_KEY }}
       WP_SCRIPT_DIST_TAG: ${{ github.event.client_payload.wp_version || inputs.WP_SCRIPT_DIST_TAG }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      NPM_REGISTRY_DOMAIN: "https://npm.pkg.github.com/"
 
     steps:
     - name: Checkout
@@ -86,6 +96,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
+        registry-url: ${{ env.NPM_REGISTRY_DOMAIN }}
         cache: ${{ env.NODE_CACHE_MODE }}
 
 

--- a/.github/workflows/update-wordpress-js-dependencies.yml
+++ b/.github/workflows/update-wordpress-js-dependencies.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       WP_DIST_TAG:
-        description: The dist tag to update the dependencies to, e.g., `wp-6.7`
+        description: The dist tag to update the dependencies to, e.g., `wp-6.7`.
         required: true
         type: string
       NPM_REGISTRY_DOMAIN:

--- a/.github/workflows/update-wordpress-js-dependencies.yml
+++ b/.github/workflows/update-wordpress-js-dependencies.yml
@@ -38,7 +38,7 @@ jobs:
       GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
       GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}
-      WP_DIST_TAG: ${{ github.event.client_payload.wp_version || inputs.WP_DIST_TAG }}
+      WP_DIST_TAG: ${{ inputs.WP_DIST_TAG }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       NPM_REGISTRY_DOMAIN: ${{ inputs.NPM_REGISTRY_DOMAIN }}
 

--- a/.github/workflows/update-wordpress-js-dependencies.yml
+++ b/.github/workflows/update-wordpress-js-dependencies.yml
@@ -92,7 +92,7 @@ jobs:
 
     - name: Set up node
       env:
-        NPM_REGISTRY_DOMAIN: ${{ secrets.NPM_REGISTRY_DOMAIN }}
+        NPM_REGISTRY_DOMAIN: ${{ inputs.NPM_REGISTRY_DOMAIN }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       uses: actions/setup-node@v4
       with:
@@ -103,14 +103,14 @@ jobs:
     - name: Install dependencies
       env:
         ARGS: ${{ env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
-        NPM_REGISTRY_DOMAIN: ${{ secrets.NPM_REGISTRY_DOMAIN }}
+        NPM_REGISTRY_DOMAIN: ${{ inputs.NPM_REGISTRY_DOMAIN }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       run: ${{ format('{0} {1} --ignore-scripts', env.PACKAGE_MANAGER, env.ARGS) }}
     
     - name: Update dependencies
       env:
         SCRIPT_START: ${{ env.PACKAGE_MANAGER == 'npm' && 'npm run' }}
-        NPM_REGISTRY_DOMAIN: ${{ secrets.NPM_REGISTRY_DOMAIN }}
+        NPM_REGISTRY_DOMAIN: ${{ inputs.NPM_REGISTRY_DOMAIN }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       run: |
         ./node_modules/.bin/wp-scripts packages-update --dist-tag=${{ env.WP_DIST_TAG }}

--- a/.github/workflows/update-wordpress-js-dependencies.yml
+++ b/.github/workflows/update-wordpress-js-dependencies.yml
@@ -35,13 +35,13 @@ jobs:
     timeout-minutes: 10
     env:
       PACKAGE_MANAGER: npm
-      GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
-      GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}
-      GITHUB_USER_SSH_KEY: ${{ secrets.DEPLOYBOT_SSH_PRIVATE_KEY }}
-      GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.DEPLOYBOT_SSH_PUBLIC_KEY }}
+      GITHUB_USER_EMAIL: ${{ secrets.GITHUB_USER_EMAIL }}
+      GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
+      GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
+      GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}
       WP_SCRIPT_DIST_TAG: ${{ github.event.client_payload.wp_version || inputs.WP_SCRIPT_DIST_TAG }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
-      NPM_REGISTRY_DOMAIN: "https://npm.pkg.github.com/"
+      NPM_REGISTRY_DOMAIN: ${{ inputs.NPM_REGISTRY_DOMAIN }}
 
     steps:
     - name: Checkout

--- a/.github/workflows/update-wordpress-js-dependencies.yml
+++ b/.github/workflows/update-wordpress-js-dependencies.yml
@@ -2,7 +2,7 @@ name: Update WordPress JS Dependencies
 on:
   workflow_call:
     inputs:
-      WP_SCRIPT_DIST_TAG:
+      WP_DIST_TAG:
         description: The dist-tag to update the dependencies to, e.g., `wp-6.7`
         required: true
         type: string
@@ -38,7 +38,7 @@ jobs:
       GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
       GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}
-      WP_SCRIPT_DIST_TAG: ${{ github.event.client_payload.wp_version || inputs.WP_SCRIPT_DIST_TAG }}
+      WP_DIST_TAG: ${{ github.event.client_payload.wp_version || inputs.WP_DIST_TAG }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       NPM_REGISTRY_DOMAIN: ${{ inputs.NPM_REGISTRY_DOMAIN }}
 
@@ -51,7 +51,7 @@ jobs:
 
     - name: Set global variables
       run: |
-        echo "TEMP_BRANCH_NAME=update/${{ env.WP_SCRIPT_DIST_TAG }}" >> $GITHUB_ENV
+        echo "TEMP_BRANCH_NAME=update/${{ env.WP_DIST_TAG }}" >> $GITHUB_ENV
         echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
     - name: Set up SSH
@@ -106,7 +106,7 @@ jobs:
       env:
         SCRIPT_START: ${{ env.PACKAGE_MANAGER == 'npm' && 'npm run' }}
       run: |
-        ./node_modules/.bin/wp-scripts packages-update --dist-tag=${{ env.WP_SCRIPT_DIST_TAG }}
+        ./node_modules/.bin/wp-scripts packages-update --dist-tag=${{ env.WP_DIST_TAG }}
 
     - name: Git add, commit
       run: |
@@ -124,8 +124,8 @@ jobs:
         gh pr create \
           --base ${{ github.event.repository.default_branch }} \
           --head ${{ env.TEMP_BRANCH_NAME }} \
-          --title "Align WP Dependencies to meet dist tag ${{ env.WP_SCRIPT_DIST_TAG }} - ${{ env.CURRENT_DATE }}" \
-          --body "This PR updates the WordPress dependencies to meet the version ${{ env.WP_SCRIPT_DIST_TAG }}." \
+          --title "Align WP Dependencies to meet dist tag ${{ env.WP_DIST_TAG }} - ${{ env.CURRENT_DATE }}" \
+          --body "This PR updates the WordPress dependencies to meet the version ${{ env.WP_DIST_TAG }}." \
           --label "dependencies"
       
     - name: Delete signing key files

--- a/.github/workflows/update-wordpress-js-dependencies.yml
+++ b/.github/workflows/update-wordpress-js-dependencies.yml
@@ -1,0 +1,128 @@
+name: Update WordPress JS Dependencies
+on:
+  workflow_call:
+    inputs:
+      WP_SCRIPT_DIST_TAG:
+        description: The tag to use for updating the dependencies. e.g. wp-6.6
+        default: wp-6.6
+        required: true
+        type: string
+    secrets:
+      GITHUB_USER_EMAIL:
+        description: Email address for the GitHub user configuration.
+        required: false
+      GITHUB_USER_NAME:
+        description: Username for the GitHub user configuration.
+        required: false
+      GITHUB_USER_SSH_KEY:
+        description: Private SSH key associated with the GitHub user for the token passed as `GITHUB_USER_TOKEN`.
+        required: false
+      GITHUB_USER_SSH_PUBLIC_KEY:
+        description: Public SSH key associated with the GitHub user for the token passed as `GITHUB_USER_TOKEN`.
+        required: false
+      
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PACKAGE_MANAGER: npm
+      GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
+      GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}
+      GITHUB_USER_SSH_KEY: ${{ secrets.DEPLOYBOT_SSH_PRIVATE_KEY }}
+      GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.DEPLOYBOT_SSH_PUBLIC_KEY }}
+      WP_SCRIPT_DIST_TAG: ${{ github.event.client_payload.wp_version || inputs.WP_SCRIPT_DIST_TAG }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ssh-key: ${{ env.GITHUB_USER_SSH_KEY }}
+
+    - name: Set global variables
+      run: |
+        echo "TEMP_BRANCH_NAME=update/${{ env.WP_SCRIPT_DIST_TAG }}" >> $GITHUB_ENV
+        echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+    - name: Set up SSH
+      if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
+      uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: ${{ env.GITHUB_USER_SSH_KEY }}
+
+    - name: Set up Git
+      run: |
+        git config --global user.email "${{ env.GITHUB_USER_EMAIL }}"
+        git config --global user.name "${{ env.GITHUB_USER_NAME }}"
+        git config --global advice.addIgnoredFile false
+        git config --global push.autoSetupRemote true
+
+    - name: Set up signing commits
+      if: ${{ env.GITHUB_USER_SSH_PUBLIC_KEY != '' }}
+      run: |
+        : # Create empty SSH private key file so Git does not complain.
+        touch "${{ runner.temp }}/signingkey"
+        echo "${{ env.GITHUB_USER_SSH_PUBLIC_KEY }}" > "${{ runner.temp }}/signingkey.pub"
+        git config --global commit.gpgsign true
+        git config --global gpg.format ssh
+        git config --global user.signingkey "${{ runner.temp }}/signingkey.pub"
+
+    - name: Checkout to temporary branch
+      run: |
+        git show-ref -q refs/remotes/origin/${{ env.TEMP_BRANCH_NAME }} && git checkout ${{ env.TEMP_BRANCH_NAME }} || git checkout -b ${{ env.TEMP_BRANCH_NAME }}
+
+    - name: Set up node cache mode
+      run: |
+        if [ "${{ env.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
+          echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
+        elif [ "${{ env.PACKAGE_MANAGER }}" == 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ]; then
+          echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
+        else
+          echo "No lock files found or unknown package manager"
+        fi
+
+    - name: Set up node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+        cache: ${{ env.NODE_CACHE_MODE }}
+
+
+    - name: Install dependencies
+      env:
+        ARGS: ${{ env.NODE_CACHE_MODE == 'yarn' && '--frozen-lockfile' || env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
+      run: ${{ format('{0} {1} --ignore-scripts', env.PACKAGE_MANAGER, env.ARGS) }}
+    
+    - name: Running the update
+      env:
+        SCRIPT_START: ${{ env.PACKAGE_MANAGER == 'yarn' && 'yarn' || env.PACKAGE_MANAGER == 'npm' && 'npm run' }}
+      run: |
+        ./node_modules/.bin/wp-scripts packages-update --dist-tag=${{ env.WP_SCRIPT_DIST_TAG }}
+
+    - name: Git add and commit
+      run: |
+        git add -A
+        git commit -m "[BOT] Add dependencies changes for #${{ github.ref }}" --no-verify || ((echo "HAS_GIT_CHANGES=no" >> $GITHUB_ENV) && (echo "No changes to commit"))
+
+    - name: Git push
+      if: ${{ env.HAS_GIT_CHANGES != 'no' }}
+      run: git push
+      
+
+    - name: Create Pull Request
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh pr create \
+          --base ${{ github.event.repository.default_branch }} \
+          --head ${{ env.TEMP_BRANCH_NAME }} \
+          --title "Align WP Dependencies to meet dist tag ${{ env.WP_SCRIPT_DIST_TAG }} - ${{ env.CURRENT_DATE }}" \
+          --body "This PR updates the WordPress dependencies to meet the version ${{ env.WP_SCRIPT_DIST_TAG }}." \
+          --label "dependencies"
+      
+    - name: Delete signing key files
+      if: ${{ always() && env.GITHUB_USER_SSH_PUBLIC_KEY != '' }}
+      run: |
+        rm -f "${{ runner.temp }}/signingkey"
+        rm -f "${{ runner.temp }}/signingkey.pub"

--- a/.github/workflows/update-wordpress-js-dependencies.yml
+++ b/.github/workflows/update-wordpress-js-dependencies.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       WP_DIST_TAG:
-        description: The dist-tag to update the dependencies to, e.g., `wp-6.7`
+        description: The dist tag to update the dependencies to, e.g., `wp-6.7`
         required: true
         type: string
       NPM_REGISTRY_DOMAIN:
@@ -96,13 +96,12 @@ jobs:
         registry-url: ${{ env.NPM_REGISTRY_DOMAIN }}
         cache: ${{ env.NODE_CACHE_MODE }}
 
-
     - name: Install dependencies
       env:
         ARGS: ${{ env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
       run: ${{ format('{0} {1} --ignore-scripts', env.PACKAGE_MANAGER, env.ARGS) }}
     
-    - name: Running the update
+    - name: Update dependencies
       env:
         SCRIPT_START: ${{ env.PACKAGE_MANAGER == 'npm' && 'npm run' }}
       run: |

--- a/.github/workflows/update-wordpress-js-dependencies.yml
+++ b/.github/workflows/update-wordpress-js-dependencies.yml
@@ -34,20 +34,14 @@ jobs:
     timeout-minutes: 10
     env:
       PACKAGE_MANAGER: npm
-      GITHUB_USER_EMAIL: ${{ secrets.GITHUB_USER_EMAIL }}
-      GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
-      GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
-      GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}
       WP_DIST_TAG: ${{ inputs.WP_DIST_TAG }}
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
-      NPM_REGISTRY_DOMAIN: ${{ inputs.NPM_REGISTRY_DOMAIN }}
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ssh-key: ${{ env.GITHUB_USER_SSH_KEY }}
+        ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
     - name: Set global variables
       run: |
@@ -55,12 +49,17 @@ jobs:
         echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
     - name: Set up SSH
+      env:
+        GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
       if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
       uses: webfactory/ssh-agent@v0.9.0
       with:
         ssh-private-key: ${{ env.GITHUB_USER_SSH_KEY }}
 
     - name: Set up Git
+      env:
+        GITHUB_USER_EMAIL: ${{ secrets.GITHUB_USER_EMAIL }}
+        GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
       run: |
         git config --global user.email "${{ env.GITHUB_USER_EMAIL }}"
         git config --global user.name "${{ env.GITHUB_USER_NAME }}"
@@ -68,6 +67,8 @@ jobs:
         git config --global push.autoSetupRemote true
 
     - name: Set up signing commits
+      env:
+        GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}
       if: ${{ env.GITHUB_USER_SSH_PUBLIC_KEY != '' }}
       run: |
         : # Create empty SSH private key file so Git does not complain.
@@ -90,6 +91,9 @@ jobs:
         fi
 
     - name: Set up node
+      env:
+        NPM_REGISTRY_DOMAIN: ${{ secrets.NPM_REGISTRY_DOMAIN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
@@ -99,11 +103,15 @@ jobs:
     - name: Install dependencies
       env:
         ARGS: ${{ env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
+        NPM_REGISTRY_DOMAIN: ${{ secrets.NPM_REGISTRY_DOMAIN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       run: ${{ format('{0} {1} --ignore-scripts', env.PACKAGE_MANAGER, env.ARGS) }}
     
     - name: Update dependencies
       env:
         SCRIPT_START: ${{ env.PACKAGE_MANAGER == 'npm' && 'npm run' }}
+        NPM_REGISTRY_DOMAIN: ${{ secrets.NPM_REGISTRY_DOMAIN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       run: |
         ./node_modules/.bin/wp-scripts packages-update --dist-tag=${{ env.WP_DIST_TAG }}
 
@@ -128,6 +136,8 @@ jobs:
           --label "dependencies"
       
     - name: Delete signing key files
+      env:
+        GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}
       if: ${{ always() && env.GITHUB_USER_SSH_PUBLIC_KEY != '' }}
       run: |
         rm -f "${{ runner.temp }}/signingkey"

--- a/.github/workflows/update-wordpress-js-dependencies.yml
+++ b/.github/workflows/update-wordpress-js-dependencies.yml
@@ -3,8 +3,7 @@ on:
   workflow_call:
     inputs:
       WP_SCRIPT_DIST_TAG:
-        description: The tag to use for updating the dependencies. e.g. wp-6.6
-        default: wp-6.6
+        description: The tag to use for updating the dependencies. e.g. wp-6.7
         required: true
         type: string
       NPM_REGISTRY_DOMAIN:

--- a/docs/update-wp-dependencies.md
+++ b/docs/update-wp-dependencies.md
@@ -8,16 +8,10 @@ workflows handle automatic updates of the `@wordpress/*` packages to a specified
 dist tag) and can optionally create a pull request with all necessary changes.
 
 1. **Update WordPress JS Dependencies Workflow**:  
-   This workflow lives in an individual repository (the one containing the WordPress JS dependencies
-   to update). It checks out the repository, updates the `@wordpress/*` dependencies to a specific
-   tag, and opens a pull request if changes are found.
+   This workflow lives in an individual repository (the one containing the WordPress JS dependencies to update). It checks out the repository, updates the `@wordpress/*` dependencies to a specific tag, and opens a pull request if changes are found.
 
 2. **Update WordPress JS Dependencies Orchestrator Workflow**:  
-   This workflow can be placed in a single "orchestrator" repository (e.g., a website repository).
-   It triggers the "Update WordPress JS Dependencies Workflow" in multiple other repositories. This
-   is accomplished by sending
-   a [repository\_dispatch](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event)
-   event to each of the target repositories.
+   This workflow can be placed in a single "orchestrator" repository (e.g., a website repository). It triggers the "Update WordPress JS Dependencies Workflow" in multiple other repositories. This is accomplished by sending a [workflow\_dispatch](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch) event to each of the target repositories.
 
 ## Update WordPress JS Dependencies Workflow
 
@@ -28,10 +22,10 @@ WordPress version tag (e.g., `wp-6.7`) and creates a pull request containing all
 
 #### Inputs
 
-| Name                  | Default                         | Description                                           |
-|-----------------------|---------------------------------|-------------------------------------------------------|
-| `WP_DIST_TAG`          | `'wp-6.7'`                      | The tag to update the dependencies to, e.g., `wp-6.7` |
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                    |
+| Name                  | Default                         | Description                                                |
+|-----------------------|---------------------------------|------------------------------------------------------------|
+| `WP_DIST_TAG`         | `'wp-6.7'`                      | The dist tag to update the dependencies to, e.g., `wp-6.7` |
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                         |
 
 #### Secrets
 
@@ -52,7 +46,7 @@ on:
   workflow_dispatch:
     inputs:
       WP_DIST_TAG:
-        description: 'The tag to update the dependencies to, e.g., `wp-6.7`.'
+        description: The dist tag to update the dependencies to, e.g., `wp-6.7`.
         default: 'wp-6.7'
         required: true
         type: string
@@ -80,10 +74,10 @@ maintain a centralized list of repositories needing consistent WordPress JS depe
 
 #### Inputs
 
-| Name         | Default    | Description                                                    |
-|--------------|------------|----------------------------------------------------------------|
-| `WP_DIST_TAG` | `'wp-6.7'` | The tag to update the dependencies to, e.g., `wp-6.7`          |
-| `PACKAGES`   | `''`       | Comma-separated list of additional `owner/repo`s to be updated |
+| Name          | Default    | Description                                                    |
+|---------------|------------|----------------------------------------------------------------|
+| `WP_DIST_TAG` | `'wp-6.7'` | The dist tag to update the dependencies to, e.g., `wp-6.7`     |
+| `PACKAGES`    | `''`       | Comma-separated list of additional `owner/repo`s to be updated |
 
 #### Secrets
 
@@ -100,7 +94,7 @@ on:
   workflow_dispatch:
     inputs:
       WP_DIST_TAG:
-        description: 'The tag to update the dependencies to, e.g., `wp-6.7`'
+        description: The dist tag to update the dependencies to, e.g., `wp-6.7`
         required: true
       PACKAGES:
         description: 'Comma-separated list of additional `owner/repo`s to be updated.'

--- a/docs/update-wp-dependencies.md
+++ b/docs/update-wp-dependencies.md
@@ -1,6 +1,6 @@
 # Update WP Dependencies
 
-This workflow is meant to ease the task of updating the **@wordpress/<name>** dependencies.
+This workflow is meant to ease the task of updating the **@wordpress/name** dependencies.
 
 We are providing two reusable workflows. 
 
@@ -13,17 +13,17 @@ We are providing two reusable workflows.
 The workflow will create a PR with the updated dependencies.
 
 
-### Configuration parameters
+### Configuration parameters for WP Dependencies Update Workflow
 
-#### Inputs
+#### Inputs for WP Dependencies Update Workflow
 
-| Name                  | Default                         | Description                                                                                                                                                                                                                                                                                                           |
-|-----------------------|---------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `WP_SCRIPT_DIST_TAG`  | `'wp-6.7'`                      | The dist tag used by [wp-scripts packages-update](https://github.com/WordPress/gutenberg/tree/trunk/packages/scripts#packages-update)<br/> you can see which tags are available by going to any [WordPress Package in NPM](https://www.npmjs.com/package/@wordpress/blocks?activeTab=versions) and see the Tag column |
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                                                                                                                                                                                                                                                    |
+| Name                  | Default                         | Description                                                                                                                                                                                                                                                                                                       |
+|-----------------------|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `WP_SCRIPT_DIST_TAG`  | `'wp-6.7'`                      | The dist tag used by [wp-scripts packages-update](https://github.com/WordPress/gutenberg/tree/trunk/packages/scripts#packages-update). You can see which tags are available by going to any [WordPress Package in NPM](https://www.npmjs.com/package/@wordpress/blocks?activeTab=versions) and see the Tag column |
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                                                                                                                                                                                                                                                |
 
 
-#### Secrets
+#### Secrets for WP Dependencies Update Workflow
 
 | Name                         | Description                                                                  |
 |------------------------------|------------------------------------------------------------------------------|
@@ -67,17 +67,17 @@ jobs:
 The workflow will trigger the WP Dependencies Update Workflow in other repositories.
 
 
-### Configuration parameters
+### Configuration parameters for WP Dependencies Update Orchestrator Workflow
 
-#### Inputs
+#### Inputs for WP Dependencies Update Orchestrator Workflow
 
-| Name                  | Default    | Description                                                                                                                                                                                                                                                                                                           |
-|-----------------------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `WP_SCRIPT_DIST_TAG`  | `'wp-6.7'` | The dist tag used by [wp-scripts packages-update](https://github.com/WordPress/gutenberg/tree/trunk/packages/scripts#packages-update)<br/> you can see which tags are available by going to any [WordPress Package in NPM](https://www.npmjs.com/package/@wordpress/blocks?activeTab=versions) and see the Tag column |
-| `PACKAGES`            | `''`       | A comma-separated list of repository in the form of <organization-name>/<repository-name>                                                                                                                                                                                                                             |
+| Name                  | Default    | Description                                                                                                                                                                                                                                                                                                       |
+|-----------------------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `WP_SCRIPT_DIST_TAG`  | `'wp-6.7'` | The dist tag used by [wp-scripts packages-update](https://github.com/WordPress/gutenberg/tree/trunk/packages/scripts#packages-update). You can see which tags are available by going to any [WordPress Package in NPM](https://www.npmjs.com/package/@wordpress/blocks?activeTab=versions) and see the Tag column |
+| `PACKAGES`            | `''`       | A comma-separated list of repository in the form of organization-name/repository-name                                                                                                                                                                                                                             |
 
 
-#### Secrets
+#### Secrets for WP Dependencies Update Orchestrator Workflow
 
 | Name           | Description                                       |
 |----------------|---------------------------------------------------|

--- a/docs/update-wp-dependencies.md
+++ b/docs/update-wp-dependencies.md
@@ -56,8 +56,6 @@ on:
         default: 'wp-6.7'
         required: true
         type: string
-  repository_dispatch:
-    types: [ 'update_wp_dependencies' ]
 
 jobs:
   update-dependencies:

--- a/docs/update-wp-dependencies.md
+++ b/docs/update-wp-dependencies.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD024 -->
+
 # Update WordPress JS Dependencies
 
 This documentation describes two closely related reusable workflows for updating JavaScript

--- a/docs/update-wp-dependencies.md
+++ b/docs/update-wp-dependencies.md
@@ -1,0 +1,112 @@
+# Update WP Dependencies
+
+This workflow is meant to ease the task of updating the **@wordpress/<name>** dependencies.
+
+We are providing two reusable workflows. 
+
+1. One workflow lives in the package having the dependencies, we will call this "Update WP Dependencies Workflow".
+2. The other workflow lives in a package that is meant to orchestrate other packages through composer, we will call this "Update WP Dependencies Orchestrator Workflow". 
+    This is simply a workflow that triggers the other one in other packages.
+
+## WP Dependencies Update Workflow
+
+The workflow will create a PR with the updated dependencies.
+
+
+### Configuration parameters
+
+#### Inputs
+
+| Name                  | Default                         | Description                                                                                                                                                                                                                                                                                                           |
+|-----------------------|---------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `WP_SCRIPT_DIST_TAG`  | `'wp-6.7'`                      | The dist tag used by [wp-scripts packages-update](https://github.com/WordPress/gutenberg/tree/trunk/packages/scripts#packages-update)<br/> you can see which tags are available by going to any [WordPress Package in NPM](https://www.npmjs.com/package/@wordpress/blocks?activeTab=versions) and see the Tag column |
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                                                                                                                                                                                                                                                    |
+
+
+#### Secrets
+
+| Name                         | Description                                                                  |
+|------------------------------|------------------------------------------------------------------------------|
+| `GITHUB_USER_EMAIL`          | Email address for the GitHub user configuration                              |
+| `GITHUB_USER_NAME`           | Username for the GitHub user configuration                                   |
+| `GITHUB_USER_SSH_KEY`        | Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME` |
+| `GITHUB_USER_SSH_PUBLIC_KEY` | Public SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`  |
+| `NPM_REGISTRY_TOKEN`         | Authentication for the private npm registry                                  |
+
+**Example with configuration parameters:**
+
+```yaml
+name: WordPress JS Dependencies Update
+on:
+  workflow_dispatch:
+    inputs:
+      WP_SCRIPT_DIST_TAG:
+        description: The tag to use for updating the dependencies. e.g. wp-6.7
+        default: wp-6.7
+        required: true
+        type: string
+  repository_dispatch:
+    types: ['update_wp_dependencies']
+
+jobs:
+  update_wp_dependencies:
+    uses: inpsyde/reusable-workflows/.github/workflows/update-wordpress-js-dependencies.yml@main
+    secrets:
+        GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
+        GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}
+        GITHUB_USER_SSH_KEY: ${{ secrets.DEPLOYBOT_SSH_PRIVATE_KEY }}
+        GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.DEPLOYBOT_SSH_PUBLIC_KEY }}
+        NPM_REGISTRY_TOKEN: ${{ secrets.DEPLOYBOT_PACKAGES_READ_ACCESS_TOKEN }}
+    with:
+        NPM_REGISTRY_DOMAIN: "https://npm.pkg.github.com/"
+        WP_SCRIPT_DIST_TAG: ${{ inputs.WP_SCRIPT_DIST_TAG }}
+```
+
+## WP Dependencies Update Orchestrator Workflow
+
+The workflow will trigger the WP Dependencies Update Workflow in other repositories.
+
+
+### Configuration parameters
+
+#### Inputs
+
+| Name                  | Default    | Description                                                                                                                                                                                                                                                                                                           |
+|-----------------------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `WP_SCRIPT_DIST_TAG`  | `'wp-6.7'` | The dist tag used by [wp-scripts packages-update](https://github.com/WordPress/gutenberg/tree/trunk/packages/scripts#packages-update)<br/> you can see which tags are available by going to any [WordPress Package in NPM](https://www.npmjs.com/package/@wordpress/blocks?activeTab=versions) and see the Tag column |
+| `PACKAGES`            | `''`       | A comma-separated list of repository in the form of <organization-name>/<repository-name>                                                                                                                                                                                                                             |
+
+
+#### Secrets
+
+| Name           | Description                                       |
+|----------------|---------------------------------------------------|
+| `GH_API_TOKEN` | A classic API token with repo and workflow access |
+
+**Example with configuration parameters:**
+
+```yaml
+name: Call Update WordPress Deps using loop from composer and defined packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      WP_SCRIPT_DIST_TAG:
+        description: 'The WP dist tag. e.g.: wp-6.7'
+        required: true
+      PACKAGES:
+        description: Comma separated list of packages to call the update js wordpress dependencies.
+        required: false
+        type: string
+
+
+jobs:
+  update-dependencies:
+    uses: inpsyde/reusable-workflows/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml@main
+    with:
+      WP_SCRIPT_DIST_TAG: ${{ inputs.WP_SCRIPT_DIST_TAG }}
+      PACKAGES: ${{ inputs.PACKAGES }}
+    secrets:
+      GH_API_TOKEN: ${{ secrets.DEPLOYBOT_REPO_READ_WRITE_TOKEN }}
+```
+

--- a/docs/update-wp-dependencies.md
+++ b/docs/update-wp-dependencies.md
@@ -30,7 +30,7 @@ WordPress version tag (e.g., `wp-6.7`) and creates a pull request containing all
 
 | Name                  | Default                         | Description                                           |
 |-----------------------|---------------------------------|-------------------------------------------------------|
-| `WP_VERSION`          | `'wp-6.7'`                      | The tag to update the dependencies to, e.g., `wp-6.7` |
+| `WP_DIST_TAG`          | `'wp-6.7'`                      | The tag to update the dependencies to, e.g., `wp-6.7` |
 | `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                    |
 
 #### Secrets
@@ -51,7 +51,7 @@ name: Update WordPress JS Dependencies
 on:
   workflow_dispatch:
     inputs:
-      WP_VERSION:
+      WP_DIST_TAG:
         description: 'The tag to update the dependencies to, e.g., `wp-6.7`.'
         default: 'wp-6.7'
         required: true
@@ -69,7 +69,7 @@ jobs:
     GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.DEPLOYBOT_SSH_PUBLIC_KEY }}
     NPM_REGISTRY_TOKEN: ${{ secrets.DEPLOYBOT_PACKAGES_READ_ACCESS_TOKEN }}
   with:
-    WP_VERSION: ${{ inputs.WP_VERSION }}
+    WP_DIST_TAG: ${{ inputs.WP_DIST_TAG }}
 ```
 
 ## Update WordPress JS Dependencies Orchestrator Workflow
@@ -84,14 +84,14 @@ maintain a centralized list of repositories needing consistent WordPress JS depe
 
 | Name         | Default    | Description                                                    |
 |--------------|------------|----------------------------------------------------------------|
-| `WP_VERSION` | `'wp-6.7'` | The tag to update the dependencies to, e.g., `wp-6.7`          |
+| `WP_DIST_TAG` | `'wp-6.7'` | The tag to update the dependencies to, e.g., `wp-6.7`          |
 | `PACKAGES`   | `''`       | Comma-separated list of additional `owner/repo`s to be updated |
 
 #### Secrets
 
 | Name           | Description                                                                                                             |
 |----------------|-------------------------------------------------------------------------------------------------------------------------|
-| `GH_API_TOKEN` | A personal access token (classic) with `repo` and `workflow` permissions, used to authenticate when calling GitHub APIs |
+| `GH_TOKEN` | A personal access token (classic) with `repo` and `workflow` permissions, used to authenticate when calling GitHub APIs |
 
 ### Usage example
 
@@ -101,7 +101,7 @@ name: Update WordPress JS Dependencies Orchestrator
 on:
   workflow_dispatch:
     inputs:
-      WP_VERSION:
+      WP_DIST_TAG:
         description: 'The tag to update the dependencies to, e.g., `wp-6.7`'
         required: true
       PACKAGES:
@@ -113,8 +113,8 @@ jobs:
   update-dependency-orchestrator:
     uses: inpsyde/reusable-workflows/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml@main
     with:
-      WP_VERSION: ${{ inputs.WP_VERSION }}
+      WP_DIST_TAG: ${{ inputs.WP_DIST_TAG }}
       PACKAGES: ${{ inputs.PACKAGES }}
     secrets:
-      GH_API_TOKEN: ${{ secrets.DEPLOYBOT_REPO_READ_WRITE_TOKEN }}
+      GH_TOKEN: ${{ secrets.DEPLOYBOT_REPO_READ_WRITE_TOKEN }}
 ```

--- a/docs/update-wp-dependencies.md
+++ b/docs/update-wp-dependencies.md
@@ -2,10 +2,7 @@
 
 # Update WordPress JS Dependencies
 
-This documentation describes two closely related reusable workflows for updating JavaScript
-dependencies that use [WordPress packages](https://www.npmjs.com/search?q=%40wordpress%2F). These
-workflows handle automatic updates of the `@wordpress/*` packages to a specified WordPress version (
-dist tag) and can optionally create a pull request with all necessary changes.
+This documentation describes two closely related reusable workflows for updating JavaScript dependencies that use [WordPress packages](https://www.npmjs.com/search?q=%40wordpress%2F). These workflows handle automatic updates of the `@wordpress/*` packages to a specified WordPress version (dist tag) and can optionally create a pull request with all necessary changes.
 
 1. **Update WordPress JS Dependencies Workflow**:  
    This workflow lives in an individual repository (the one containing the WordPress JS dependencies to update). It checks out the repository, updates the `@wordpress/*` dependencies to a specific tag, and opens a pull request if changes are found.
@@ -15,8 +12,7 @@ dist tag) and can optionally create a pull request with all necessary changes.
 
 ## Update WordPress JS Dependencies Workflow
 
-This workflow updates the `@wordpress/*` dependencies in the current repository to a specified
-WordPress version tag (e.g., `wp-6.7`) and creates a pull request containing all modified files.
+This workflow updates the `@wordpress/*` dependencies in the current repository to a specified WordPress version tag (e.g., `wp-6.7`) and creates a pull request containing all modified files.
 
 ### Configuration parameters
 
@@ -66,9 +62,7 @@ jobs:
 
 ## Update WordPress JS Dependencies Orchestrator Workflow
 
-This workflow triggers the “Update WordPress JS Dependencies Workflow” in multiple external
-repositories by sending a `repository_dispatch` event to each target repository. This allows you to
-maintain a centralized list of repositories needing consistent WordPress JS dependency versions.
+This workflow triggers the “Update WordPress JS Dependencies Workflow” in multiple external repositories by sending a `repository_dispatch` event to each target repository. This allows you to maintain a centralized list of repositories needing consistent WordPress JS dependency versions.
 
 ### Configuration parameters
 
@@ -81,8 +75,8 @@ maintain a centralized list of repositories needing consistent WordPress JS depe
 
 #### Secrets
 
-| Name           | Description                                                                                                             |
-|----------------|-------------------------------------------------------------------------------------------------------------------------|
+| Name       | Description                                                                                                             |
+|------------|-------------------------------------------------------------------------------------------------------------------------|
 | `GH_TOKEN` | A personal access token (classic) with `repo` and `workflow` permissions, used to authenticate when calling GitHub APIs |
 
 ### Usage example


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

**What is the current behavior?** (You can also link to an open issue here)
There is no workflow to automatically create a PR with updated WordPress dependencies.


**What is the new behavior (if this is a feature change)?**
It adds two new workflows to create a PR with updated WordPress dependencies.

The reusable workflow for the orchestrator was added in here:

[reusable-workflows/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml at update_wordpress_js_dependencies · inpsyde/reusable-workflows](https://github.com/inpsyde/reusable-workflows/blob/update_wordpress_js_dependencies/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml)  

### How does it work?
#### Individual package
The workflow can be called from the individual package or from the orchestrator.

Example:
```yaml
name: WordPress JS Dependencies Update
on:
  workflow_dispatch:
    inputs:
      WP_SCRIPT_DIST_TAG:
        description: The tag to use for updating the dependencies. e.g. wp-6.6
        default: wp-6.6
        required: true
        type: string
  repository_dispatch:
    types: ['update_wp_dependencies']

jobs:
  update_wp_dependencies:
    uses: inpsyde/reusable-workflows/.github/workflows/update-wordpress-js-dependencies.yml@update_wordpress_js_dependencies
    secrets:
        GITHUB_USER_EMAIL: ${{ secrets.SOME_EMAIL }}
        GITHUB_USER_NAME: ${{ secrets.SOME_USER }}
        GITHUB_USER_SSH_KEY: ${{ secrets.SOME_SSH_PRIVATE_KEY }}
        GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.SOME_SSH_PUBLIC_KEY }}
        NPM_REGISTRY_TOKEN: ${{ secrets.SOME_TOKEN }}
    with:
        NPM_REGISTRY_DOMAIN: "https://npm.pkg.github.com/"
        WP_SCRIPT_DIST_TAG: ${{ inputs.WP_SCRIPT_DIST_TAG }}
```

#### Orchestrator
An orchestrator is a repository that consumes other packages, typically a website repository.

Orchestrator example:

```yaml
name: Call Update WordPress Deps using loop from composer and defined packages 

on:
  workflow_dispatch:
    inputs:
      WP_SCRIPT_DIST_TAG:
        description: 'The WP dist tag. e.g.: wp-6.7'
        required: true
      PACKAGES:
        description: Comma separated list of packages to call the update js wordpress dependencies.
        required: false
        type: string
  

jobs:
  update-dependencies:
    uses: inpsyde/reusable-workflows/.github/workflows/update-wordpress-js-dependencies-orchestrator.yml@update_wordpress_js_dependencies
    with:
      WP_SCRIPT_DIST_TAG: ${{ inputs.WP_SCRIPT_DIST_TAG }}
      PACKAGES: ${{ inputs.PACKAGES }}
    secrets:
      GH_API_TOKEN: ${{ secrets.SOME_TOKEN }}
```

The workflow is triggered on demand. The user needs to define the wp dist tag and could optionally define some repos in the `PACKAGES` input in a comma-separated string.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
