### PR TITLE
Allow additional PHP tools

### DIFF
--- a/.github/workflows/deploy-deployer.yml
+++ b/.github/workflows/deploy-deployer.yml
@@ -17,6 +17,11 @@ on:
         default: '8.2'
         required: false
         type: string
+      PHP_TOOLS:
+        description: PHP tools supported by shivammathur/setup-php to be installed.
+        default: ''
+        required: false
+        type: string
       PHP_EXTENSIONS:
         description: PHP extensions supported by shivammathur/setup-php to be installed or disabled.
         default: ''
@@ -78,7 +83,7 @@ jobs:
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           extensions: ${{ inputs.PHP_EXTENSIONS }}
-          tools: composer
+          tools: composer, ${{ inputs.PHP_TOOLS }}
           coverage: none
 
       - name: Set up WireGuard

--- a/docs/deploy-deployer.md
+++ b/docs/deploy-deployer.md
@@ -67,14 +67,15 @@ jobs:
 
 ### Inputs
 
-| Name                  | Default                         | Description                                                                    |
-|-----------------------|---------------------------------|--------------------------------------------------------------------------------|
-| `ENVIRONMENT`         |                                 | Name of the target environment to load Deployer settings                       |
-| `VERBOSITY`           | `'v'`                           | Deployer command verbosity                                                     |
-| `PHP_VERSION`         | `'8.2'`                         | PHP version with which the scripts are executed                                |
-| `PHP_EXTENSIONS`      | `''`                            | PHP extensions supported by shivammathur/setup-php to be installed or disabled |
-| `NODE_VERSION`        | `'22'`                          | Node.js version to use when npm workspaces are detected                        |
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                             |
+| Name                  | Default                         | Description                                                                                                                     |
+|-----------------------|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| `ENVIRONMENT`         |                                 | Name of the target environment to load Deployer settings                                                                        |
+| `VERBOSITY`           | `'v'`                           | Deployer command verbosity                                                                                                      |
+| `PHP_VERSION`         | `'8.2'`                         | PHP version with which the scripts are executed                                                                                 |
+| `PHP_EXTENSIONS`      | `''`                            | PHP extensions supported by shivammathur/setup-php to be installed or disabled                                                  |
+| `PHP_TOOLS`           | `''`                            | PHP tools supported by [shivammathur/setup-php](https://github.com/shivammathur/setup-php#wrench-tools-support) to be installed |
+| `NODE_VERSION`        | `'22'`                          | Node.js version to use when npm workspaces are detected                                                                         |
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                                                              |
 
 ### Secrets
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
FEATURE


## What is the current behavior? (You can also link to an open issue here)
Not being able to add PHP_TOOLS


## What is the new behavior (if this is a feature change)?
The workflow supports adding PHP_TOOLS like wp-cli, which provides flexibility for deployments via deployer. 
For example: 
Deployer can run WP CLI commands without manually installing it or manipulating the path or binaries in the provided GA environment.


## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No


## Other information
