### PR TITLE
wordpress.org release (SPP-91)

### DIFF
--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -16,6 +16,12 @@ on:
         type: string
         required: true
 
+      TEST_MODE:
+        description: "In test mode no commit to SVN repository happens. Instead, local SVN repository is used, and then provided as an archive for manual checking."
+        type: boolean
+        default: false
+        required: false
+
     secrets:
       SVN_USERNAME:
         required: true
@@ -85,3 +91,7 @@ jobs:
           svn status | grep '^!' | cut -c9- | while IFS= read -r file; do
             svn delete "$file@"  # @ suffix handles files with @ in name
           done
+
+      - name: [TEST MODE] Pack files and provide as an artefact instead of commiting to the actual repository
+          if: ${{ inputs.TEST_MODE }}
+          run: | #TODO: create an artifact and upload it here

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -54,9 +54,6 @@ jobs:
           if [[ ! -f "$GITHUB_WORKSPACE/readme.txt" ]]; then 
             echo "No readme.txt in the Git repository - preserving exising one";
             EXTRA_EXCLUDES="--exclude=readme.txt" 
-          else
-            echo ""
-          fi
           
           rsync -rc \
           --delete \

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -33,6 +33,11 @@ jobs:
       SVN_TRUNK_PATH: "$SVN_REPO_PATH/trunk"
     runs-on: ubuntu-latest
     steps:
+      - name: Install required tools
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y subversion rsync
+
       - name: Checkout git repository
         uses: actions/checkout@v6
 
@@ -41,11 +46,6 @@ jobs:
           echo "Checking out SVN repository"
           mkdir $SVN_REPO_PATH && cd $SVN_REPO_PATH
           svn checkout "${{ inputs.SVN_REPOSITORY }}/${{ inputs.SVN_PLUGIN_SLUG }}"
-
-      - name: Install required tools
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y subversion rsync
 
       - name: Synchronize SVN repository with Git
         run: |

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -145,6 +145,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.SVN_PLUGIN_SLUG }}
-          path: ${{ runner.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}/trunk
+          path: ${{ env.SVN_REPO_ROOT }}/trunk
           include-hidden-files: true
           compression-level: 1 #Minimal compression - we don't want to waste resources for this

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -77,6 +77,8 @@ jobs:
           --exclude='node_modules' \
           --exclude='.github' \
           --exclude='.ddev' \
+          --exclude='.idea' \
+          --exclude='.vscode' \
           --exclude-from='.distignore' \
           "$GITHUB_WORKSPACE/" "$SVN_REPO_ROOT/trunk/"
           

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -49,11 +49,6 @@ jobs:
           set -euo pipefail
 
           touch .distignore
-
-          EXTRA_EXCLUDES=""
-          if [[ ! -f "$GITHUB_WORKSPACE/readme.txt" ]]; then 
-            echo "No readme.txt in the Git repository - preserving exising one";
-            EXTRA_EXCLUDES="--exclude=readme.txt" 
           
           rsync -rc \
           --delete \
@@ -72,5 +67,4 @@ jobs:
           --exclude='.github' \
           --exclude='.ddev' \
           --exclude-from='.distignore' \
-          $EXTRA_EXCLUDES \
           "$GITHUB_WORKSPACE/" "$SVN_TRUNK_PATH/"

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          touch .distignore
+          touch .distignore # Ensure file exists so --exclude-from doesn't fail
           
           rsync -rc \
           --delete \
@@ -134,7 +134,8 @@ jobs:
           cd "${SVN_REPO_ROOT}/trunk"
           svn add . --force
           
-          if svn status | grep -q '^!'; then #Only run if there's anything to delete
+          #Only run if there's anything to delete
+          if svn status | grep -q '^!'; then
             svn status | grep '^!' | cut -c9- | while IFS= read -r file; do
               svn delete "$file@"  # @ suffix handles files with @ in name
             done

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -48,6 +48,11 @@ jobs:
           mkdir $SVN_REPO_PATH && cd $SVN_REPO_PATH
           svn checkout "${{ inputs.SVN_REPOSITORY }}/${{ inputs.SVN_PLUGIN_SLUG }}"
 
+      - name: Install required tools
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y subversion rsync
+
       - name: Synchronize SVN repository with Git
         run: |
       # run rsync here

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -33,6 +33,9 @@ on:
       SVN_PASSWORD:
         required: true
 
+      GITHUB_USER_SSH_KEY:
+        required: true
+
 jobs:
   update_svn_from_git:
     env:

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -27,18 +27,15 @@ on:
         required: true
 
 jobs:
-  check_out_git_repository:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout git repository
-        uses: actions/checkout@v6
-
   update_svn_from_git:
     env:
       SVN_REPO_PATH: "$HOME/svn_repository"
       SVN_TRUNK_PATH: "$SVN_REPO_PATH/trunk"
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout git repository
+        uses: actions/checkout@v6
+
       - name: Checkout SVN repository
         run: |
           echo "Checking out SVN repository"

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -26,9 +26,6 @@ on:
         type: string
         required: true
 
-env:
-  SVN_REPO_PATH: $HOME/svn_repository
-
 jobs:
   check_out_git_repository:
     runs-on: ubuntu-latest

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Checkout SVN repository
         run: |
           set -euo pipefail
-          echo "Checking out SVN repository"
           mkdir -p $SVN_REPO_PATH && cd $SVN_REPO_PATH
           svn checkout "${{ inputs.SVN_REPOSITORY }}/${{ inputs.SVN_PLUGIN_SLUG }}"
 

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -215,7 +215,6 @@ jobs:
             --non-interactive \
             -m "Update trunk to version ${VALIDATED_PLUGIN_VERSION}"
 
-
       - name: Create a new tag
         if: inputs.UPDATE_TRUNK_ONLY == false  && inputs.DRY_RUN != true
         env:

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -88,7 +88,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p $SVN_REPO_PATH && cd $SVN_REPO_PATH
-          svn checkout "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}"          
+          svn checkout "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}" --depth immediates
+          cd $SVN_REPO_ROOT && svn update trunk --set-depth infinity
 
       - name: Synchronize SVN repository with Git
         working-directory: ${{ github.workspace }} #Make sure we are in the right place before start sync

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -37,6 +37,9 @@ jobs:
         uses: actions/checkout@v6
 
   update_svn_from_git:
+    env:
+      SVN_REPO_PATH: "$HOME/svn_repository"
+      SVN_TRUNK_PATH: "$SVN_REPO_PATH/trunk"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout SVN repository

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -35,20 +35,11 @@ on:
 
 jobs:
   update_svn_from_git:
-    # TODO: Set env vars here and remove an extra step.
-    # This works in real GH Actions but act doesn't support runner context at job level, so we had to create an extra step
-    # Desired format:
-    #   env:
-    #     SVN_REPO_PATH: "${{ runner.workspace }}/svn_repository"
-    #     SVN_REPO_ROOT: "${{ runner.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}"
+    env:
+      SVN_REPO_PATH: "${{ runner.workspace }}/svn_repository"
+      SVN_REPO_ROOT: "${{ runner.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}"
     runs-on: ubuntu-latest
     steps:
-      #TODO: remove this step (see the comment above for details)
-      - name: Configure paths
-        run: |
-          echo "SVN_REPO_PATH=${{ runner.workspace }}/svn_repository" >> $GITHUB_ENV
-          echo "SVN_REPO_ROOT=${{ runner.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}" >> $GITHUB_ENV
-
       - name: Install required tools
         run: |
           sudo apt-get update -y

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -10,6 +10,11 @@ on:
         type: string
         required: true
 
+      TAG:
+        description: "Git tag to publish to publish at WordPress.org (note: it must exist in git and not exist in SVN)"
+        type: string
+        required: true
+
       DRY_RUN:
         description: "In dry-run mode no commit to the SVN repository happens. Instead, files from trunk are provided as an artifact."
         type: boolean
@@ -33,7 +38,7 @@ jobs:
     #     SVN_REPO_ROOT: "${{ runner.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}"
     runs-on: ubuntu-latest
     steps:
-        #TODO: remove this step (see the comment above for details)
+      #TODO: remove this step (see the comment above for details)
       - name: Configure paths
         run: |
           echo "SVN_REPO_PATH=${{ runner.workspace }}/svn_repository" >> $GITHUB_ENV
@@ -46,6 +51,8 @@ jobs:
 
       - name: Checkout git repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.TAG }} #TODO: Sanitize and validate tag name
 
       - name: Checkout SVN repository
         run: |

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -83,6 +83,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.GIT_REF }}
+          ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Checkout SVN repository
         run: |

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           set -euo pipefail
           
