### PR TITLE
Add Codecov support to PHPUnit and Jest workflow

### DIFF
--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -25,9 +25,14 @@ on:
         type: string
       NODE_OPTIONS:
         description: Space-separated list of command-line Node options.
-        type: string
         default: ''
         required: false
+        type: string
+      CODECOV_FLAGS:
+        description: Flags to be passed to Codecov.
+        default: 'unittests'
+        required: false
+        type: string
     secrets:
       NPM_REGISTRY_TOKEN:
         description: Authentication for the private npm registry.
@@ -134,5 +139,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
-          flags: unittests
+          flags: ${{ inputs.CODECOV_FLAGS }}
           verbose: true

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -44,6 +44,9 @@ on:
       ENV_VARS:
         description: Additional environment variables as a JSON formatted object.
         required: false
+      CODECOV_TOKEN:
+        description: Codecov token.
+        required: false
 
 jobs:
   tests-unit-js:
@@ -118,4 +121,18 @@ jobs:
         run: ${{ format('{0} {1}', inputs.PACKAGE_MANAGER, env.ARGS) }}
 
       - name: Run Jest
-        run: ./node_modules/.bin/jest ${{ inputs.JEST_ARGS }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          COVERAGE_ARGS=""
+          [ -n "$CODECOV_TOKEN" ] && COVERAGE_ARGS="--coverage"
+          ./node_modules/.bin/jest $COVERAGE_ARGS ${{ inputs.JEST_ARGS }}
+
+      - name: Upload coverage to Codecov
+        if: ${{ hashFiles('coverage/lcov.info') != '' }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          flags: unittests
+          verbose: true

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -23,12 +23,20 @@ on:
         default: '--coverage-text'
         required: false
         type: string
+      CODECOV_COVERAGE_FILE:
+        description: Path to the coverage file to upload to Codecov. Upload is skipped when the file does not exist.
+        default: 'coverage.xml'
+        required: false
+        type: string
     secrets:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
         required: false
       ENV_VARS:
         description: Additional environment variables as a JSON formatted object.
+        required: false
+      CODECOV_TOKEN:
+        description: Codecov token.
         required: false
 
 jobs:
@@ -68,3 +76,12 @@ jobs:
 
       - name: Run PHPUnit
         run: ./$(composer config bin-dir)/phpunit ${{ inputs.PHPUNIT_ARGS }}
+
+      - name: Upload coverage to Codecov
+        if: ${{ hashFiles(inputs.CODECOV_COVERAGE_FILE) != '' }}
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ inputs.CODECOV_COVERAGE_FILE }}
+          flags: unittests
+          verbose: true

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ hashFiles(inputs.CODECOV_COVERAGE_FILE) != '' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ inputs.CODECOV_COVERAGE_FILE }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -23,6 +23,11 @@ on:
         default: '--coverage-text'
         required: false
         type: string
+      CODECOV_FLAGS:
+        description: Flags to be passed to Codecov.
+        default: 'unittests'
+        required: false
+        type: string
     secrets:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
@@ -83,5 +88,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
-          flags: unittests
+          flags: ${{ inputs.CODECOV_FLAGS }}
           verbose: true

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -24,7 +24,7 @@ on:
         required: false
         type: string
       CODECOV_COVERAGE_FILE:
-        description: Path to the coverage file to upload to Codecov. Upload is skipped when the file does not exist.
+        description: Path to the coverage file to upload to Codecov.
         default: 'coverage.xml'
         required: false
         type: string

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -23,11 +23,6 @@ on:
         default: '--coverage-text'
         required: false
         type: string
-      CODECOV_COVERAGE_FILE:
-        description: Path to the coverage file to upload to Codecov.
-        default: 'coverage.xml'
-        required: false
-        type: string
     secrets:
       COMPOSER_AUTH_JSON:
         description: Authentication for privately hosted packages and repositories as a JSON formatted object.
@@ -75,13 +70,18 @@ jobs:
           composer-options: ${{ inputs.COMPOSER_ARGS }}
 
       - name: Run PHPUnit
