### PR TITLE
Allow initial `1.0.0` releases for build and distribute workflow

### DIFF
--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -309,7 +309,7 @@ jobs:
           sed -Ei "s/SHA: .*/SHA: ${{ github.sha }}/g" style.css
 
       - name: Update version in package.json
-        run: npm version ${{ env.PACKAGE_VERSION }} --no-git-tag-version
+        run: npm version ${{ env.PACKAGE_VERSION }} --no-git-tag-version --allow-same-version
 
       - name: Update version in composer.json
         if: ${{ env.HAS_COMPOSER == 'true' }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
When running the workflow on a package generated from the CLI/blueprint, which sets the `version` in `package.json` to `1.0.0`, the script breaks on the initial run (when trying to create a `1.0.0` release) with:
```
Run npm version 1.0.0 --no-git-tag-version
npm error Version not changed
```


**What is the new behavior (if this is a feature change)?**
Creating a `1.0.0` release while already having `1.0.0` in `package.json` works.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
The workflow fails because the underlying `npm version` command cannot be called with a version that already exists in `package.json`. Since the blueprint sets the version to `1.0.0` (see https://github.com/inpsyde/blueprints/blob/a8f5cd02dd9b419346f423e82becfcfe5eb66d89/features/setup-node/templates/package.json#L5), this causes failures on every initial release, with the only workaround being to skip this tag and create a `1.0.1` release.
The solution is to allow `npm version` to fail gracefully with the [`--allow-same-version`](https://docs.npmjs.com/cli/v9/commands/npm-version#allow-same-version) flag.