-          cd $SVN_REPO_ROOT
+          cd "${SVN_REPO_ROOT}/trunk"
           svn add . --force
           
           if svn status | grep -q '^!'; then #Only run if there's anything to delete

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -143,6 +143,7 @@ jobs:
           cd "$SVN_REPO_ROOT" && svn update trunk --set-depth infinity
 
       - name: Verify version doesn't exist in SVN
+        if: inputs.UPDATE_TRUNK_ONLY != true
         run: |
           set -euo pipefail
 

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -92,6 +92,16 @@ jobs:
             svn delete "$file@"  # @ suffix handles files with @ in name
           done
 
-      - name: [TEST MODE] Pack files and provide as an artefact instead of commiting to the actual repository
-          if: ${{ inputs.TEST_MODE }}
-          run: | #TODO: create an artifact and upload it here
+      - name: Commit changes to SVN repository
+        if: inputs.TEST_MODE != true
+        run: | #TODO: do SVN commit here
+          echo 'Committing...'
+
+      - name: Compress and upload trunk contents as an artifact
+        if: inputs.TEST_MODE == true
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.SVN_PLUGIN_SLUG }}
+          path: ${{ runner.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}/trunk
+          include-hidden-files: true
+          compression-level: 1

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -129,9 +129,12 @@ jobs:
           
           cd $SVN_REPO_ROOT
           svn add . --force
-          svn status | grep '^!' | cut -c9- | while IFS= read -r file; do
-            svn delete "$file@"  # @ suffix handles files with @ in name
-          done
+          
+          if svn status | grep -q '^!'; then #Only run if there's anything to delete
+            svn status | grep '^!' | cut -c9- | while IFS= read -r file; do
+              svn delete "$file@"  # @ suffix handles files with @ in name
+            done
+          fi
 
       - name: Commit changes to SVN repository
         if: inputs.DRY_RUN != true

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -153,7 +153,7 @@ jobs:
         if: inputs.DRY_RUN != true
         run: |
           cd "$SVN_REPO_ROOT"
-          svn copy trunk "tags/$VALIDATED_PLUGIN_VERSION"
+          svn copy trunk "tags/${VALIDATED_PLUGIN_VERSION}"
           echo 'Committing...' #TODO: do SVN commit here
 
       - name: Compress and upload trunk contents as an artifact

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -83,8 +83,6 @@ jobs:
           --exclude='.distignore' \
           --exclude-from='.distignore' \
           ./ "$SVN_REPO_ROOT/trunk/"
-          
-          cd "$SVN_REPO_ROOT/trunk" && pwd && ls -lha
 
       - name: Update SVN tracking
         run: |

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout SVN repository
         run: |
           echo "Checking out SVN repository"
-          mkdir $SVN_REPO_PATH && cd $SVN_REPO_PATH
+          mkdir -p $SVN_REPO_PATH && cd $SVN_REPO_PATH
           svn checkout "${{ inputs.SVN_REPOSITORY }}/${{ inputs.SVN_PLUGIN_SLUG }}"
 
       - name: Synchronize SVN repository with Git

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -77,3 +77,11 @@ jobs:
           --exclude='.ddev' \
           --exclude-from='.distignore' \
           "$GITHUB_WORKSPACE/" "$SVN_REPO_ROOT/trunk/"
+
+      - name: Update SVN tracking
+        run: |
+          cd $SVN_REPO_ROOT
+          svn add . --force
+          svn status | grep '^!' | cut -c9- | while IFS= read -r file; do
+            svn delete "$file@"  # @ suffix handles files with @ in name
+          done

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -26,6 +26,12 @@ on:
         default: false
         required: false
 
+      UPDATE_TRUNK_ONLY:
+        description: "Only update trunk at wordpress.org, but don't create a new tag (version)"
+        type: boolean
+        default: true
+        required: false
+
     secrets:
       SVN_USERNAME:
         required: true
@@ -209,6 +215,17 @@ jobs:
             --non-interactive \
             -m "Update trunk to version ${VALIDATED_PLUGIN_VERSION}"
 
+
+      - name: Create a new tag
+        if: inputs.UPDATE_TRUNK_ONLY == false  && inputs.DRY_RUN != true
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          
+          echo "🚀 Publishing version ${VALIDATED_PLUGIN_VERSION}"
+          
           svn copy \
             "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/trunk" \
             "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/tags/${VALIDATED_PLUGIN_VERSION}" \

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -83,6 +83,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$SVN_REPO_PATH" && cd "$SVN_REPO_PATH"
+          
+          #We only getting full contents of trunk here, the rest of directories we left empty.
+          #For some older plugins, tags directory may take gigabytes, and we don't need them here.
+          
           svn checkout "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}" --depth immediates
           cd "$SVN_REPO_ROOT" && svn update trunk --set-depth infinity
 

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -79,6 +79,7 @@ jobs:
           --exclude='.ddev' \
           --exclude='.idea' \
           --exclude='.vscode' \
+          --exclude='.distignore' \
           --exclude-from='.distignore' \
           "$GITHUB_WORKSPACE/" "$SVN_REPO_ROOT/trunk/"
           

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -84,8 +84,8 @@ jobs:
           set -euo pipefail
           mkdir -p "$SVN_REPO_PATH" && cd "$SVN_REPO_PATH"
           
-          #We only getting full contents of trunk here, the rest of directories we left empty.
-          #For some older plugins, tags directory may take gigabytes, and we don't need them here.
+          # We only do a full checkout of trunk here, leaving other directories empty.
+          # Tags directory can take gigabytes for older plugins, and we don't need them for publishing.
           
           svn checkout "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}" --depth immediates
           cd "$SVN_REPO_ROOT" && svn update trunk --set-depth infinity

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -37,7 +37,7 @@ on:
         required: true
 
 jobs:
-  push_trunk:
+  update_svn_from_git:
     env:
       SVN_REPO_PATH: "${{ github.workspace }}/svn_repository"
       SVN_REPO_ROOT: "${{ github.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}"
@@ -129,10 +129,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$SVN_REPO_PATH" && cd "$SVN_REPO_PATH"
-
+          
           # We only do a full checkout of trunk here, leaving other directories empty.
           # Tags directory can take gigabytes for older plugins, and we don't need them for publishing.
-
+          
           svn checkout "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}" --depth immediates
           cd "$SVN_REPO_ROOT" && svn update trunk --set-depth infinity
 
@@ -157,7 +157,7 @@ jobs:
           set -euo pipefail
 
           touch .distignore # Ensure file exists so --exclude-from doesn't fail
-
+          
           rsync -rc \
           --delete \
           --delete-excluded \
@@ -174,10 +174,10 @@ jobs:
       - name: Update SVN tracking
         run: |
           set -euo pipefail
-
+          
           cd "${SVN_REPO_ROOT}/trunk"
           svn add . --force
-
+          
           #Only run if there's anything to delete
           if svn status | grep -q '^!'; then
             svn status | grep '^!' | cut -c9- | while IFS= read -r file; do
@@ -185,7 +185,7 @@ jobs:
             done
           fi
 
-      - name: Commit trunk to SVN repository
+      - name: Commit changes to SVN repository
         if: inputs.DRY_RUN != true
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
@@ -200,7 +200,7 @@ jobs:
 
           # WordPress.org SVN doesn't support SSH keys or tokens.
           # Keeping credentials as step-level env vars with --no-auth-cache is the best available option.
-          echo '🚀 Committing trunk...'
+          echo '🚀 Committing...'
 
           svn commit trunk \
             --username "$SVN_USERNAME" \
@@ -209,7 +209,16 @@ jobs:
             --non-interactive \
             -m "Update trunk to version ${VALIDATED_PLUGIN_VERSION}"
 
-          echo "✅ Trunk updated to version ${VALIDATED_PLUGIN_VERSION}"
+          svn copy \
+            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/trunk" \
+            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/tags/${VALIDATED_PLUGIN_VERSION}" \
+            --username "$SVN_USERNAME" \
+            --password "$SVN_PASSWORD" \
+            --no-auth-cache \
+            --non-interactive \
+            -m "Tagging version ${VALIDATED_PLUGIN_VERSION}"
+
+          echo "✅ Version ${VALIDATED_PLUGIN_VERSION} was published to WordPress.org"
 
       - name: Compress and upload trunk contents as an artifact
         if: inputs.DRY_RUN == true
@@ -219,34 +228,3 @@ jobs:
           path: ${{ env.SVN_REPO_ROOT }}/trunk
           include-hidden-files: true
           compression-level: 1 #Minimal compression - we don't want to waste resources for this
-
-  create_tag:
-    needs: push_trunk
-    if: inputs.DRY_RUN != true
-    environment: wordpress-org-release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install subversion
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y subversion
-
-      - name: Create SVN tag
-        env:
-          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        run: |
-          set -euo pipefail
-
-          echo '🚀 Creating tag...'
-
-          svn copy \
-            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/trunk" \
-            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/tags/${{ inputs.PLUGIN_VERSION }}" \
-            --username "$SVN_USERNAME" \
-            --password "$SVN_PASSWORD" \
-            --no-auth-cache \
-            --non-interactive \
-            -m "Tagging version ${{ inputs.PLUGIN_VERSION }}"
-
-          echo "✅ Version ${{ inputs.PLUGIN_VERSION }} was published to WordPress.org"

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout git repository
         uses: actions/checkout@v6
 
-  check_out_svn_repository:
+  update_svn_from_git:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout SVN repository

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -10,8 +10,8 @@ on:
         type: string
         required: true
 
-      TEST_MODE:
-        description: "In test mode no commit to the SVN repository happens. Instead, files from trunk are provided as an artifact."
+      DRY_RUN:
+        description: "In dry-run mode no commit to the SVN repository happens. Instead, files from trunk are provided as an artifact."
         type: boolean
         default: false
         required: false
@@ -93,12 +93,12 @@ jobs:
           done
 
       - name: Commit changes to SVN repository
-        if: inputs.TEST_MODE != true
+        if: inputs.DRY_RUN != true
         run: | #TODO: do SVN commit here
           echo 'Committing...'
 
       - name: Compress and upload trunk contents as an artifact
-        if: inputs.TEST_MODE == true
+        if: inputs.DRY_RUN == true
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.SVN_PLUGIN_SLUG }}

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -151,10 +151,39 @@ jobs:
 
       - name: Commit changes to SVN repository
         if: inputs.DRY_RUN != true
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         run: |
+          set -euo pipefail
+
+          [ -d "$SVN_REPO_ROOT" ] || { echo "❌ SVN_REPO_ROOT not found"; exit 1; }
           cd "$SVN_REPO_ROOT"
