### PR TITLE
Fix auto-detection of latest package version

### DIFF
--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -139,7 +139,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_USER_SSH_KEY }}
         run: |
           # Fetch latest public release
-          LATEST_RELEASE=$(git for-each-ref --sort=-creatordate --count=1 --format='%(refname:short)' 'refs/tags/[0-9]*' || echo "")
+          LATEST_RELEASE=$(git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags \
+            | grep -E '^v?[0-9]' \
+            | grep -v '/' \
+            | head -1 || echo "")
           
           if [ -z "$LATEST_RELEASE" ]; then
             echo "No releases found, using default version 0.0.0."

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -141,14 +141,6 @@ jobs:
           # Fetch latest public release
           LATEST_RELEASE=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' || echo "")
           
-          # Fallback: Fetch latest version tag (supports 1.2.3 and v1.2.3, ignores tags with slashes)
-          if [[ -z $LATEST_RELEASE ]]; then
-            LATEST_RELEASE=$(git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags \
-              | grep -E '^v?[0-9]' \
-              | grep -v '/' \
-              | head -1 || echo "")
-          fi
-          
           if [ -z "$LATEST_RELEASE" ]; then
             echo "No releases found, using default version 0.0.0."
             LATEST_RELEASE="0.0.0"

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -139,7 +139,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_USER_SSH_KEY }}
         run: |
           # Fetch latest public release
-          LATEST_RELEASE=$(git for-each-ref --sort=-creatordate --count=1 --format='%(refname:short)' refs/tags || echo "")
+          LATEST_RELEASE=$(git for-each-ref --sort=-creatordate --count=1 --format='%(refname:short)' 'refs/tags/[0-9]*' || echo "")
           
           if [ -z "$LATEST_RELEASE" ]; then
             echo "No releases found, using default version 0.0.0."

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -139,10 +139,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_USER_SSH_KEY }}
         run: |
           # Fetch latest public release
-          LATEST_RELEASE=$(git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags \
-            | grep -E '^v?[0-9]' \
-            | grep -v '/' \
-            | head -1 || echo "")
+          LATEST_RELEASE=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' || echo "")
+          
+          # Fallback: Fetch latest version tag (supports 1.2.3 and v1.2.3, ignores tags with slashes)
+          if [[ -z $LATEST_RELEASE ]]; then
+            LATEST_RELEASE=$(git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags \
+              | grep -E '^v?[0-9]' \
+              | grep -v '/' \
+              | head -1 || echo "")
+          fi
           
           if [ -z "$LATEST_RELEASE" ]; then
             echo "No releases found, using default version 0.0.0."

--- a/docs/build-and-distribute.md
+++ b/docs/build-and-distribute.md
@@ -29,10 +29,10 @@ This approach keeps source code separate from build artifacts while maintaining 
 
 If no `PACKAGE_VERSION` is provided, the workflow automatically:
 
-1. Fetches the latest tag from the repository
+1. Fetches the latest GitHub Release from the repository
 2. Strips the `dev/` prefix from the branch name and normalizes it to be semver-compatible
 3. Creates a pre-release version like `1.2.3-main` or `2.0.0-abc-123`
-4. Falls back to `0.0.0-{branch}` if no tags exist
+4. Falls back to `0.0.0-{branch}` if no published release exists
 
 **Examples:**
 
@@ -121,7 +121,7 @@ jobs:
 | `PHP_TOOLS`           | `''`                                             | PHP tools supported by shivammathur/setup-php to be installed                                                    |
 | `COMPOSER_ARGS`       | `'--no-dev --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer when gathering production dependencies                                       |
 | `PACKAGE_NAME`        | `''`                                             | The name of the package (falls back to the repository name)                                                      |
-| `PACKAGE_VERSION`     | `''`                                             | The new package version. If not provided, will use latest tag version with branch name as pre-release identifier |
+| `PACKAGE_VERSION`     | `''`                                             | The new package version. If not provided, will use the latest GitHub Release version with branch name as pre-release identifier |
 | `PRE_SCRIPT`          | `''`                                             | Run custom shell code before creating the release archive                                                        |
 | `BUILT_BRANCH_NAME`   | `''`                                             | Override the automatic build branch naming (defaults to stripping `dev/` prefix from origin branch)              |
 

--- a/docs/build-and-distribute.md
+++ b/docs/build-and-distribute.md
@@ -46,12 +46,11 @@ This ensures every build has a unique, meaningful version identifier that traces
 
 The latest GitHub Release tag is used as the base for `PACKAGE_VERSION` and is validated by `npm version` against semver. Release tags must therefore exactly match this pattern:
 
-```
+```text
 [v]MAJOR.MINOR.PATCH[-IDENTIFIER]
 ```
 