-        run: ./$(composer config bin-dir)/phpunit ${{ inputs.PHPUNIT_ARGS }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          COVERAGE_ARGS=""
+          [ -n "$CODECOV_TOKEN" ] && COVERAGE_ARGS="--coverage-clover coverage.xml"
+          ./$(composer config bin-dir)/phpunit $COVERAGE_ARGS ${{ inputs.PHPUNIT_ARGS }}
 
       - name: Upload coverage to Codecov
-        if: ${{ hashFiles(inputs.CODECOV_COVERAGE_FILE) != '' }}
+        if: ${{ hashFiles('coverage.xml') != '' }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ${{ inputs.CODECOV_COVERAGE_FILE }}
+          files: ./coverage.xml
           flags: unittests
           verbose: true

--- a/docs/js.md
+++ b/docs/js.md
@@ -27,6 +27,7 @@ jobs:
 | `NPM_REGISTRY_DOMAIN` | `'https://npm.pkg.github.com/'`                    | Domain of the private npm registry                        |
 | `NODE_VERSION`        | `18`                                               | Node version with which the unit tests are to be executed |
 | `JEST_ARGS`           | `'--reporters=default --reporters=github-actions'` | Set of arguments passed to Jest                           |
+| `CODECOV_FLAGS`       | `'unittests'`                                      | Flags to be passed to Codecov                             |
 
 **Note**: The default `github-actions` reporter requires Jest 28 or higher.
 
@@ -58,6 +59,7 @@ jobs:
     with:
       NODE_VERSION: 14
       JEST_ARGS: 'my-test --reporters=jest-junit'
+      CODECOV_FLAGS: 'js'
 ```
 
 ## Static analysis JavaScript

--- a/docs/js.md
+++ b/docs/js.md
@@ -39,6 +39,7 @@ jobs:
 | `GITHUB_USER_NAME`    | Username for the GitHub user configuration                                   |
 | `GITHUB_USER_SSH_KEY` | Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME` |
 | `ENV_VARS`            | Additional environment variables as a JSON formatted object                  |
+| `CODECOV_TOKEN`       | Codecov token                                                                |
 
 **Example with configuration parameters:**
 
@@ -53,9 +54,10 @@ jobs:
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       ENV_VARS: >-
         [{"name":"EXAMPLE_USERNAME", "value":"${{ secrets.USERNAME }}"}]
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       NODE_VERSION: 14
-      JEST_ARGS: 'my-test --reporters=jest-junit --coverage'
+      JEST_ARGS: 'my-test --reporters=jest-junit'
 ```
 
 ## Static analysis JavaScript

--- a/docs/php.md
+++ b/docs/php.md
@@ -153,7 +153,6 @@ jobs:
 | `PHP_EXTENSIONS`        | `''`                | PHP extensions supported by shivammathur/setup-php to be installed or disabled |
 | `COMPOSER_ARGS`         | `'--prefer-dist'`   | Set of arguments passed to Composer                                            |
 | `PHPUNIT_ARGS`          | `'--coverage-text'` | Set of arguments passed to PHPUnit                                             |
-| `CODECOV_COVERAGE_FILE` | `'coverage.xml'`    | Path to the coverage file to upload to Codecov                                 |
 
 #### Secrets
 
@@ -180,7 +179,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       PHP_VERSION: ${{ matrix.php }}
-      PHPUNIT_ARGS: '--coverage-text --coverage-clover coverage.xml'
+      PHPUNIT_ARGS: '--coverage-text'
 ```
 
 ## Lint PHP

--- a/docs/php.md
+++ b/docs/php.md
@@ -153,6 +153,7 @@ jobs:
 | `PHP_EXTENSIONS` | `''`                | PHP extensions supported by shivammathur/setup-php to be installed or disabled |
 | `COMPOSER_ARGS`  | `'--prefer-dist'`   | Set of arguments passed to Composer                                            |
 | `PHPUNIT_ARGS`   | `'--coverage-text'` | Set of arguments passed to PHPUnit                                             |
+| `CODECOV_FLAGS`  | `'unittests'`       | Flags to be passed to Codecov                                                  |
 
 #### Secrets
 
@@ -180,6 +181,7 @@ jobs:
     with:
       PHP_VERSION: ${{ matrix.php }}
       PHPUNIT_ARGS: '--coverage-text'
+      CODECOV_FLAGS: 'php'
 ```
 
 ## Lint PHP

--- a/docs/php.md
+++ b/docs/php.md
@@ -147,12 +147,13 @@ jobs:
 
 #### Inputs
 
-| Name             | Default             | Description                                                                    |
-|------------------|---------------------|--------------------------------------------------------------------------------|
-| `PHP_VERSION`    | `'8.2'`             | PHP version with which the scripts are executed                                |
-| `PHP_EXTENSIONS` | `''`                | PHP extensions supported by shivammathur/setup-php to be installed or disabled |
-| `COMPOSER_ARGS`  | `'--prefer-dist'`   | Set of arguments passed to Composer                                            |
-| `PHPUNIT_ARGS`   | `'--coverage-text'` | Set of arguments passed to PHPUnit                                             |
+| Name                    | Default             | Description                                                                    |
+|-------------------------|---------------------|--------------------------------------------------------------------------------|
+| `PHP_VERSION`           | `'8.2'`             | PHP version with which the scripts are executed                                |
+| `PHP_EXTENSIONS`        | `''`                | PHP extensions supported by shivammathur/setup-php to be installed or disabled |
+| `COMPOSER_ARGS`         | `'--prefer-dist'`   | Set of arguments passed to Composer                                            |
+| `PHPUNIT_ARGS`          | `'--coverage-text'` | Set of arguments passed to PHPUnit                                             |
+| `CODECOV_COVERAGE_FILE` | `'coverage.xml'`    | Path to the coverage file to upload to Codecov                                 |
 
 #### Secrets
 
@@ -160,6 +161,7 @@ jobs:
 |----------------------|------------------------------------------------------------------------------------------|
 | `COMPOSER_AUTH_JSON` | Authentication for privately hosted packages and repositories as a JSON formatted object |
 | `ENV_VARS`           | Additional environment variables as a JSON formatted object                              |
+| `CODECOV_TOKEN`      | Codecov token                                                                            |
 
 **Example with configuration parameters:**
 
@@ -174,9 +176,11 @@ jobs:
       matrix:
         php: [ "8.1", "8.2", "8.3" ]
     uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@main
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       PHP_VERSION: ${{ matrix.php }}
-      PHPUNIT_ARGS: '--coverage-text --debug'
+      PHPUNIT_ARGS: '--coverage-text --coverage-clover coverage.xml'
 ```
 
 ## Lint PHP

--- a/docs/php.md
+++ b/docs/php.md
@@ -147,12 +147,12 @@ jobs:
 
 #### Inputs
 
-| Name                    | Default             | Description                                                                    |
-|-------------------------|---------------------|--------------------------------------------------------------------------------|
-| `PHP_VERSION`           | `'8.2'`             | PHP version with which the scripts are executed                                |
-| `PHP_EXTENSIONS`        | `''`                | PHP extensions supported by shivammathur/setup-php to be installed or disabled |
-| `COMPOSER_ARGS`         | `'--prefer-dist'`   | Set of arguments passed to Composer                                            |
-| `PHPUNIT_ARGS`          | `'--coverage-text'` | Set of arguments passed to PHPUnit                                             |
+| Name             | Default             | Description                                                                    |
+|------------------|---------------------|--------------------------------------------------------------------------------|
+| `PHP_VERSION`    | `'8.2'`             | PHP version with which the scripts are executed                                |
+| `PHP_EXTENSIONS` | `''`                | PHP extensions supported by shivammathur/setup-php to be installed or disabled |
+| `COMPOSER_ARGS`  | `'--prefer-dist'`   | Set of arguments passed to Composer                                            |
+| `PHPUNIT_ARGS`   | `'--coverage-text'` | Set of arguments passed to PHPUnit                                             |
 
 #### Secrets
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature


## What is the current behavior? (You can also link to an open issue here)
The PHPUnit and Jest workflows don't support (conditionally) uploading coverage reports to Codecov.


## What is the new behavior (if this is a feature change)?
Add Codecov support for the "Unit tests PHP" and "Unit tests JavaScript" workflows by uploading the respective coverage files to Codecov.


## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No. The tests are only run with coverage support, i.e., write to a coverage report file, when the `CODECOV_TOKEN` secret is set. And only if these files exist (`coverage/lcov.info` for Jest and `coverage.xml` for PHPUnit).


## Other information
Closes #188 