-          svn copy trunk "tags/${VALIDATED_PLUGIN_VERSION}"
-          echo 'Committing...' #TODO: do SVN commit here
+
+          svn status trunk | grep -q '^C' && { echo "❌ SVN conflicts in trunk"; exit 1; }
+          svn status trunk | grep -q '^[ADMR!~]' || { echo "❌ No changes in trunk"; exit 1; }
+
+          # WordPress.org SVN doesn't support SSH keys or tokens.
+          # Keeping credentials as step-level env vars with --no-auth-cache is the best available option.
+          echo '🚀 Committing...'
+
+          svn commit trunk \
+            --username "$SVN_USERNAME" \
+            --password "$SVN_PASSWORD" \
+            --no-auth-cache \
+            --non-interactive \
+            -m "Update trunk to version ${VALIDATED_PLUGIN_VERSION}"
+
+          svn copy \
+            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/trunk" \
+            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/tags/${VALIDATED_PLUGIN_VERSION}" \
+            --username "$SVN_USERNAME" \
+            --password "$SVN_PASSWORD" \
+            --no-auth-cache \
+            --non-interactive \
+            -m "Tagging version ${VALIDATED_PLUGIN_VERSION}"
+
+          echo "✅ Version ${VALIDATED_PLUGIN_VERSION} was published to WordPress.org"
 
       - name: Compress and upload trunk contents as an artifact
         if: inputs.DRY_RUN == true

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: Update SVN tracking
         run: |
+          set -euo pipefail
+          
           cd $SVN_REPO_ROOT
           svn add . --force
           svn status | grep '^!' | cut -c9- | while IFS= read -r file; do

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -54,6 +54,7 @@ jobs:
           svn checkout "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}"          
 
       - name: Synchronize SVN repository with Git
+        working-directory: ${{ github.workspace }} #Make sure we are in the right place before start sync
         run: |
           set -euo pipefail
 
@@ -81,7 +82,7 @@ jobs:
           --exclude='.vscode' \
           --exclude='.distignore' \
           --exclude-from='.distignore' \
-          "$GITHUB_WORKSPACE/" "$SVN_REPO_ROOT/trunk/"
+          ./ "$SVN_REPO_ROOT/trunk/"
           
           cd "$SVN_REPO_ROOT/trunk" && pwd && ls -lha
 

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: wordpress.org publishing
+
+on:
+  workflow_call:
+    inputs:
+      SVN_REPOSITORY:
+        description: "SVN repository to push a new version to. Defaults to wordpress.org"
+        type: string
+        default: "https://plugins.svn.wordpress.org"
+        required: false
+
+      SVN_PLUGIN_SLUG:
+        description: "Plugin slug in the SVN repository. E.g. if plugin URL is https://wordpress.org/plugins/payoneer-checkout, slug is payoneer-checkout."
+        type: string
+        required: true
+
+      SVN_USERNAME:
+        description: "In case of wordpress.org, this is your username"
+        type: string
+        required: true
+
+      SVN_PASSWORD:
+        description: "In case of wordpress.org, it should be a separate SVN password, not account password. See https://make.wordpress.org/meta/handbook/tutorials-guides/svn-access/ for more details."
+        type: string
+        required: true
+
+env:
+  SVN_REPO_PATH: $HOME/svn_repository
+
+jobs:
+  check_out_git_repository:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout git repository
+        uses: actions/checkout@v6
+
+  check_out_svn_repository:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout SVN repository
+        run: |
+          echo "Checking out SVN repository"
+          mkdir $SVN_REPO_PATH && cd $SVN_REPO_PATH
+          svn checkout "${{ inputs.SVN_REPOSITORY }}/${{ inputs.SVN_PLUGIN_SLUG }}"
+
+      - name: Synchronize SVN repository with Git
+        run: |
+      # run rsync here

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -11,7 +11,7 @@ on:
         required: true
 
       TEST_MODE:
