### PR TITLE
Support custom Composer vendor directory locations

### DIFF
--- a/.github/workflows/coding-standards-php.yml
+++ b/.github/workflows/coding-standards-php.yml
@@ -28,6 +28,11 @@ on:
         default: '--graceful-warnings ./phpcs-report.xml'
         required: false
         type: string
+      VENDOR_DIR:
+        description: Path to the Composer vendor directory, relative to the repository root.
+        default: 'vendor'
+        required: false
+        type: string
     secrets:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
@@ -74,7 +79,7 @@ jobs:
           composer-options: ${{ inputs.COMPOSER_ARGS }}
 
       - name: Run PHP_CodeSniffer
-        run: ./vendor/bin/phpcs ${{ inputs.PHPCS_ARGS }}
+        run: ./${{ inputs.VENDOR_DIR }}/bin/phpcs ${{ inputs.PHPCS_ARGS }}
 
       - name: Annotate PHP_CodeSniffer report
         if: ${{ always() }}

--- a/.github/workflows/coding-standards-php.yml
+++ b/.github/workflows/coding-standards-php.yml
@@ -28,11 +28,6 @@ on:
         default: '--graceful-warnings ./phpcs-report.xml'
         required: false
         type: string
-      VENDOR_DIR:
-        description: Path to the Composer vendor directory, relative to the repository root.
-        default: 'vendor'
-        required: false
-        type: string
     secrets:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
@@ -79,7 +74,7 @@ jobs:
           composer-options: ${{ inputs.COMPOSER_ARGS }}
 
       - name: Run PHP_CodeSniffer
-        run: ./${{ inputs.VENDOR_DIR }}/bin/phpcs ${{ inputs.PHPCS_ARGS }}
+        run: ./$(composer config bin-dir)/phpcs ${{ inputs.PHPCS_ARGS }}
 
       - name: Annotate PHP_CodeSniffer report
         if: ${{ always() }}

--- a/.github/workflows/deploy-deployer.yml
+++ b/.github/workflows/deploy-deployer.yml
@@ -155,4 +155,4 @@ jobs:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
         run: |
           cd deployment
-          ./vendor/bin/dep deploy ${{ inputs.ENVIRONMENT }} -${{ inputs.VERBOSITY}}
+          ./$(composer config bin-dir)/dep deploy ${{ inputs.ENVIRONMENT }} -${{ inputs.VERBOSITY}}

--- a/.github/workflows/static-analysis-php.yml
+++ b/.github/workflows/static-analysis-php.yml
@@ -75,8 +75,8 @@ jobs:
 
       - name: Run Psalm
         if: ${{ hashFiles('psalm.xml', 'psalm.xml.dist') != '' }}
-        run: ./vendor/bin/psalm --php-version="${{ inputs.PHP_VERSION }}" ${{ inputs.PSALM_ARGS }}
+        run: ./$(composer config bin-dir)/psalm --php-version="${{ inputs.PHP_VERSION }}" ${{ inputs.PSALM_ARGS }}
 
       - name: Run PHPStan
         if: ${{ hashFiles('phpstan.dist.neon', 'phpstan.neon', 'phpstan.neon.dist') != '' }}
-        run: ./vendor/bin/phpstan ${{ inputs.PHPSTAN_ARGS }}
+        run: ./$(composer config bin-dir)/phpstan ${{ inputs.PHPSTAN_ARGS }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -67,4 +67,4 @@ jobs:
           composer-options: ${{ inputs.COMPOSER_ARGS }}
 
       - name: Run PHPUnit
-        run: ./vendor/bin/phpunit ${{ inputs.PHPUNIT_ARGS }}
+        run: ./$(composer config bin-dir)/phpunit ${{ inputs.PHPUNIT_ARGS }}

--- a/docs/php.md
+++ b/docs/php.md
@@ -5,7 +5,7 @@
 ## Coding standards analysis
 
 This workflow runs [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer). It does so by
-executing the binary in the `./vendor/bin/` folder.
+executing the binary resolved via `composer config bin-dir`.
 
 **Simplest possible example:**
 
@@ -64,7 +64,7 @@ versions.
 
 This workflow runs either [Psalm](https://psalm.dev/) or [PHPStan](https://phpstan.org/), or both, based on the existence of a supported configuration file in your repository root folder. 
 
-It does so by executing the binary in the `./vendor/bin/` folder.
+It does so by executing the binary resolved via `composer config bin-dir`.
 
 **Supported configuration files:**
 
@@ -128,8 +128,8 @@ with multiple PHP versions, use the [Lint PHP](#lint-php) workflow.
 
 ## Unit tests PHP
 
-This workflow runs [PHPUnit](https://phpunit.de/). It does so by executing the binary in the
-`./vendor/bin/` folder.
+This workflow runs [PHPUnit](https://phpunit.de/). It does so by executing the binary resolved via
+`composer config bin-dir`.
 
 **Simplest possible example:**
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature


## What is the current behavior? (You can also link to an open issue here)
The workflows hardcode `./vendor/bin/` as the path to the binary files. Projects that configure a custom `vendor-dir` in `composer.json` (e.g. `public/wp-content/vendor/`) cannot use these workflows.


## What is the new behavior (if this is a feature change)?

Tools are now executed using the binary path resolved dynamically via `composer config bin-dir`, instead of the hardcoded `./vendor/bin/`. This means workflows will automatically respect any custom `bin-dir` configured in the project's `composer.json`, supporting setups where the vendor directory is not in the repository root (e.g. `public/wp-content/vendor`). 

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No


## Other information
