### PR TITLE
Fix the cache setting when package-lock.json file is missing

### DIFF
--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -147,12 +147,12 @@ jobs:
       - name: Run script for test
         continue-on-error: true
         run: |
-          touch .env.ci
-          echo "${{ secrets.ENV_FILE_DATA }}" >> .env.ci
-          # Ensure .env.ci is deleted on exit
-          trap 'rm -f .env.ci' EXIT
+          touch .env
+          echo "${{ secrets.ENV_FILE_DATA }}" >> .env
+          # Ensure .env is deleted on exit
+          trap 'rm -f .env' EXIT
           
-          cat .env.ci
+          cat .env
           
           npm run ${{ inputs.SCRIPT_NAME }}
 

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -152,6 +152,8 @@ jobs:
           # Ensure .env.ci is deleted on exit
           trap 'rm -f .env.ci' EXIT
           
+          cat .env.ci
+          
           npm run ${{ inputs.SCRIPT_NAME }}
 
       - name: Upload artifact

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -82,6 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PHP_CHECK: false
+      NODE_CACHE_MODE: ''
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -102,6 +103,14 @@ jobs:
         run: |
           git config --global user.email "${{ env.GITHUB_USER_EMAIL }}"
           git config --global user.name "${{ env.GITHUB_USER_NAME }}"
+
+      - name: Set up node cache mode
+        run: |
+          if [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; then
+            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
+          else
+            echo "No lock files found or unknown package manager"
+          fi
 
       - name: Set up PHP
         if: ${{ inputs.COMPOSER_DEPS_INSTALL }}
@@ -126,7 +135,7 @@ jobs:
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          cache: 'npm'
+          cache: ${{ env.NODE_CACHE_MODE }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -145,16 +145,12 @@ jobs:
           npx playwright install ${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}
 
       - name: Run script for test
-        env:
-          ENV_FILE_DATA: ${{ secrets.ENV_FILE_DATA }}
         continue-on-error: true
         run: |
           touch .env.ci
           echo "${{ secrets.ENV_FILE_DATA }}" >> .env.ci
-          set -a && source .env.ci && set +a
-          rm .env.ci
-          
-          echo $WP_STORAGE_STATE_SKIP_2FA
+          # Ensure .env.ci is deleted on exit
+          trap 'rm -f .env.ci' EXIT
           
           npm run ${{ inputs.SCRIPT_NAME }}
 

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -145,14 +145,14 @@ jobs:
           npx playwright install ${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}
 
       - name: Run script for test
+        env:
+          ENV_FILE_DATA: ${{ secrets.ENV_FILE_DATA }}
         continue-on-error: true
         run: |
-          touch .env
-          echo "${{ secrets.ENV_FILE_DATA }}" >> .env
-          # Ensure .env is deleted on exit
-          trap 'rm -f .env' EXIT
-          
-          cat .env
+          touch .env.ci
+          echo "${{ secrets.ENV_FILE_DATA }}" >> .env.ci
+          set -a && source .env.ci && set +a
+          rm .env.ci
           
           npm run ${{ inputs.SCRIPT_NAME }}
 

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -138,7 +138,7 @@ jobs:
           cache: ${{ env.NODE_CACHE_MODE }}
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ${{ env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
 
       - name: Install Playwright dependencies
         run: |

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -154,6 +154,8 @@ jobs:
           set -a && source .env.ci && set +a
           rm .env.ci
           
+          echo $WP_STORAGE_STATE_SKIP_2FA
+          
           npm run ${{ inputs.SCRIPT_NAME }}
 
       - name: Upload artifact


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Fix

## What is the current behavior? (You can also link to an open issue here)

When a package doesn't ship the `package-lock.json` file, the workflow fails

## What is the new behavior (if this is a feature change)?

Conditionally add the npm cache only when `package-lock.json` is found

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

## Other information
