### PR TITLE
[MLP-2247] Fix/debug assets compiler on build plugin archive

### DIFF
--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -172,15 +172,15 @@ jobs:
         run: |
           hasAssetConfig(){
             test -f assets-compiler.json
-            local EXIT=$?
-            if [ $EXIT -eq 0 ]; then
-              echo "0"
+            local ASSET_CONFIG_EXISTS=$?
+            if [ $ASSET_CONFIG_EXISTS -eq 0 ]; then
+              echo "0" # File exists
               exit 0
             fi
             # If 'assets-compiler.json' does not exist, check 'composer.json'
             jq '.extra | has("composer-asset-compiler")' --exit-status < composer.json >/dev/null 2>&1
-            local EXIT=$?
-            echo "$EXIT"
+            local COMPOSER_CONFIG_EXISTS=$?
+            echo "$COMPOSER_CONFIG_EXISTS"
           }
           hasTranslateConfig(){
             jq '.extra | has("wp-translation-downloader")' --exit-status < composer.json >/dev/null 2>&1

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -208,7 +208,7 @@ jobs:
         run: |
           # If no config file, bail 
           if [ ! -f "scoper.inc.php" ]; then
-          echo "No Php-Scoper config file found (scoper.inc.php). Aborting..."
+          echo "scoper_failed=1" >> $GITHUB_OUTPUT
           exit 1
           fi
           php-scoper add-prefix --force --output-dir=build --no-interaction
@@ -216,7 +216,7 @@ jobs:
           sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
 
       - name: Move code to the `build/` directory
-        if: ${{ failure() && steps.php-scoper.conclusion == 'failure' }}
+        if: steps.php-scoper.outputs.scoper_failed == '1'
         run: |
           shopt -s extglob dotglob
           mkdir build

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -166,6 +166,7 @@ jobs:
           hasAssetConfig(){
             test -f assets-compiler.json
             local EXIT=$?
+            echo "Has the file: $EXIT"
             if [ ! $EXIT ]; then
               echo "$EXIT"
               exit 0

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -161,46 +161,17 @@ jobs:
         with:
           name: ${{ needs.checkout-dependencies.outputs.artifact }}
 
+      - name: Configure Composer plugins
+        run: |
+          composer global config --no-plugins --no-interaction allow-plugins.composer/installers true
+          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/wp-translation-downloader true
+          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/composer-assets-compiler true
+
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@verbose
         with:
           php-version: ${{ inputs.PHP_VERSION_BUILD }}
-          tools: humbug/php-scoper, sniccowp/php-scoper-wordpress-excludes, rector
-
-      - name: Check optional Composer build tools
-        id: composer-tools
-        run: |
-          hasAssetConfig(){
-            test -f assets-compiler.json
-            local ASSET_CONFIG_EXISTS=$?
-            if [ $ASSET_CONFIG_EXISTS -eq 0 ]; then
-              echo "0" # File exists
-              exit 0
-            fi
-            # If 'assets-compiler.json' does not exist, check 'composer.json'
-            jq '.extra | has("composer-asset-compiler")' --exit-status < composer.json >/dev/null 2>&1
-            local COMPOSER_CONFIG_EXISTS=$?
-            echo "$COMPOSER_CONFIG_EXISTS"
-          }
-          hasTranslateConfig(){
-            jq '.extra | has("wp-translation-downloader")' --exit-status < composer.json >/dev/null 2>&1
-            local EXIT=$?
-            echo "$EXIT"
-          }
-          hasScoperConfig(){
-            test -f scoper.inc.php
-            local EXIT=$?
-            echo "$EXIT"
-          }
-          hasRectorConfig(){
-            test -f rector.php
-            local EXIT=$?
-            echo "$EXIT"
-          }
-          echo "assets-compiler=$( hasAssetConfig )" >> $GITHUB_OUTPUT
-          echo "translation-downloader=$( hasTranslateConfig )" >> $GITHUB_OUTPUT
-          echo "php-scoper=$( hasScoperConfig )" >> $GITHUB_OUTPUT
-          echo "rector=$( hasRectorConfig )" >> $GITHUB_OUTPUT
+          tools: humbug/php-scoper, sniccowp/php-scoper-wordpress-excludes, rector/rector, inpsyde/composer-assets-compiler, inpsyde/wp-translation-downloader
 
       - name: Set up node cache mode
         run: |
@@ -213,7 +184,6 @@ jobs:
           fi
 
       - name: Set up node
-        if: steps.composer-tools.outputs.assets-compiler == '0'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.NODE_VERSION }}
@@ -221,34 +191,26 @@ jobs:
           cache: ${{ env.NODE_CACHE_MODE }}
 
       - name: Install and run Composer Asset Compiler