-        description: "In test mode no commit to SVN repository happens. Instead, local SVN repository is used, and then provided as an archive for manual checking."
+        description: "In test mode no commit to the SVN repository happens. Instead, files from trunk are provided as an artifact."
         type: boolean
         default: false
         required: false

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -21,7 +21,7 @@ on:
         required: true
 
       DRY_RUN:
-        description: "In dry-run mode no commit to the SVN repository happens. Instead, files from trunk are provided as an artifact."
+        description: "Create artifact from trunk instead of committing to SVN"
         type: boolean
         default: false
         required: false
@@ -147,4 +147,4 @@ jobs:
           name: ${{ inputs.SVN_PLUGIN_SLUG }}
           path: ${{ runner.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}/trunk
           include-hidden-files: true
-          compression-level: 1
+          compression-level: 1 #Minimal compression - we don't want to waste resources for this

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -10,8 +10,13 @@ on:
         type: string
         required: true
 
-      TAG:
-        description: "Git tag to publish to publish at WordPress.org (note: it must exist in git and not exist in SVN)"
+      PLUGIN_VERSION:
+        description: "Plugin version to publish at WordPress.org (note: it must not exist in SVN)"
+        type: string
+        required: true
+
+      GIT_REF:
+        description: "Git ref to publish at WordPress.org (tag, branch or commit)"
         type: string
         required: true
 
@@ -49,10 +54,35 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y subversion rsync
 
+      - name: Validate versions
+        env:
+          PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}
+          GIT_REF: ${{ inputs.GIT_REF }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$PLUGIN_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "❌ WordPress.org expects version formatted as MAJOR.MINOR.PATCH"
+            echo "   Three groups of numbers separated by dots"
+            echo "   Each group: either 0 or digits not starting with 0"
+            echo "   Received: $PLUGIN_VERSION"
+            exit 1
+          fi
+
+          echo "VALIDATED_PLUGIN_VERSION=$PLUGIN_VERSION" >> $GITHUB_ENV
+          echo "✅ Valid WordPress.org version: $PLUGIN_VERSION"
+
+          if ! git check-ref-format --allow-onelevel "$GIT_REF"; then
+            echo "❌ Invalid Git ref name: $GIT_REF"
+            exit 1
+          fi
+        # We do not create VALIDATED_GIT_REF env var here because actions/checkout action we are going to use it with cannot take ref from vars anyway.
+        # But since it is validated, it is safe to use it directly from user input.
+
       - name: Checkout git repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.TAG }} #TODO: Sanitize and validate tag name
+          ref: ${{ inputs.GIT_REF }}
 
       - name: Checkout SVN repository
         run: |
@@ -105,7 +135,7 @@ jobs:
         if: inputs.DRY_RUN != true
         run: |
           cd "$SVN_REPO_ROOT"
-          svn copy trunk "tags/$TAG" #TODO: put sanitized and validated tag into this env var or use step outputs instead
+          svn copy trunk "tags/$VALIDATED_PLUGIN_VERSION"
           echo 'Committing...' #TODO: do SVN commit here
 
       - name: Compress and upload trunk contents as an artifact

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -5,12 +5,6 @@ name: wordpress.org publishing
 on:
   workflow_call:
     inputs:
-      SVN_REPOSITORY:
-        description: "SVN repository to push a new version to. Defaults to wordpress.org"
-        type: string
-        default: "https://plugins.svn.wordpress.org"
-        required: false
-
       SVN_PLUGIN_SLUG:
         description: "Plugin slug in the SVN repository. E.g. if plugin URL is https://wordpress.org/plugins/payoneer-checkout, slug is payoneer-checkout."
         type: string
@@ -57,7 +51,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p $SVN_REPO_PATH && cd $SVN_REPO_PATH
-          svn checkout "${{ inputs.SVN_REPOSITORY }}/${{ inputs.SVN_PLUGIN_SLUG }}"          
+          svn checkout "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}"          
 
       - name: Synchronize SVN repository with Git
         run: |

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -79,6 +79,52 @@ jobs:
           ref: ${{ inputs.GIT_REF }}
           ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
+      - name: Verify version consistency
+        run: |
+          set -euo pipefail
+
+          PLUGIN_FILE=$(find . -maxdepth 1 -type f -name '*.php' -exec grep -l 'Plugin Name:' {} + | head -1)
+          if [ -z "$PLUGIN_FILE" ]; then
+            echo "❌ No plugin file with 'Plugin Name:' header found"
+            exit 1
+          fi
+
+          EXTRACTION_ERROR=0
+
+          PLUGIN_FILE_VERSION=$(grep -m1 'Version:' "$PLUGIN_FILE" | grep -oP '[\d]+\.[\d]+\.[\d]+')
+          if [ -z "$PLUGIN_FILE_VERSION" ]; then
+            echo "❌ Could not extract version from $PLUGIN_FILE"
+            EXTRACTION_ERROR=1
+          fi
+
+          if [ ! -f readme.txt ]; then
+            echo "❌ readme.txt not found"
+            EXTRACTION_ERROR=1
+          else
+            README_VERSION=$(grep -m1 'Stable tag:' readme.txt | grep -oP '[\d]+\.[\d]+\.[\d]+' || true)
+            if [ -z "$README_VERSION" ]; then
+              echo "❌ Could not extract 'Stable tag:' from readme.txt"
+              EXTRACTION_ERROR=1
+            fi
+          fi
+
+          [ "$EXTRACTION_ERROR" = "1" ] && exit 1
+
+          MISMATCH=0
+
+          if [ "$VALIDATED_PLUGIN_VERSION" != "$PLUGIN_FILE_VERSION" ]; then
+            echo "❌ Input version ($VALIDATED_PLUGIN_VERSION) does not match $PLUGIN_FILE ($PLUGIN_FILE_VERSION)"
+            MISMATCH=1
+          fi
+          if [ "$VALIDATED_PLUGIN_VERSION" != "$README_VERSION" ]; then
+            echo "❌ Input version ($VALIDATED_PLUGIN_VERSION) does not match readme.txt Stable tag ($README_VERSION)"
+            MISMATCH=1
+          fi
+
+          [ "$MISMATCH" = "1" ] && exit 1
+
+          echo "✅ Version $VALIDATED_PLUGIN_VERSION is consistent across inputs, plugin file, and readme.txt"
+
       - name: Checkout SVN repository
         run: |
           set -euo pipefail

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -103,8 +103,10 @@ jobs:
 
       - name: Commit changes to SVN repository
         if: inputs.DRY_RUN != true