-<details>
-<summary>Valid and invalid samples</summary>
+#### Valid and invalid samples
 
 **Valid:**
 
@@ -70,7 +69,6 @@ The latest GitHub Release tag is used as the base for `PACKAGE_VERSION` and is v
 - `a.b.c` → non-numeric segments
 - `release/1.2.3` → contains a slash
 
-</details>
 
 ## Simple usage example
 

--- a/docs/build-and-distribute.md
+++ b/docs/build-and-distribute.md
@@ -42,6 +42,34 @@ If no `PACKAGE_VERSION` is provided, the workflow automatically:
 
 This ensures every build has a unique, meaningful version identifier that traces back to both the base release and the source branch.
 
+### GitHub Release tag format
+
+The latest GitHub Release tag is used as the base for `PACKAGE_VERSION` and is validated by `npm version` against semver. Release tags must therefore exactly match this pattern:
+
+```
+[v]MAJOR.MINOR.PATCH[-IDENTIFIER]
+```
+
+<details>
+<summary>Valid and invalid samples</summary>
+
+**Valid:**
+- `1.2.3`
+- `v1.2.3`
+- `1.2.3-alpha`
+- `1.2.3-feature.1`
+- `1.2.3-2026-05-21`
+
+**Invalid:**
+- `1.2` → missing PATCH
+- `1.2.3.4` → too many segments
+- `1.2.3-` → empty identifier
+- `v.1.2.3` → dot after `v`
+- `a.b.c` → non-numeric segments
+- `release/1.2.3` → contains a slash
+
+</details>
+
 ## Simple usage example
 
 ### WordPress Plugin/Theme or PHP Library

--- a/docs/build-and-distribute.md
+++ b/docs/build-and-distribute.md
@@ -54,6 +54,7 @@ The latest GitHub Release tag is used as the base for `PACKAGE_VERSION` and is v
 <summary>Valid and invalid samples</summary>
 
 **Valid:**
+
 - `1.2.3`
 - `v1.2.3`
 - `1.2.3-alpha`
@@ -61,6 +62,7 @@ The latest GitHub Release tag is used as the base for `PACKAGE_VERSION` and is v
 - `1.2.3-2026-05-21`
 
 **Invalid:**
+
 - `1.2` → missing PATCH
 - `1.2.3.4` → too many segments
 - `1.2.3-` → empty identifier
@@ -139,20 +141,19 @@ jobs:
 
 ### Inputs
 
-| Name                  | Default                                          | Description                                                                                                      |
-|-----------------------|--------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
-| `NODE_OPTIONS`        | `''`                                             | Space-separated list of command-line Node options                                                                |
-| `NODE_VERSION`        | `18`                                             | Node version with which the assets will be compiled                                                              |
-| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                  | Domain of the private npm registry                                                                               |
-| `PHP_VERSION`         | `'8.2'`                                          | PHP version with which the PHP tools are to be executed                                                          |
-| `PHP_EXTENSIONS`      | `''`                                             | PHP extensions supported by shivammathur/setup-php to be installed or disabled                                   |
-| `PHP_TOOLS`           | `''`                                             | PHP tools supported by shivammathur/setup-php to be installed                                                    |
-| `COMPOSER_ARGS`       | `'--no-dev --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer when gathering production dependencies                                       |
-| `PACKAGE_NAME`        | `''`                                             | The name of the package (falls back to the repository name)                                                      |
+| Name                  | Default                                          | Description                                                                                                                     |
+|-----------------------|--------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| `NODE_OPTIONS`        | `''`                                             | Space-separated list of command-line Node options                                                                               |
+| `NODE_VERSION`        | `18`                                             | Node version with which the assets will be compiled                                                                             |
+| `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                  | Domain of the private npm registry                                                                                              |
+| `PHP_VERSION`         | `'8.2'`                                          | PHP version with which the PHP tools are to be executed                                                                         |
+| `PHP_EXTENSIONS`      | `''`                                             | PHP extensions supported by shivammathur/setup-php to be installed or disabled                                                  |
+| `PHP_TOOLS`           | `''`                                             | PHP tools supported by shivammathur/setup-php to be installed                                                                   |
+| `COMPOSER_ARGS`       | `'--no-dev --prefer-dist --optimize-autoloader'` | Set of arguments passed to Composer when gathering production dependencies                                                      |
+| `PACKAGE_NAME`        | `''`                                             | The name of the package (falls back to the repository name)                                                                     |
 | `PACKAGE_VERSION`     | `''`                                             | The new package version. If not provided, will use the latest GitHub Release version with branch name as pre-release identifier |
