### PR TITLE
Prevent silent failures in test-playwright workflow

### DIFF
--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -145,6 +145,7 @@ jobs:
           npx playwright install ${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}
 
       - name: Run script for test
+        id: run-script
         continue-on-error: true
         run: |
           touch .env.ci
@@ -155,6 +156,7 @@ jobs:
           npm run ${{ inputs.SCRIPT_NAME }}
 
       - name: Upload artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.ARTIFACT_NAME }}
@@ -163,3 +165,9 @@ jobs:
           overwrite: ${{ inputs.ARTIFACT_OVERWRITE }}
           include-hidden-files: ${{ inputs.ARTIFACT_INCLUDE_HIDDEN_FILES }}
           retention-days: ${{ inputs.ARTIFACT_RETENTION_DAYS }}
+
+      - name: Check test results
+        if: steps.run-script.outcome == 'failure'
+        run: |
+          echo "Tests failed! Check the artifacts for details."
+          exit 1


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Improvement


## What is the current behavior? (You can also link to an open issue here)
The test step uses `continue-on-error` to allow artifact upload for debugging(my guess), but the workflow never checked the actual test outcome afterward. This caused test failures to be silently ignored, showing green CI status.


## What is the new behavior (if this is a feature change)?
Add step ID and outcome check to properly fail the job when tests fail.


## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No


## Other information