-        run: | #TODO: do SVN commit here
-          echo 'Committing...'
+        run: |
+          cd "$SVN_REPO_ROOT"
+          svn copy trunk "tags/$TAG" #TODO: put sanitized and validated tag into this env var or use step outputs instead
+          echo 'Committing...' #TODO: do SVN commit here
 
       - name: Compress and upload trunk contents as an artifact
         if: inputs.DRY_RUN == true

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -196,7 +196,6 @@ jobs:
           [ -d "$SVN_REPO_ROOT" ] || { echo "❌ SVN_REPO_ROOT not found"; exit 1; }
           cd "$SVN_REPO_ROOT"
 
-          svn status trunk | grep -q '^C' && { echo "❌ SVN conflicts in trunk"; exit 1; }
           svn status trunk | grep -q '^[ADMR!~]' || { echo "❌ No changes in trunk"; exit 1; }
 
           # WordPress.org SVN doesn't support SSH keys or tokens.

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     inputs:
       SVN_PLUGIN_SLUG:
-        description: "Plugin slug in the SVN repository. E.g. if plugin URL is https://wordpress.org/plugins/payoneer-checkout, slug is payoneer-checkout."
+        description: "WordPress.org plugin slug (e.g., 'woocommerce' from https://wordpress.org/plugins/woocommerce)"
         type: string
         required: true
 
@@ -59,6 +59,8 @@ jobs:
 
           touch .distignore
           
+          ls $GITHUB_WORKSPACE
+          
           rsync -rc \
           --delete \
           --delete-excluded \
@@ -77,6 +79,8 @@ jobs:
           --exclude='.ddev' \
           --exclude-from='.distignore' \
           "$GITHUB_WORKSPACE/" "$SVN_REPO_ROOT/trunk/"
+          
+          cd "$SVN_REPO_ROOT/trunk" && pwd && ls -lha
 
       - name: Update SVN tracking
         run: |

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -6,17 +6,17 @@ on:
   workflow_call:
     inputs:
       SVN_PLUGIN_SLUG:
-        description: "WordPress.org plugin slug (e.g., 'woocommerce' from https://wordpress.org/plugins/woocommerce)"
+        description: "WordPress.org plugin slug (e.g., 'woocommerce')"
         type: string
         required: true
 
       PLUGIN_VERSION:
-        description: "Plugin version to publish at WordPress.org (note: it must not exist in SVN)"
+        description: "Plugin version to publish (MAJOR.MINOR.PATCH)"
         type: string
         required: true
 
       GIT_REF:
-        description: "Git ref to publish at WordPress.org (tag, branch or commit)"
+        description: "Git ref to publish (tag, branch, or commit)"
         type: string
         required: true
 

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -99,8 +99,6 @@ jobs:
 
           touch .distignore
           
-          ls $GITHUB_WORKSPACE
-          
           rsync -rc \
           --delete \
           --delete-excluded \

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -164,18 +164,9 @@ jobs:
           --exclude='.git' \
           --exclude='.svn' \
           --exclude='auth.json' \
+          --exclude='.npmrc' \
           --exclude='.env' \
           --exclude='.env.*' \
-          --exclude='composer.json' \
-          --exclude='composer.lock' \
-          --exclude='package.json' \
-          --exclude='package-lock.json' \
-          --exclude='yarn.lock' \
-          --exclude='node_modules' \
-          --exclude='.github' \
-          --exclude='.ddev' \
-          --exclude='.idea' \
-          --exclude='.vscode' \
           --exclude='.distignore' \
           --exclude-from='.distignore' \
           ./ "$SVN_REPO_ROOT/trunk/"

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -43,10 +43,41 @@ jobs:
 
       - name: Checkout SVN repository
         run: |
+          set -euo pipefail
           echo "Checking out SVN repository"
           mkdir -p $SVN_REPO_PATH && cd $SVN_REPO_PATH
           svn checkout "${{ inputs.SVN_REPOSITORY }}/${{ inputs.SVN_PLUGIN_SLUG }}"
 
       - name: Synchronize SVN repository with Git
         run: |
-      # run rsync here
+          set -euo pipefail
+
+          touch .distignore
+
+          EXTRA_EXCLUDES=""
+          if [[ ! -f "$GITHUB_WORKSPACE/readme.txt" ]]; then 
+            echo "No readme.txt in the Git repository - preserving exising one";
+            EXTRA_EXCLUDES="--exclude=readme.txt" 
+          else
+            echo ""
+          fi
+          
+          rsync -rc \
+          --delete \
+          --delete-excluded \
+          --exclude='.git' \
+          --exclude='.svn' \
+          --exclude='auth.json' \
+          --exclude='.env' \
+          --exclude='.env.*' \
+          --exclude='composer.json' \
+          --exclude='composer.lock' \
+          --exclude='package.json' \
+          --exclude='package-lock.json' \
+          --exclude='yarn.lock' \
+          --exclude='node_modules' \
+          --exclude='.github' \
+          --exclude='.ddev' \
+          --exclude-from='.distignore' \
+          $EXTRA_EXCLUDES \
+          "$GITHUB_WORKSPACE/" "$SVN_TRUNK_PATH/"

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -16,14 +16,11 @@ on:
         type: string
         required: true
 
+    secrets:
       SVN_USERNAME:
-        description: "In case of wordpress.org, this is your username"
-        type: string
         required: true
 
       SVN_PASSWORD:
-        description: "In case of wordpress.org, it should be a separate SVN password, not account password. See https://make.wordpress.org/meta/handbook/tutorials-guides/svn-access/ for more details."
-        type: string
         required: true
 
 jobs:

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -37,7 +37,7 @@ on:
         required: true
 
 jobs:
-  update_svn_from_git:
+  push_trunk:
     env:
       SVN_REPO_PATH: "${{ github.workspace }}/svn_repository"
       SVN_REPO_ROOT: "${{ github.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}"
@@ -129,10 +129,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$SVN_REPO_PATH" && cd "$SVN_REPO_PATH"
-          
+
           # We only do a full checkout of trunk here, leaving other directories empty.
           # Tags directory can take gigabytes for older plugins, and we don't need them for publishing.
-          
+
           svn checkout "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}" --depth immediates
           cd "$SVN_REPO_ROOT" && svn update trunk --set-depth infinity
 
@@ -157,7 +157,7 @@ jobs:
           set -euo pipefail
 
           touch .distignore # Ensure file exists so --exclude-from doesn't fail
-          
+
           rsync -rc \
           --delete \
           --delete-excluded \
@@ -183,10 +183,10 @@ jobs:
       - name: Update SVN tracking
         run: |
           set -euo pipefail
-          
+
           cd "${SVN_REPO_ROOT}/trunk"
           svn add . --force
-          
+
           #Only run if there's anything to delete
           if svn status | grep -q '^!'; then
             svn status | grep '^!' | cut -c9- | while IFS= read -r file; do
@@ -194,7 +194,7 @@ jobs:
             done
           fi
 
-      - name: Commit changes to SVN repository
+      - name: Commit trunk to SVN repository
         if: inputs.DRY_RUN != true
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
@@ -210,7 +210,7 @@ jobs:
 
           # WordPress.org SVN doesn't support SSH keys or tokens.
           # Keeping credentials as step-level env vars with --no-auth-cache is the best available option.
-          echo '🚀 Committing...'
+          echo '🚀 Committing trunk...'
 
           svn commit trunk \
             --username "$SVN_USERNAME" \
@@ -219,16 +219,7 @@ jobs:
             --non-interactive \
             -m "Update trunk to version ${VALIDATED_PLUGIN_VERSION}"
 