-        if: steps.composer-tools.outputs.assets-compiler == '0'
         run: |
-          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/composer-assets-compiler true
-          composer global require inpsyde/composer-assets-compiler
           composer compile-assets ${{ inputs.COMPILE_ASSETS_ARGS }}
 
       - name: Install and run WordPress Translation Downloader
-        if: steps.composer-tools.outputs.translation-downloader == '0'
         run: |
-          composer global config --no-plugins --no-interaction allow-plugins.composer/installers true
-          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/wp-translation-downloader true
-          composer global require inpsyde/wp-translation-downloader
           composer wp-translation-downloader:download
 
       - name: Run Rector
-        if: steps.composer-tools.outputs.rector == '0'
         run: |
           rector
 
       - name: Run PHP-Scoper
-        if: steps.composer-tools.outputs.php-scoper == '0'
+        id: php-scoper
         run: |
-          php-scoper add-prefix --force --output-dir=build
+          php-scoper add-prefix --force --output-dir=build --no-interaction
           composer --working-dir=build dump-autoload -o
           sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
 
       - name: Move code to the `build/` directory
-        if: steps.composer-tools.outputs.php-scoper != '0'
+        if: steps.php-scoper.outputs == 'failed'
         run: |
           shopt -s extglob dotglob
           mkdir build

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -166,13 +166,11 @@ jobs:
           hasAssetConfig(){
             test -f assets-compiler.json
             local EXIT=$?
-            echo "Has the file: $EXIT"
             if [ ! $EXIT ]; then
               echo "$EXIT"
               exit 0
             fi
-            jq '.extra | has("composer-asset-compiler")' --exit-status < composer.json >/dev/null 2>&1
-            local EXIT=$?
+            
             echo "$EXIT"
           }
           hasTranslateConfig(){

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -168,7 +168,7 @@ jobs:
           composer global config --no-plugins --no-interaction allow-plugins.inpsyde/composer-assets-compiler true
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@verbose
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.PHP_VERSION_BUILD }}
           tools: rector, php-scoper, sniccowp/php-scoper-wordpress-excludes, inpsyde/composer-assets-compiler, inpsyde/wp-translation-downloader

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -161,16 +161,16 @@ jobs:
       - name: Check optional Composer build tools
         id: composer-tools
         run: |
-          pwd
-          ls -la
           hasAssetConfig(){
             test -f assets-compiler.json
             local EXIT=$?
-            if [ ! $EXIT ]; then
-              echo "$EXIT"
+            if [ $EXIT -eq 0 ]; then
+              echo "0"
               exit 0
             fi
-            
+            # If 'assets-compiler.json' does not exist, check 'composer.json'
+            jq '.extra | has("composer-asset-compiler")' --exit-status < composer.json >/dev/null 2>&1
+            local EXIT=$?
             echo "$EXIT"
           }
           hasTranslateConfig(){
@@ -188,7 +188,6 @@ jobs:
             local EXIT=$?
             echo "$EXIT"
           }
-          echo "Assets Compiler Status: $(hasAssetConfig)"
           echo "assets-compiler=$( hasAssetConfig )" >> $GITHUB_OUTPUT
           echo "translation-downloader=$( hasTranslateConfig )" >> $GITHUB_OUTPUT
           echo "php-scoper=$( hasScoperConfig )" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -171,7 +171,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.PHP_VERSION_BUILD }}
-          tools: humbug/php-scoper, sniccowp/php-scoper-wordpress-excludes, rector/rector, inpsyde/composer-assets-compiler, inpsyde/wp-translation-downloader
+          tools: rector, php-scoper, sniccowp/php-scoper-wordpress-excludes, inpsyde/composer-assets-compiler, inpsyde/wp-translation-downloader
 
       - name: Set up node cache mode
         run: |
