### PR TITLE
feat(deploy-deployer): expose Deployer exit code and reason as workfl…

### DIFF
--- a/.github/workflows/deploy-deployer.yml
+++ b/.github/workflows/deploy-deployer.yml
@@ -59,12 +59,22 @@ on:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
         required: false
+    outputs:
+      deploy_exit_code:
+        description: Deployer process exit code (0=success, 1=error, 2=warning).
+        value: ${{ jobs.deploy.outputs.exit_code }}
+      deploy_reason:
+        description: Human-readable deployment result message parsed from Deployer output.
+        value: ${{ jobs.deploy.outputs.reason }}
 jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
       NODE_CACHE_MODE: ''
       COMPOSER_NO_DEV: 1
+    outputs:
+      exit_code: ${{ steps.run-deployer.outputs.exit_code }}
+      reason: ${{ steps.run-deployer.outputs.reason }}
 
     steps:
       - name: Checkout
@@ -154,10 +164,36 @@ jobs:
           ssh-keyscan -p ${{ secrets.DEPLOY_PORT }} ${{ secrets.DEPLOY_HOSTNAME }} >> ~/.ssh/known_hosts
 
       - name: Run Deployer
+        id: run-deployer
         env:
           DEPLOY_HOSTNAME: ${{ secrets.DEPLOY_HOSTNAME }}
           DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
         run: |
           cd deployment
-          ./$(composer config bin-dir)/dep deploy ${{ inputs.ENVIRONMENT }} -${{ inputs.VERBOSITY}}
+          set +e
+          output=$(./$(composer config bin-dir)/dep deploy ${{ inputs.ENVIRONMENT }} -${{ inputs.VERBOSITY}} 2>&1)
+          exit_code=$?
+          set -e
+          echo "$output"
+          echo "exit_code=${exit_code}" >> $GITHUB_OUTPUT
+          if [ "$exit_code" -eq 0 ]; then
+            reason="Deployment completed successfully"
+          elif [ "$exit_code" -eq 2 ]; then
+            reason=$(echo "$output" | grep -oE '\[WARNING\][^\n]+' | head -1 | sed 's/\[WARNING\] *//')
+            reason="${reason:-Deployment completed with warnings}"
+          else
+            reason=$(echo "$output" | grep -oE '\[(ERROR|CRITICAL)\][^\n]+' | head -1 | sed 's/\[\(ERROR\|CRITICAL\)\] *//')
+            reason="${reason:-Deployment failed}"
+          fi
+          echo "reason=${reason}" >> $GITHUB_OUTPUT
+
+  assert-result:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail on deployment error or warning
+        if: needs.deploy.outputs.exit_code != '0'
+        run: |
+          echo "::error::Deployer exited with code ${{ needs.deploy.outputs.exit_code }}: ${{ needs.deploy.outputs.reason }}"
+          exit ${{ needs.deploy.outputs.exit_code }}

--- a/.github/workflows/deploy-deployer.yml
+++ b/.github/workflows/deploy-deployer.yml
@@ -72,11 +72,21 @@ on:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
         required: false
+    outputs:
+      deploy_exit_code:
+        description: Deployer process exit code (0=success, 1=error, 2=warning).
+        value: ${{ jobs.deploy.outputs.exit_code }}
+      deploy_reason:
+        description: Human-readable deployment result message parsed from Deployer output.
+        value: ${{ jobs.deploy.outputs.reason }}
 jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
       COMPOSER_NO_DEV: 1
+    outputs:
+      exit_code: ${{ steps.run-deployer.outputs.exit_code }}
+      reason: ${{ steps.run-deployer.outputs.reason }}
 
     steps:
       - name: Checkout
@@ -160,6 +170,7 @@ jobs:
           ssh-keyscan -p ${{ secrets.DEPLOY_PORT }} ${{ secrets.DEPLOY_HOSTNAME }} >> ~/.ssh/known_hosts
 
       - name: Run Deployer
+        id: run-deployer
         env:
           ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
           DEPLOY_HOSTNAME: ${{ secrets.DEPLOY_HOSTNAME }}
@@ -167,4 +178,29 @@ jobs:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
         run: |
           cd deployment
-          ./$(composer config bin-dir)/dep deploy ${{ inputs.ENVIRONMENT }} -${{ inputs.VERBOSITY}}
+          set +e
+          output=$(./$(composer config bin-dir)/dep deploy ${{ inputs.ENVIRONMENT }} -${{ inputs.VERBOSITY}} 2>&1)
+          exit_code=$?
+          set -e
+          echo "$output"
+          echo "exit_code=${exit_code}" >> $GITHUB_OUTPUT
+          if [ "$exit_code" -eq 0 ]; then
+            reason="Deployment completed successfully"
+          elif [ "$exit_code" -eq 2 ]; then
+            reason=$(echo "$output" | grep -oE '\[WARNING\][^\n]+' | head -1 | sed 's/\[WARNING\] *//')
+            reason="${reason:-Deployment completed with warnings}"
+          else
+            reason=$(echo "$output" | grep -oE '\[(ERROR|CRITICAL)\][^\n]+' | head -1 | sed 's/\[\(ERROR\|CRITICAL\)\] *//')
+            reason="${reason:-Deployment failed}"
+          fi
+          echo "reason=${reason}" >> $GITHUB_OUTPUT
+
+  assert-result:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail on deployment error or warning
+        if: needs.deploy.outputs.exit_code != '0'
+        run: |
+          echo "::error::Deployer exited with code ${{ needs.deploy.outputs.exit_code }}: ${{ needs.deploy.outputs.reason }}"
+          exit ${{ needs.deploy.outputs.exit_code }}


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature — exposes Deployer's process exit code and a parsed reason message as `workflow_call` outputs.

## What is the current behavior? (You can also link to an open issue here)

Closes #230

Deployer stdout (info, warnings, errors) is only visible in CI logs. Callers have no way to pass the deployment result to downstream jobs (e.g. Slack notifications).

## What is the new behavior (if this is a feature change)?

Two new `workflow_call` outputs are available:

- `deploy_exit_code` — Deployer's process exit code (`0` = success, `1` = error, `2` = warning)
- `deploy_reason` — a human-readable message parsed from Deployer's output

Example usage in a calling workflow:

```yaml
slack-notification:
  needs: build-and-deploy
  if: always() && needs.build-and-deploy.result != 'skipped'
  steps:
    - uses: slackapi/slack-github-action@v2
      with:
        payload: |
          text: "Deploy result: ${{ needs.build-and-deploy.outputs.deploy_reason }}"
```

To make the outputs available even when the deployment fails, the workflow is split into two jobs:

- **`deploy`**: runs the full deployment and captures exit code + reason; always exits `0` so its outputs are committed
- **`assert-result`**: fails strictly on any non-zero exit code (including warnings, exit `2`), surfacing the reason via `::error::` annotation

This is necessary because GitHub Actions only exposes `workflow_call` outputs from jobs that complete successfully.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No breaking change in workflow behavior — the overall `workflow_call` result is still `failure` when Deployer fails, since `assert-result` fails.

There is a **visual change**: the `deploy` job will always appear green in the GitHub Actions UI. The failure is now visible in the `assert-result` job instead.

## Other information

N/A