-          svn copy \
-            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/trunk" \
-            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/tags/${VALIDATED_PLUGIN_VERSION}" \
-            --username "$SVN_USERNAME" \
-            --password "$SVN_PASSWORD" \
-            --no-auth-cache \
-            --non-interactive \
-            -m "Tagging version ${VALIDATED_PLUGIN_VERSION}"
-
-          echo "✅ Version ${VALIDATED_PLUGIN_VERSION} was published to WordPress.org"
+          echo "✅ Trunk updated to version ${VALIDATED_PLUGIN_VERSION}"
 
       - name: Compress and upload trunk contents as an artifact
         if: inputs.DRY_RUN == true
@@ -238,3 +229,34 @@ jobs:
           path: ${{ env.SVN_REPO_ROOT }}/trunk
           include-hidden-files: true
           compression-level: 1 #Minimal compression - we don't want to waste resources for this
+
+  create_tag:
+    needs: push_trunk
+    if: inputs.DRY_RUN != true
+    environment: wordpress-org-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install subversion
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y subversion
+
+      - name: Create SVN tag
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          echo '🚀 Creating tag...'
+
+          svn copy \
+            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/trunk" \
+            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/tags/${{ inputs.PLUGIN_VERSION }}" \
+            --username "$SVN_USERNAME" \
+            --password "$SVN_PASSWORD" \
+            --no-auth-cache \
+            --non-interactive \
+            -m "Tagging version ${{ inputs.PLUGIN_VERSION }}"
+
+          echo "✅ Version ${{ inputs.PLUGIN_VERSION }} was published to WordPress.org"

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -25,11 +25,20 @@ on:
 
 jobs:
   update_svn_from_git:
-    env:
-      SVN_REPO_PATH: "$HOME/svn_repository"
-      SVN_TRUNK_PATH: "$SVN_REPO_PATH/trunk"
+    # TODO: Set env vars here and remove an extra step.
+    # This works in real GH Actions but act doesn't support runner context at job level, so we had to create an extra step
+    # Desired format:
+    #   env:
+    #     SVN_REPO_PATH: "${{ runner.workspace }}/svn_repository"
+    #     SVN_REPO_ROOT: "${{ runner.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}"
     runs-on: ubuntu-latest
     steps:
+        #TODO: remove this step (see the comment above for details)
+      - name: Configure paths
+        run: |
+          echo "SVN_REPO_PATH=${{ runner.workspace }}/svn_repository" >> $GITHUB_ENV
+          echo "SVN_REPO_ROOT=${{ runner.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}" >> $GITHUB_ENV
+
       - name: Install required tools
         run: |
           sudo apt-get update -y
@@ -42,7 +51,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p $SVN_REPO_PATH && cd $SVN_REPO_PATH
-          svn checkout "${{ inputs.SVN_REPOSITORY }}/${{ inputs.SVN_PLUGIN_SLUG }}"
+          svn checkout "${{ inputs.SVN_REPOSITORY }}/${{ inputs.SVN_PLUGIN_SLUG }}"          
 
       - name: Synchronize SVN repository with Git
         run: |
@@ -67,4 +76,4 @@ jobs:
           --exclude='.github' \
           --exclude='.ddev' \
           --exclude-from='.distignore' \
-          "$GITHUB_WORKSPACE/" "$SVN_TRUNK_PATH/"
+          "$GITHUB_WORKSPACE/" "$SVN_REPO_ROOT/trunk/"

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -70,6 +70,19 @@ jobs:
         # We do not create VALIDATED_GIT_REF env var here because actions/checkout action we are going to use it with cannot take ref from vars anyway.
         # But since it is validated, it is safe to use it directly from user input.
 
+      - name: Checkout git repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.GIT_REF }}
+          ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
+
+      - name: Checkout SVN repository
+        run: |
+          set -euo pipefail
+          mkdir -p "$SVN_REPO_PATH" && cd "$SVN_REPO_PATH"
+          svn checkout "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}" --depth immediates
+          cd "$SVN_REPO_ROOT" && svn update trunk --set-depth infinity
+
       - name: Verify version doesn't exist in SVN
         run: |
           set -euo pipefail
@@ -84,19 +97,6 @@ jobs:
           fi
 
           echo "✅ Version $VALIDATED_PLUGIN_VERSION is available"
-
-      - name: Checkout git repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.GIT_REF }}
-          ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
-
-      - name: Checkout SVN repository
-        run: |
-          set -euo pipefail
-          mkdir -p "$SVN_REPO_PATH" && cd "$SVN_REPO_PATH"
-          svn checkout "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}" --depth immediates
-          cd "$SVN_REPO_ROOT" && svn update trunk --set-depth infinity
 
       - name: Synchronize SVN repository with Git
         working-directory: ${{ github.workspace }} #Make sure we are in the right place before start sync

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -39,7 +39,7 @@ jobs:
           sudo apt-get install -y subversion rsync
 
       - name: Checkout git repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Checkout SVN repository
         run: |

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -217,7 +217,7 @@ jobs:
             -m "Update trunk to version ${VALIDATED_PLUGIN_VERSION}"
 
       - name: Create a new tag
-        if: inputs.UPDATE_TRUNK_ONLY == false  && inputs.DRY_RUN != true
+        if: inputs.UPDATE_TRUNK_ONLY == false && inputs.DRY_RUN != true
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -36,8 +36,8 @@ on:
 jobs:
   update_svn_from_git:
     env:
-      SVN_REPO_PATH: "${{ runner.workspace }}/svn_repository"
-      SVN_REPO_ROOT: "${{ runner.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}"
+      SVN_REPO_PATH: "${{ github.workspace }}/svn_repository"
+      SVN_REPO_ROOT: "${{ github.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}"
     runs-on: ubuntu-latest
     steps:
       - name: Install required tools

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -54,6 +54,20 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y subversion rsync
 