@@ -199,24 +199,19 @@ jobs:
           composer wp-translation-downloader:download
 
       - name: Run Rector
+        if: ${{ hashFiles('rector.php') != '' }}
         run: |
           rector
 
       - name: Run PHP-Scoper
-        continue-on-error: true
-        id: php-scoper
+        if: ${{ hashFiles('scoper.inc.php') != '' }}
         run: |
-          # If no config file, bail 
-          if [ ! -f "scoper.inc.php" ]; then
-          echo "scoper_failed=1" >> $GITHUB_OUTPUT
-          exit 1
-          fi
           php-scoper add-prefix --force --output-dir=build --no-interaction
           composer --working-dir=build dump-autoload -o
           sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
 
       - name: Move code to the `build/` directory
-        if: steps.php-scoper.outputs.scoper_failed == '1'
+        if: ${{ hashFiles('scoper.inc.php') == '' }}
         run: |
           shopt -s extglob dotglob
           mkdir build

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -216,7 +216,7 @@ jobs:
           sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
 
       - name: Move code to the `build/` directory
-        if: steps.php-scoper.conclusion == 'failure'
+        if: ${{ failure() && steps.php-scoper.conclusion == 'failure' }}
         run: |
           shopt -s extglob dotglob
           mkdir build

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -210,7 +210,7 @@ jobs:
           sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
 
       - name: Move code to the `build/` directory
-        if: steps.run-php-scoper.outcome == 'failure'
+        if: ${{ steps.run-php-scoper.outcome == 'failure' }}
         run: |
           shopt -s extglob dotglob
           mkdir build

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -165,7 +165,42 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.PHP_VERSION_BUILD }}
-          tools: humbug/php-scoper, sniccowp/php-scoper-wordpress-excludes, rector/rector, inpsyde/composer-assets-compiler, inpsyde/wp-translation-downloader
+          tools: humbug/php-scoper, sniccowp/php-scoper-wordpress-excludes, rector
+
+      - name: Check optional Composer build tools
+        id: composer-tools
+        run: |
+          hasAssetConfig(){
+            test -f assets-compiler.json
+            local ASSET_CONFIG_EXISTS=$?
+            if [ $ASSET_CONFIG_EXISTS -eq 0 ]; then
+              echo "0" # File exists
+              exit 0
+            fi
+            # If 'assets-compiler.json' does not exist, check 'composer.json'
+            jq '.extra | has("composer-asset-compiler")' --exit-status < composer.json >/dev/null 2>&1
+            local COMPOSER_CONFIG_EXISTS=$?
+            echo "$COMPOSER_CONFIG_EXISTS"
+          }
+          hasTranslateConfig(){
+            jq '.extra | has("wp-translation-downloader")' --exit-status < composer.json >/dev/null 2>&1
+            local EXIT=$?
+            echo "$EXIT"
+          }
+          hasScoperConfig(){
+            test -f scoper.inc.php
+            local EXIT=$?
+            echo "$EXIT"
+          }
+          hasRectorConfig(){
+            test -f rector.php
+            local EXIT=$?
+            echo "$EXIT"
+          }
+          echo "assets-compiler=$( hasAssetConfig )" >> $GITHUB_OUTPUT
+          echo "translation-downloader=$( hasTranslateConfig )" >> $GITHUB_OUTPUT
+          echo "php-scoper=$( hasScoperConfig )" >> $GITHUB_OUTPUT
+          echo "rector=$( hasRectorConfig )" >> $GITHUB_OUTPUT
 
       - name: Set up node cache mode
         run: |
@@ -178,40 +213,42 @@ jobs:
           fi
 
       - name: Set up node
+        if: steps.composer-tools.outputs.assets-compiler == '0'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
           cache: ${{ env.NODE_CACHE_MODE }}
 
-      - name: Run Composer Asset Compiler
-        continue-on-error: true
+      - name: Install and run Composer Asset Compiler
+        if: steps.composer-tools.outputs.assets-compiler == '0'
         run: |
           composer global config --no-plugins --no-interaction allow-plugins.inpsyde/composer-assets-compiler true
