### PR TITLE
Resolve authentication failures during Composer install in test-playwright workflow

### DIFF
--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -115,8 +115,6 @@ jobs:
       - name: Set up PHP
         if: ${{ inputs.COMPOSER_DEPS_INSTALL }}
         uses: shivammathur/setup-php@v2
-        env:
-          COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           tools: composer
@@ -125,6 +123,8 @@ jobs:
       - name: Install Composer dependencies
         if: ${{ inputs.COMPOSER_DEPS_INSTALL }}
         uses: ramsey/composer-install@v3
+        env:
+          COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
         with:
           composer-options: '--prefer-dist'
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Fix


## What is the current behavior? (You can also link to an open issue here)
The workflow fails during Composer dependency installation with authentication errors when the GitHub Actions cache is not available.


## What is the new behavior (if this is a feature change)?
The `COMPOSER_AUTH` environment variable is now set in the "Install Composer dependencies" step.



## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No


## Other information
