### PR TITLE
Playwright: Improve local build tooling

### DIFF
--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -176,6 +176,9 @@ jobs:
         working-directory: ${{ inputs.WORK_DIR }}
         run: npm ${{ env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
 
+      - name: Build assets
+        run: npm run build --if-present
+
       - name: Install Playwright dependencies
         working-directory: ${{ inputs.WORK_DIR }}
         run: |

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -152,7 +152,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.PHP_VERSION }}
-          tools: composer
+          tools: composer, php-scoper, sniccowp/php-scoper-wordpress-excludes
           coverage: none
 
       - name: Install Composer dependencies
@@ -178,6 +178,16 @@ jobs:
 
       - name: Build assets
         run: npm run build --if-present
+
+      - name: Run PHP-Scoper
+        if: ${{ inputs.COMPOSER_DEPS_INSTALL && hashFiles('scoper.inc.php') != '' }}
+        # The sed call appends the Git commit SHA to the Composer autoload cache key to ensure unique identification for prefixed files.
+        # This prevents Composer from skipping autoloaded files due to hash collisions based on relative paths.
+        run: |
+          php-scoper add-prefix --force --output-dir=build
+          composer --working-dir=build dump-autoload -o
+          sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
+          rsync -av ./build/ . && rm -rf ./build/
 
       - name: Install Playwright dependencies
         working-directory: ${{ inputs.WORK_DIR }}

--- a/docs/test-playwright.md
+++ b/docs/test-playwright.md
@@ -5,6 +5,7 @@ This workflow executes Playwright-based tests in a controlled and isolated envir
 The workflow can:
 
 - execute a building step, both for node and PHP environments (if the PHP version is provided and a `composer.json` file is present)
+- compile frontend assets via `npm run build` (skipped gracefully if no `build` script is defined in `package.json`)
 - create an environment variables file named `.env.ci` dedicated to the test step; load this file using `dotenv-ci` directly in your test script, e.g., `./node_modules/.bin/dotenv -e .env.ci -- npm run e2e`. The file is also sourced before `PRE_SCRIPT`, making all variables available as environment variables.
 - execute the tests using Playwright via a custom npm script.
 - upload the artifacts.


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature — adds build steps to the Playwright test workflow.


## What is the current behavior? (You can also link to an open issue here)
`test-playwright.yml` has no build steps beyond installing npm dependencies. Projects that need compiled assets or scoped PHP (via PHP-Scoper) are forced to download a pre-built artifact from a prior job inside PRE_SCRIPT, adding boilerplate and a hard dependency on an upstream build workflow (like downloading the last build&distribute run artifact via gh cli).


## What is the new behavior (if this is a feature change)?
Two build steps are inserted between dependency installation and Playwright execution, both running at the repo root (consistent with the existing Composer steps):                       
   
  1. `npm run build --if-present` — compiles frontend assets. Skips gracefully if no build script is defined in package.json.                                                                 
  2. PHP-Scoper — auto-detected via the presence of scoper.inc.php, gated on `COMPOSER_DEPS_INSTALL: true`. Runs php-scoper add-prefix, rebuilds the autoloader, applies the SHA-based autoload cache key fix, and merges the output back in-place. Mirrors the approach in build-and-distribute.yml exactly, including `sniccowp/php-scoper-wordpress-excludes` in the PHP tools. 
                  
After these steps the built plugin is available at `$GITHUB_WORKSPACE` and wp-env (if used) can pick it up directly without any `PRE_SCRIPT` boilerplate.      


## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No. Both steps are either unconditionally safe (`--if-present` skips silently) or explicitly gated (`COMPOSER_DEPS_INSTALL: true` + `scoper.inc.php` present). Existing callers are unaffected.


## Other information
Build step design follows build-and-distribute.yml as the reference implementation.