-          composer compile-assets ${{ inputs.COMPILE_ASSETS_ARGS }} || echo "Error: $?"
+          composer global require inpsyde/composer-assets-compiler
+          composer compile-assets ${{ inputs.COMPILE_ASSETS_ARGS }}
 
-      - name: Run WordPress Translation Downloader
-        continue-on-error: true
+      - name: Install and run WordPress Translation Downloader
+        if: steps.composer-tools.outputs.translation-downloader == '0'
         run: |
           composer global config --no-plugins --no-interaction allow-plugins.composer/installers true
           composer global config --no-plugins --no-interaction allow-plugins.inpsyde/wp-translation-downloader true
-          composer wp-translation-downloader:download || echo "Error: $?"
+          composer global require inpsyde/wp-translation-downloader
+          composer wp-translation-downloader:download
 
       - name: Run Rector
-        continue-on-error: true
+        if: steps.composer-tools.outputs.rector == '0'
         run: |
-          rector || echo "Error: $?"
+          rector
 
       - name: Run PHP-Scoper
-        id: run-php-scoper
-        continue-on-error: true
+        if: steps.composer-tools.outputs.php-scoper == '0'
         run: |
           php-scoper add-prefix --force --output-dir=build
           composer --working-dir=build dump-autoload -o
           sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
 
       - name: Move code to the `build/` directory
-        if: ${{ steps.run-php-scoper.outcome == 'failure' }}
+        if: steps.composer-tools.outputs.php-scoper != '0'
         run: |
           shopt -s extglob dotglob
           mkdir build

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -161,14 +161,8 @@ jobs:
         with:
           name: ${{ needs.checkout-dependencies.outputs.artifact }}
 
-      - name: Configure Composer plugins
-        run: |
-          composer global config --no-plugins --no-interaction allow-plugins.composer/installers true
-          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/wp-translation-downloader true
-          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/composer-assets-compiler true
-
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@verbose
         with:
           php-version: ${{ inputs.PHP_VERSION_BUILD }}
           tools: rector, php-scoper, sniccowp/php-scoper-wordpress-excludes, inpsyde/composer-assets-compiler, inpsyde/wp-translation-downloader

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -203,6 +203,7 @@ jobs:
           rector
 
       - name: Run PHP-Scoper
+        continue-on-error: true
         id: php-scoper
         run: |
           # If no config file, bail 

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -161,6 +161,8 @@ jobs:
       - name: Check optional Composer build tools
         id: composer-tools
         run: |
+          pwd
+          ls -la
           hasAssetConfig(){
             test -f assets-compiler.json
             local EXIT=$?
@@ -187,6 +189,7 @@ jobs:
             local EXIT=$?
             echo "$EXIT"
           }
+          echo "Assets Compiler Status: $(hasAssetConfig)"
           echo "assets-compiler=$( hasAssetConfig )" >> $GITHUB_OUTPUT
           echo "translation-downloader=$( hasTranslateConfig )" >> $GITHUB_OUTPUT
           echo "php-scoper=$( hasScoperConfig )" >> $GITHUB_OUTPUT
@@ -229,7 +232,7 @@ jobs:
         if: steps.composer-tools.outputs.rector == '0'
         run: |
           rector
-          
+
       - name: Run PHP-Scoper
         if: steps.composer-tools.outputs.php-scoper == '0'
         run: |

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -165,42 +165,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.PHP_VERSION_BUILD }}
-          tools: humbug/php-scoper, sniccowp/php-scoper-wordpress-excludes, rector
-
-      - name: Check optional Composer build tools
-        id: composer-tools
-        run: |
-          hasAssetConfig(){
-            test -f assets-compiler.json
-            local ASSET_CONFIG_EXISTS=$?
-            if [ $ASSET_CONFIG_EXISTS -eq 0 ]; then
-              echo "0" # File exists
-              exit 0
-            fi
-            # If 'assets-compiler.json' does not exist, check 'composer.json'
-            jq '.extra | has("composer-asset-compiler")' --exit-status < composer.json >/dev/null 2>&1
-            local COMPOSER_CONFIG_EXISTS=$?
-            echo "$COMPOSER_CONFIG_EXISTS"
-          }
-          hasTranslateConfig(){
-            jq '.extra | has("wp-translation-downloader")' --exit-status < composer.json >/dev/null 2>&1
-            local EXIT=$?
-            echo "$EXIT"
-          }
-          hasScoperConfig(){
-            test -f scoper.inc.php
-            local EXIT=$?
-            echo "$EXIT"
-          }
-          hasRectorConfig(){
-            test -f rector.php
-            local EXIT=$?
-            echo "$EXIT"
-          }
-          echo "assets-compiler=$( hasAssetConfig )" >> $GITHUB_OUTPUT
-          echo "translation-downloader=$( hasTranslateConfig )" >> $GITHUB_OUTPUT
-          echo "php-scoper=$( hasScoperConfig )" >> $GITHUB_OUTPUT
-          echo "rector=$( hasRectorConfig )" >> $GITHUB_OUTPUT
+          tools: humbug/php-scoper, sniccowp/php-scoper-wordpress-excludes, rector/rector, inpsyde/composer-assets-compiler, inpsyde/wp-translation-downloader
 
       - name: Set up node cache mode
         run: |