-| `PRE_SCRIPT`          | `''`                                             | Run custom shell code before creating the release archive                                                        |
-| `BUILT_BRANCH_NAME`   | `''`                                             | Override the automatic build branch naming (defaults to stripping `dev/` prefix from origin branch)              |
-
+| `PRE_SCRIPT`          | `''`                                             | Run custom shell code before creating the release archive                                                                       |
+| `BUILT_BRANCH_NAME`   | `''`                                             | Override the automatic build branch naming (defaults to stripping `dev/` prefix from origin branch)                             |
 
 #### A note on `BUILT_BRANCH_NAME`
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Bug fix

## What is the current behavior? (You can also link to an open issue here)

The automatically determined `PACKAGE_VERSION` defaulted to the most recently created git tag, regardless of whether that tag represented an actual release version or something else (e.g. arbitrary non-semver tags such as `archive/qa-legacy-ui-tests`).

This caused two problems downstream, where `PACKAGE_VERSION` is consumed:

- Build breaks on tags containing slashes. The "Prepare WordPress Plugin" and "Prepare WordPress Theme" steps interpolate `PACKAGE_VERSION` into a `sed` expression that uses `/` as its delimiter; a slash in the tag breaks the substitution with an error.
- Invalid versions without a slash silently land in project files. Non-semver tags get written into `package.json` (via `npm version`, which rejects them) and `composer.json` (via `jq`, which accepts any string), corrupting the build artifact.

## What is the new behavior (if this is a feature change)?

The workflow now fetches the tag name of an actual GitHub Release via `gh release list`, so only published releases are considered.

Assumption: A release tag represents a **valid semantic version** and never contains slashes, e.g.

- `4.0.3`
- `4.0.3-alpha-2026-05-06`
- `v2.17.0`

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

The "0.0.0" fallback already existed previously, but it now triggers in more cases: any repository that has tags but no published GitHub Release will fall back to "0.0.0" instead of picking up a tag.

This will not block the build, but it will insert a "0.0.0"-based version string into project files in the following steps:

- Prepare WordPress Plugin
- Prepare WordPress Theme
- Update version in `package.json`
- Update version in `composer.json`

## Other information

Repositories that previously relied on tags being picked up without ever cutting a GitHub Release should publish a Release to keep getting a meaningful version prefix.

### `npm version` requirements

The workflow [constructs `PACKAGE_VERSION`](https://github.com/inpsyde/reusable-workflows/blob/37fbc05c85d592af4f24088a301a9ab8c7647b00/.github/workflows/build-and-distribute.yml#L164) and validates it against semver via`npm version` in the "[Update version in package.json](https://github.com/inpsyde/reusable-workflows/blob/37fbc05c85d592af4f24088a301a9ab8c7647b00/.github/workflows/build-and-distribute.yml#L318)" step. This means, the `LATEST_RELEASE` string itself must match the following pattern to pass this check:

```
[v]MAJOR.MINOR.PATCH[-IDENTIFIER]
```

Valid samples:
- `1.2.3`
- `v1.2.3`
- `1.2.3-alpha`
- `1.2.3-feature.1`
- `1.2.3-2026-05-21`

Invalid samples:
- `1.2`           → missing PATCH
- `1.2.3.4`     → too many segments
- `1.2.3-`       → empty identifier
- `v.1.2.3`      → dot after v
- `a.b.c`        → non-numeric segments