+      - name: Validate plugin slug
+        env:
+          SVN_PLUGIN_SLUG: ${{ inputs.SVN_PLUGIN_SLUG }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$SVN_PLUGIN_SLUG" =~ ^[a-z0-9-]+$ ]]; then
+            echo "❌ Invalid plugin slug: $SVN_PLUGIN_SLUG"
+            echo "   WordPress.org slugs may only contain lowercase letters, numbers, and hyphens"
+            exit 1
+          fi
+
+          echo "✅ Valid plugin slug: $SVN_PLUGIN_SLUG"
+
       - name: Validate versions
         env:
           PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -88,9 +88,9 @@ jobs:
       - name: Checkout SVN repository
         run: |
           set -euo pipefail
-          mkdir -p $SVN_REPO_PATH && cd $SVN_REPO_PATH
+          mkdir -p "$SVN_REPO_PATH" && cd "$SVN_REPO_PATH"
           svn checkout "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}" --depth immediates
-          cd $SVN_REPO_ROOT && svn update trunk --set-depth infinity
+          cd "$SVN_REPO_ROOT" && svn update trunk --set-depth infinity
 
       - name: Synchronize SVN repository with Git
         working-directory: ${{ github.workspace }} #Make sure we are in the right place before start sync

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -79,6 +79,21 @@ jobs:
         # We do not create VALIDATED_GIT_REF env var here because actions/checkout action we are going to use it with cannot take ref from vars anyway.
         # But since it is validated, it is safe to use it directly from user input.
 
+      - name: Verify version doesn't exist in SVN
+        run: |
+          set -euo pipefail
+
+          cd "${SVN_REPO_ROOT}/tags"
+          svn update --set-depth immediates
+
+          if [ -d "$VALIDATED_PLUGIN_VERSION" ]; then
+            echo "❌ Version $VALIDATED_PLUGIN_VERSION already exists in WordPress.org!"
+            echo "   Check: https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/tags/"
+            exit 1
+          fi
+
+          echo "✅ Version $VALIDATED_PLUGIN_VERSION is available"
+
       - name: Checkout git repository
         uses: actions/checkout@v4
         with:

--- a/docs/wordpress-org-release.md
+++ b/docs/wordpress-org-release.md
@@ -16,6 +16,9 @@ To achieve that, this workflow:
 > [!NOTE]
 > This workflow intentionally fails if the version already exists as an SVN tag. There is no amendment flow.
 
+> [!IMPORTANT]
+> The plugin's SVN repository must already exist on WordPress.org before running this workflow — including in `DRY_RUN` mode. Initial plugin submission requires a separate manual process via the [WordPress.org plugin submission form](https://wordpress.org/plugins/developers/add/).
+
 ## Simple usage example
 
 This workflow cannot be triggered directly. Create a workflow file in your plugin's repository that calls it via `uses:`, as shown below.

--- a/docs/wordpress-org-release.md
+++ b/docs/wordpress-org-release.md
@@ -1,0 +1,89 @@
+# WordPress.org Release
+
+This reusable workflow publishes a WordPress plugin to the [WordPress.org plugin directory](https://wordpress.org/plugins/) via SVN.
+
+To achieve that, this workflow:
+
+1. Validates that `PLUGIN_VERSION` is formatted as `MAJOR.MINOR.PATCH`
+2. Checks out the Git repository at `GIT_REF`
+3. Verifies that the version in the plugin file header and `readme.txt` `Stable tag` both match `PLUGIN_VERSION`
+4. Checks out the WordPress.org SVN repository (trunk is fully checked out; tag contents are never fetched — only tag names are listed when needed for the version check)
+5. Verifies the version does not already exist as an SVN tag (skipped when `UPDATE_TRUNK_ONLY=true`)
+6. Synchronizes the Git working directory to SVN trunk via `rsync`, respecting `.distignore` and excluding sensitive files like `auth.json`, `.env`, and `.npmrc`
+7. Commits trunk to SVN (or uploads it as an artifact in `DRY_RUN` mode)
+8. Creates an SVN tag from trunk (skipped when `UPDATE_TRUNK_ONLY=true` or `DRY_RUN=true`)
+
+> [!NOTE]
+> This workflow intentionally fails if the version already exists as an SVN tag. There is no amendment flow.
+
+## Simple usage example
+
+```yml
+name: Publish to WordPress.org
+on:
+  workflow_dispatch:
+    inputs:
+      PLUGIN_VERSION:
+        description: 'Version to publish (MAJOR.MINOR.PATCH)'
+        required: true
+      GIT_REF:
+        description: 'Git tag or branch to publish'
+        required: true
+      UPDATE_TRUNK_ONLY:
+        description: 'Only update trunk, skip tag creation'
+        type: boolean
+        default: true
+jobs:
+  publish:
+    uses: inpsyde/reusable-workflows/.github/workflows/wordpress-org-release.yml@main
+    with:
+      SVN_PLUGIN_SLUG: my-plugin
+      PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}
+      GIT_REF: ${{ inputs.GIT_REF }}
+      UPDATE_TRUNK_ONLY: ${{ inputs.UPDATE_TRUNK_ONLY == 'true' }}
+    secrets:
+      SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+      SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+      GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
+```
+
+## Staged release (trunk first, tag later)
+
+To verify trunk on WordPress.org before publishing, run the workflow twice with the same inputs — first with `UPDATE_TRUNK_ONLY: true` (the default), then with `UPDATE_TRUNK_ONLY: false` once trunk looks correct.
+
+> [!WARNING]
+> When `UPDATE_TRUNK_ONLY=true`, the `Stable tag` in `readme.txt` must point to an **already-released** version. If it references a version that doesn't exist as an SVN tag yet, WordPress.org may fall back to serving trunk as the stable release.
+
+## Configuration parameters
+
+### Inputs
+
+| Name | Default | Description |
+|---|---|---|
+| `SVN_PLUGIN_SLUG` | — | WordPress.org plugin slug (e.g. `my-plugin`) |
+| `PLUGIN_VERSION` | — | Version to publish, must be `MAJOR.MINOR.PATCH` |
+| `GIT_REF` | — | Git ref to publish (tag, branch, or commit SHA) |
+| `DRY_RUN` | `false` | Upload trunk as an artifact instead of committing to SVN |
+| `UPDATE_TRUNK_ONLY` | `true` | Sync trunk only; skip tag creation |
+
+### Secrets
+
+| Name | Required | Description |
+|---|---|---|
+| `SVN_USERNAME` | yes | WordPress.org SVN username |
+| `SVN_PASSWORD` | yes | WordPress.org SVN password |
+| `GITHUB_USER_SSH_KEY` | yes | SSH key used to check out the Git repository |
+
+> [!NOTE]
+> WordPress.org SVN does not support SSH keys or tokens. The `SVN_USERNAME` and `SVN_PASSWORD` secrets are the only supported authentication method.
+
+## File exclusions
+
+The following files are always excluded from the SVN sync, regardless of `.distignore`:
+
+- `.git`, `.svn`
+- `.env`, `.env.*`
+- `auth.json`, `.npmrc`
+- `.distignore` itself
+
+Additional exclusions can be specified via a `.distignore` file in the repository root (same format used by `wp dist-archive`).

--- a/docs/wordpress-org-release.md
+++ b/docs/wordpress-org-release.md
@@ -57,7 +57,7 @@ If your release process creates a Git tag named after the version (e.g. `1.2.3`)
 name: Publish to WordPress.org
 on:
   push:
-    tags: ['[0-9]+.[0-9]+.[0-9]+']
+    tags: ['[0-9]*.[0-9]*.[0-9]*']
 jobs:
   publish:
     uses: inpsyde/reusable-workflows/.github/workflows/wordpress-org-release.yml@main
@@ -126,13 +126,13 @@ To verify trunk on WordPress.org before publishing, run the workflow twice with 
 
 ### Inputs
 
-| Name | Default | Description |
-|---|---|---|
-| `SVN_PLUGIN_SLUG` | — | WordPress.org plugin slug (e.g. `my-plugin`) |
-| `PLUGIN_VERSION` | — | Version to publish, must be `MAJOR.MINOR.PATCH` |
-| `GIT_REF` | — | Git ref to publish (tag, branch, or commit SHA) |
-| `DRY_RUN` | `false` | Upload trunk as an artifact instead of committing to SVN |
-| `UPDATE_TRUNK_ONLY` | `true` | Sync trunk only; skip tag creation |
+| Name | Required | Default | Description |
+|---|---|---|---|
+| `SVN_PLUGIN_SLUG` | yes | — | WordPress.org plugin slug (e.g. `my-plugin`) |
+| `PLUGIN_VERSION` | yes | — | Version to publish, must be `MAJOR.MINOR.PATCH` |
+| `GIT_REF` | yes | — | Git ref to publish (tag, branch, or commit SHA) |
+| `DRY_RUN` | no | `false` | Upload trunk as an artifact instead of committing to SVN |
+| `UPDATE_TRUNK_ONLY` | no | `true` | Sync trunk only; skip tag creation |
 
 ### Secrets
 

--- a/docs/wordpress-org-release.md
+++ b/docs/wordpress-org-release.md
@@ -18,6 +18,8 @@ To achieve that, this workflow:
 
 ## Simple usage example
 
+This workflow cannot be triggered directly. Create a workflow file in your plugin's repository that calls it via `uses:`, as shown below.
+
 ```yml
 name: Publish to WordPress.org
 on:
@@ -46,6 +48,72 @@ jobs:
       SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
       GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
 ```
+
+## Trigger on Git tag push
+
+If your release process creates a Git tag named after the version (e.g. `1.2.3`), the version can be derived directly from the tag — no manual input needed:
+
+```yml
+name: Publish to WordPress.org
+on:
+  push:
+    tags: ['[0-9]+.[0-9]+.[0-9]+']
+jobs:
+  publish:
+    uses: inpsyde/reusable-workflows/.github/workflows/wordpress-org-release.yml@main
+    with:
+      SVN_PLUGIN_SLUG: my-plugin
+      PLUGIN_VERSION: ${{ github.ref_name }}
+      GIT_REF: ${{ github.ref }}
+      UPDATE_TRUNK_ONLY: false
+    secrets:
+      SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+      SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+      GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
+```
+
+> [!NOTE]
+> This pattern requires tags to be named as bare versions (`1.2.3`, not `v1.2.3`). If your project uses `v`-prefixed tags, strip the prefix before passing it: `PLUGIN_VERSION: ${{ github.ref_name }}` would need to become a separate step that outputs `${GITHUB_REF_NAME#v}`.
+
+> [!WARNING]
+> The version derived from the Git tag must match the `Version:` header in the main plugin file and the `Stable tag` in `readme.txt`. The workflow will fail if they don't all agree. Make sure these are updated in the same commit that the tag points to.
+
+## Advanced usage: requiring manual approval before tagging
+
+To require a manual approval step before the SVN tag is created, add an `environment:` key to the calling job and configure protection rules (required reviewers, wait timers, etc.) for that environment in your repository settings under **Settings → Environments**.
+
+```yml
+name: Publish to WordPress.org
+on:
+  workflow_dispatch:
+    inputs:
+      PLUGIN_VERSION:
+        description: 'Version to publish (MAJOR.MINOR.PATCH)'
+        required: true
+      GIT_REF:
+        description: 'Git tag or branch to publish'
+        required: true
+      UPDATE_TRUNK_ONLY:
+        description: 'Only update trunk, skip tag creation'
+        type: boolean
+        default: true
+jobs:
+  publish:
+    environment: wordpress-org-release  # enforces protection rules configured in repository settings
+    uses: inpsyde/reusable-workflows/.github/workflows/wordpress-org-release.yml@main
+    with:
+      SVN_PLUGIN_SLUG: my-plugin
+      PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}
+      GIT_REF: ${{ inputs.GIT_REF }}
+      UPDATE_TRUNK_ONLY: ${{ inputs.UPDATE_TRUNK_ONLY == 'true' }}
+    secrets:
+      SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+      SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+      GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
+```
+
+> [!NOTE]
+> The `environment:` key alone does nothing — protection rules must be explicitly configured in repository settings. An environment with no rules configured provides no approval gate.
 
 ## Staged release (trunk first, tag later)
 

--- a/docs/wordpress-org-release.md
+++ b/docs/wordpress-org-release.md
@@ -123,7 +123,10 @@ jobs:
 To verify trunk on WordPress.org before publishing, run the workflow twice with the same inputs — first with `UPDATE_TRUNK_ONLY: true` (the default), then with `UPDATE_TRUNK_ONLY: false` once trunk looks correct.
 
 > [!WARNING]
-> When `UPDATE_TRUNK_ONLY=true`, the `Stable tag` in `readme.txt` must point to an **already-released** version. If it references a version that doesn't exist as an SVN tag yet, WordPress.org may fall back to serving trunk as the stable release.
+> When `UPDATE_TRUNK_ONLY=true`, the version existence check is skipped. Do not leave trunk with a `Stable tag` pointing to a non-existent SVN tag — [WordPress.org will serve the plugin from trunk instead](https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#how-the-readme-is-parsed). Keep `Stable tag` pointing to the latest published version.
+
+> [!NOTE]
+> WordPress.org reads `readme.txt` from the tag that `Stable tag` points to, not from trunk. Updating `readme.txt` in trunk alone will not update the plugin page — a new tag must be created.
 
 ## Configuration parameters
 


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature


#### What is the current behavior? (You can also link to an open issue here)
There is no reusable workflow for wordpress.org release

Addresses [SPP-91](https://inpsyde.atlassian.net/browse/SPP-91).


#### What is the new behavior (if this is a feature change)?
Implemented a reusable workflow for publishing a plugin.


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

#### Features

* **Live mode** - Publishes plugin to wordpress.org SVN repository
* **Dry run mode** - Generates artifact preview of changes without committing (dry-run for reviewing what would be published)
* **Two-step publishing (optional)** - Allows pausing after committing changes to the trunk for manual testing and approval before creating the tag for official release
* **Automatic file filtering** - Excludes sensitive files (`auth.json`, `.npmrc`, `.env`)
* **.distignore support** - Honors `.distignore` file for custom exclusions beyond the default filter list
* **Efficient sync** - Uses rsync with checksums for fast, accurate file synchronization
* **Intelligent SVN sync** - Automatically adds new files and removes deleted files from the WordPress.org repository
* **Version validation (MAJOR.MINOR.PATCH format enforcement)** - Makes sure that the version in the main plugin file, readme.txt, and the version from input are the same
* **Duplicate publish protection** - Verifies version doesn't already exist in SVN before proceeding
* **Atomic tagging via remote SVN copy** - Tag is created server-side in a single operation

#### Out of scope
* **Building process** - this workflow assumes that either the calling action does building, or provided GIT_REF points to a pre-built tag, branch, or commit.
* **Assets directory sync** - it is rarely updated, and we don't keep wordpress.org assets in the git repository. Only trunk is synced; the new tag is then created via a remote server-side SVN copy of trunk.

Note: proper documentation is missing so far. I'm going to add it as soon as the general concept is approved.

#### Example calling action

```yaml
name: Test WordPress.org Release

on:
  workflow_dispatch:
    inputs:
      SVN_PLUGIN_SLUG:
        description: "WordPress.org plugin slug (e.g., 'woocommerce' from https://wordpress.org/plugins/woocommerce)"
        type: string
        required: true

      PLUGIN_VERSION:
        description: "Plugin version to publish at WordPress.org (note: it must not exist in SVN)"
        type: string
        required: true

      GIT_REF:
        description: "Git ref to publish at WordPress.org (tag, branch or commit)"
        type: string
        required: true

      DRY_RUN:
        description: "In dry-run mode no commit to the SVN repository happens. Instead, files from trunk are provided as an artifact."
        type: boolean
        default: false
        required: false

    secrets:
      SVN_USERNAME:
        required: true

      SVN_PASSWORD:
        required: true

      GITHUB_USER_SSH_KEY:
        required: true

jobs:
  test-release:
    name: Test Release Process
    uses: inpsyde/reusable-workflows/.github/workflows/wordpress-org-release.yml@main
    with:
      SVN_PLUGIN_SLUG: ${{ inputs.SVN_PLUGIN_SLUG }}
      PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}
      GIT_REF: ${{ inputs.GIT_REF }}
      DRY_RUN: ${{ inputs.DRY_RUN == 'true' }}
    secrets:
      SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
      SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
      GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
```

[SPP-91]: https://inpsyde.atlassian.net/browse/SPP-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