@@ -220,35 +185,33 @@ jobs:
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
           cache: ${{ env.NODE_CACHE_MODE }}
 
-      - name: Install and run Composer Asset Compiler
-        if: steps.composer-tools.outputs.assets-compiler == '0'
+      - name: Run Composer Asset Compiler
+        continue-on-error: true
         run: |
           composer global config --no-plugins --no-interaction allow-plugins.inpsyde/composer-assets-compiler true
-          composer global require inpsyde/composer-assets-compiler
-          composer compile-assets ${{ inputs.COMPILE_ASSETS_ARGS }}
+          composer compile-assets ${{ inputs.COMPILE_ASSETS_ARGS }} || echo "Error: $?"
 
-      - name: Install and run WordPress Translation Downloader
-        if: steps.composer-tools.outputs.translation-downloader == '0'
+      - name: Run WordPress Translation Downloader
+        continue-on-error: true
         run: |
           composer global config --no-plugins --no-interaction allow-plugins.composer/installers true
           composer global config --no-plugins --no-interaction allow-plugins.inpsyde/wp-translation-downloader true
-          composer global require inpsyde/wp-translation-downloader
-          composer wp-translation-downloader:download
+          composer wp-translation-downloader:download || echo "Error: $?"
 
       - name: Run Rector
-        if: steps.composer-tools.outputs.rector == '0'
+        continue-on-error: true
         run: |
-          rector
+          rector || echo "Error: $?"
 
       - name: Run PHP-Scoper
-        if: steps.composer-tools.outputs.php-scoper == '0'
+        continue-on-error: true
         run: |
           php-scoper add-prefix --force --output-dir=build
           composer --working-dir=build dump-autoload -o
           sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
 
       - name: Move code to the `build/` directory
-        if: steps.composer-tools.outputs.php-scoper != '0'
+        if: steps.php-scoper.outcome == 'failure'
         run: |
           shopt -s extglob dotglob
           mkdir build

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -161,8 +161,14 @@ jobs:
         with:
           name: ${{ needs.checkout-dependencies.outputs.artifact }}
 
+      - name: Configure Composer plugins
+        run: |
+          composer global config --no-plugins --no-interaction allow-plugins.composer/installers true
+          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/wp-translation-downloader true
+          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/composer-assets-compiler true
+
       - name: Set up PHP
-        uses: shivammathur/setup-php@verbose
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.PHP_VERSION_BUILD }}
           tools: rector, php-scoper, sniccowp/php-scoper-wordpress-excludes, inpsyde/composer-assets-compiler, inpsyde/wp-translation-downloader

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -168,7 +168,7 @@ jobs:
           composer global config --no-plugins --no-interaction allow-plugins.inpsyde/composer-assets-compiler true
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@verbose
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.PHP_VERSION_BUILD }}
           tools: humbug/php-scoper, sniccowp/php-scoper-wordpress-excludes, rector/rector, inpsyde/composer-assets-compiler, inpsyde/wp-translation-downloader
@@ -216,7 +216,7 @@ jobs:
           sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
 
       - name: Move code to the `build/` directory
-        if: steps.php-scoper.outputs == 'failed'
+        if: steps.php-scoper.conclusion == 'failure'
         run: |
           shopt -s extglob dotglob
           mkdir build

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -161,12 +161,6 @@ jobs:
         with:
           name: ${{ needs.checkout-dependencies.outputs.artifact }}
 
-      - name: Configure Composer plugins
-        run: |
-          composer global config --no-plugins --no-interaction allow-plugins.composer/installers true
-          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/wp-translation-downloader true
-          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/composer-assets-compiler true
-
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -202,7 +202,8 @@ jobs:
         run: |
           rector || echo "Error: $?"
 
-      - name: run-php-scoper
+      - name: Run PHP-Scoper
+        id: run-php-scoper
         continue-on-error: true
         run: |
           php-scoper add-prefix --force --output-dir=build

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -178,7 +178,6 @@ jobs:
           fi
 
       - name: Set up node
-        if: steps.composer-tools.outputs.assets-compiler == '0'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.NODE_VERSION }}
@@ -203,7 +202,7 @@ jobs:
         run: |
           rector || echo "Error: $?"
 
-      - name: Run PHP-Scoper
+      - name: run-php-scoper
         continue-on-error: true
         run: |
           php-scoper add-prefix --force --output-dir=build
@@ -211,7 +210,7 @@ jobs:
           sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
 
       - name: Move code to the `build/` directory
-        if: steps.php-scoper.outcome == 'failure'
+        if: steps.run-php-scoper.outcome == 'failure'
         run: |
           shopt -s extglob dotglob
           mkdir build

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -205,6 +205,11 @@ jobs:
       - name: Run PHP-Scoper
         id: php-scoper
         run: |
+          # If no config file, bail 
+          if [ ! -f "scoper.inc.php" ]; then
+          echo "No Php-Scoper config file found (scoper.inc.php). Aborting..."
+          exit 1
+          fi
           php-scoper add-prefix --force --output-dir=build --no-interaction
           composer --working-dir=build dump-autoload -o
           sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -161,8 +161,14 @@ jobs:
         with:
           name: ${{ needs.checkout-dependencies.outputs.artifact }}
 
+      - name: Configure Composer plugins
+        run: |
+          composer global config --no-plugins --no-interaction allow-plugins.composer/installers true
+          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/wp-translation-downloader true
+          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/composer-assets-compiler true
+
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@verbose
         with:
           php-version: ${{ inputs.PHP_VERSION_BUILD }}
           tools: rector, php-scoper, sniccowp/php-scoper-wordpress-excludes, inpsyde/composer-assets-compiler, inpsyde/wp-translation-downloader

--- a/.github/workflows/build-plugin-archive.yml
+++ b/.github/workflows/build-plugin-archive.yml
@@ -161,17 +161,11 @@ jobs:
         with:
           name: ${{ needs.checkout-dependencies.outputs.artifact }}
 
-      - name: Configure Composer plugins
-        run: |
-          composer global config --no-plugins --no-interaction allow-plugins.composer/installers true
-          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/wp-translation-downloader true
-          composer global config --no-plugins --no-interaction allow-plugins.inpsyde/composer-assets-compiler true
-
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.PHP_VERSION_BUILD }}
-          tools: rector, php-scoper, sniccowp/php-scoper-wordpress-excludes, inpsyde/composer-assets-compiler, inpsyde/wp-translation-downloader
+          tools: rector, php-scoper, sniccowp/php-scoper-wordpress-excludes, composer/installers, inpsyde/composer-assets-compiler, inpsyde/wp-translation-downloader
 
       - name: Set up node cache mode
         run: |
@@ -206,7 +200,7 @@ jobs:
       - name: Run PHP-Scoper
         if: ${{ hashFiles('scoper.inc.php') != '' }}
         run: |
-          php-scoper add-prefix --force --output-dir=build --no-interaction
+          php-scoper add-prefix --force --output-dir=build
           composer --working-dir=build dump-autoload -o
           sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/MLP-2247
Currently, the workflow includes a step that checks for the presence of specific configuration files or settings to determine whether to run certain (Composer) build tools like asset compilation, PHP-Scoper, or Rector. This approach adds complexity and potential points of failure to the workflow.


**What is the new behavior (if this is a feature change)?**
This PR simplifies the workflow by:

* Removing the step that checks for optional build tools.
* Adding the necessary Composer tools directly during the PHP setup step.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**: