### PR TITLE
Extract repeated setup steps into reusable composite actions

### DIFF
--- a/.github/actions/setup-git/README.md
+++ b/.github/actions/setup-git/README.md
@@ -1,4 +1,4 @@
-# Setup Git
+# Set up Git
 
 This composite action configures SSH authentication, Git user identity, and optional commit signing using [webfactory/ssh-agent](https://github.com/webfactory/ssh-agent).
 

--- a/.github/actions/setup-git/README.md
+++ b/.github/actions/setup-git/README.md
@@ -1,6 +1,6 @@
 # Set up Git
 
-This composite action configures SSH authentication, Git user identity, and optional commit signing using [webfactory/ssh-agent](https://github.com/webfactory/ssh-agent).
+This composite action configures SSH authentication, Git user identity, and optional commit signing.
 
 ## Simple usage example
 

--- a/.github/actions/setup-git/README.md
+++ b/.github/actions/setup-git/README.md
@@ -1,0 +1,33 @@
+# Setup Git
+
+This composite action configures SSH authentication, Git user identity, and optional commit signing using [webfactory/ssh-agent](https://github.com/webfactory/ssh-agent).
+
+## Simple usage example
+
+```yml
+steps:
+  - uses: actions/checkout@v4
+  - uses: ./.github/actions/setup-git
+    with:
+      ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
+      user-email: ${{ secrets.GITHUB_USER_EMAIL }}
+      user-name: ${{ secrets.GITHUB_USER_NAME }}
+```
+
+## Inputs
+
+| Name                | Default   | Description                                                                                                      |
+|---------------------|-----------|------------------------------------------------------------------------------------------------------------------|
+| `ssh-private-key`   | `''`      | Private SSH key for authentication.                                                                              |
+| `user-email`        | `''`      | Git user email.                                                                                                  |
+| `user-name`         | `''`      | Git user name.                                                                                                   |
+| `ssh-public-key`    | `''`      | Public SSH key for commit signing.                                                                               |
+| `automated-commits` | `'false'` | Enable Git settings for automated commits (auto-tracks remote branches on push, silences ignored-file warnings). |
+
+## Notes
+
+- Every step in this action is conditional. Steps are skipped when their corresponding inputs are empty, so you only need to provide the inputs relevant to your use case.
+  - SSH setup runs only when `ssh-private-key` is provided.
+  - Git identity is configured only when both `user-email` and `user-name` are provided.
+  - Commit signing is configured only when `ssh-public-key` is provided.
+- The `automated-commits` input, when set to `'true'`, applies two Git configuration settings: `push.autoSetupRemote true` (so that `git push` automatically tracks the remote branch without requiring `--set-upstream`) and `advice.addIgnoredFile false` (to suppress warnings when staging files matched by `.gitignore`). This is useful for workflows that create and push commits programmatically.

--- a/.github/actions/setup-git/README.md
+++ b/.github/actions/setup-git/README.md
@@ -23,11 +23,3 @@ steps:
 | `user-name`         | `''`      | Git user name.                                                                                                   |
 | `ssh-public-key`    | `''`      | Public SSH key for commit signing.                                                                               |
 | `automated-commits` | `'false'` | Enable Git settings for automated commits (auto-tracks remote branches on push, silences ignored-file warnings). |
-
-## Notes
-
-- Every step in this action is conditional. Steps are skipped when their corresponding inputs are empty, so you only need to provide the inputs relevant to your use case.
-  - SSH setup runs only when `ssh-private-key` is provided.
-  - Git identity is configured only when both `user-email` and `user-name` are provided.
-  - Commit signing is configured only when `ssh-public-key` is provided.
-- The `automated-commits` input, when set to `'true'`, applies two Git configuration settings: `push.autoSetupRemote true` (so that `git push` automatically tracks the remote branch without requiring `--set-upstream`) and `advice.addIgnoredFile false` (to suppress warnings when staging files matched by `.gitignore`). This is useful for workflows that create and push commits programmatically.

--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -3,23 +3,23 @@ description: Set up SSH agent, Git identity, and optional commit signing.
 
 inputs:
   ssh-private-key:
-    description: Private SSH key for authentication. Skipped when empty.
+    description: Private SSH key for authentication.
     default: ''
     required: false
   user-email:
-    description: Git user.email. Skipped when empty.
+    description: Git user email.
     default: ''
     required: false
   user-name:
-    description: Git user.name. Skipped when empty.
+    description: Git user name.
     default: ''
     required: false
   ssh-public-key:
-    description: Public SSH key for commit signing. Skipped when empty.
+    description: Public SSH key for commit signing.
     default: ''
     required: false
-  push-auto-setup-remote:
-    description: Set push.autoSetupRemote and disable addIgnoredFile advice ('true' or 'false').
+  automated-commits:
+    description: Enable Git settings for automated commits (auto-tracks remote branches on push, silences ignored-file warnings).
     default: 'false'
     required: false
 
@@ -40,7 +40,7 @@ runs:
         git config --global user.name "${{ inputs.user-name }}"
 
     - name: Set up Git configuration
-      if: ${{ inputs.push-auto-setup-remote == 'true' }}
+      if: ${{ inputs.automated-commits == 'true' }}
       shell: bash
       run: |
         git config --global advice.addIgnoredFile false

--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -1,0 +1,58 @@
+name: Setup Git
+description: Set up SSH agent, Git identity, and optional commit signing.
+
+inputs:
+  ssh-key:
+    description: Private SSH key for authentication. Skipped when empty.
+    default: ''
+    required: false
+  user-email:
+    description: Git user.email. Skipped when empty.
+    default: ''
+    required: false
+  user-name:
+    description: Git user.name. Skipped when empty.
+    default: ''
+    required: false
+  ssh-public-key:
+    description: Public SSH key for commit signing. Skipped when empty.
+    default: ''
+    required: false
+  push-auto-setup-remote:
+    description: Set push.autoSetupRemote and disable addIgnoredFile advice ('true' or 'false').
+    default: 'false'
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Set up SSH
+      if: ${{ inputs.ssh-key != '' }}
+      uses: webfactory/ssh-agent@v0.9.1
+      with:
+        ssh-private-key: ${{ inputs.ssh-key }}
+
+    - name: Set up Git identity
+      if: ${{ inputs.user-email != '' && inputs.user-name != '' }}
+      shell: bash
+      run: |
+        git config --global user.email "${{ inputs.user-email }}"
+        git config --global user.name "${{ inputs.user-name }}"
+
+    - name: Set up Git configuration
+      if: ${{ inputs.push-auto-setup-remote == 'true' }}
+      shell: bash
+      run: |
+        git config --global advice.addIgnoredFile false
+        git config --global push.autoSetupRemote true
+
+    - name: Set up commit signing
+      if: ${{ inputs.ssh-public-key != '' }}
+      shell: bash
+      run: |
+        : # Create empty SSH private key file so Git does not complain.
+        touch "${{ runner.temp }}/signingkey"
+        echo "${{ inputs.ssh-public-key }}" > "${{ runner.temp }}/signingkey.pub"
+        git config --global commit.gpgsign true
+        git config --global gpg.format ssh
+        git config --global user.signingkey "${{ runner.temp }}/signingkey.pub"

--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -1,4 +1,4 @@
-name: Setup Git
+name: Set up Git
 description: Set up SSH agent, Git identity, and optional commit signing.
 
 inputs:

--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -2,7 +2,7 @@ name: Setup Git
 description: Set up SSH agent, Git identity, and optional commit signing.
 
 inputs:
-  ssh-key:
+  ssh-private-key:
     description: Private SSH key for authentication. Skipped when empty.
     default: ''
     required: false
@@ -27,10 +27,10 @@ runs:
   using: composite
   steps:
     - name: Set up SSH
-      if: ${{ inputs.ssh-key != '' }}
+      if: ${{ inputs.ssh-private-key != '' }}
       uses: webfactory/ssh-agent@v0.9.1
       with:
-        ssh-private-key: ${{ inputs.ssh-key }}
+        ssh-private-key: ${{ inputs.ssh-private-key }}
 
     - name: Set up Git identity
       if: ${{ inputs.user-email != '' && inputs.user-name != '' }}

--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - name: Set up SSH
       if: ${{ inputs.ssh-private-key != '' }}
-      uses: webfactory/ssh-agent@v0.9.1
+      uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
       with:
         ssh-private-key: ${{ inputs.ssh-private-key }}
 

--- a/.github/actions/setup-node/README.md
+++ b/.github/actions/setup-node/README.md
@@ -24,8 +24,3 @@ steps:
 | `node-options`         | `''`                            | Space-separated list of command-line Node options.                                                          |
 | `package-manager`      | `'npm'`                         | Package manager to use (`npm` or `yarn`). **Deprecated:** yarn support will be removed in a future version. |
 | `install-dependencies` | `'true'`                        | Whether to install dependencies (`'true'` or `'false'`).                                                    |
-
-## Notes
-
-- Dependency caching is enabled automatically when a lock file is detected (`package-lock.json` or `npm-shrinkwrap.json` for npm, `yarn.lock` for yarn). If no lock file is found, caching is skipped and a plain install is performed instead of a clean install.
-- **Yarn support is deprecated.** The `package-manager` input still accepts `'yarn'`, but this option will be removed in a future version. New workflows should use npm.

--- a/.github/actions/setup-node/README.md
+++ b/.github/actions/setup-node/README.md
@@ -1,6 +1,6 @@
 # Set up Node
 
-This composite action sets up Node.js using [actions/setup-node](https://github.com/actions/setup-node), automatically detects lock files for dependency caching, and installs project dependencies.
+This composite action sets up Node.js, automatically detects lock files for dependency caching, and installs project dependencies.
 
 ## Simple usage example
 

--- a/.github/actions/setup-node/README.md
+++ b/.github/actions/setup-node/README.md
@@ -1,4 +1,4 @@
-# Setup Node
+# Set up Node
 
 This composite action sets up Node.js using [actions/setup-node](https://github.com/actions/setup-node), automatically detects lock files for dependency caching, and installs project dependencies.
 

--- a/.github/actions/setup-node/README.md
+++ b/.github/actions/setup-node/README.md
@@ -1,0 +1,31 @@
+# Setup Node
+
+This composite action sets up Node.js using [actions/setup-node](https://github.com/actions/setup-node), automatically detects lock files for dependency caching, and installs project dependencies.
+
+## Simple usage example
+
+```yml
+steps:
+  - uses: actions/checkout@v4
+  - uses: ./.github/actions/setup-node
+    with:
+      registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
+      node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+```
+
+## Inputs
+
+| Name                   | Default                         | Description                                                                                                 |
+|------------------------|---------------------------------|-------------------------------------------------------------------------------------------------------------|
+| `node-version`         | `'18'`                          | Node version to set up.                                                                                     |
+| `node-version-file`    | `''`                            | Path to a file containing the Node version (takes precedence over `node-version`).                          |
+| `registry-url`         | `'https://npm.pkg.github.com/'` | npm registry URL.                                                                                           |
+| `node-auth-token`      | `''`                            | Authentication token for the npm registry.                                                                  |
+| `node-options`         | `''`                            | Space-separated list of command-line Node options.                                                          |
+| `package-manager`      | `'npm'`                         | Package manager to use (`npm` or `yarn`). **Deprecated:** yarn support will be removed in a future version. |
+| `install-dependencies` | `'true'`                        | Whether to install dependencies (`'true'` or `'false'`).                                                    |
+
+## Notes
+
+- Dependency caching is enabled automatically when a lock file is detected (`package-lock.json` or `npm-shrinkwrap.json` for npm, `yarn.lock` for yarn). If no lock file is found, caching is skipped and a plain install is performed instead of a clean install.
+- **Yarn support is deprecated.** The `package-manager` input still accepts `'yarn'`, but this option will be removed in a future version. New workflows should use npm.

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -55,7 +55,7 @@ runs:
         echo "cache-mode=$CACHE_MODE" >> "$GITHUB_OUTPUT"
 
     - name: Set up Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       env:
         NODE_OPTIONS: ${{ inputs.node-options }}
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,9 +1,9 @@
 name: Setup Node
-description: Set up Node.js with cache detection and dependency installation.
+description: Set up Node with cache detection and dependency installation.
 
 inputs:
   node-version:
-    description: Node.js version to set up.
+    description: Node version to set up.
     default: '18'
     required: false
   node-version-file:
@@ -48,7 +48,7 @@ runs:
         fi
         echo "cache-mode=$CACHE_MODE" >> "$GITHUB_OUTPUT"
 
-    - name: Set up Node.js
+    - name: Set up Node
       uses: actions/setup-node@v4
       env:
         NODE_OPTIONS: ${{ inputs.node-options }}

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,4 +1,4 @@
-name: Setup Node
+name: Set up Node
 description: Set up Node with cache detection and dependency installation.
 
 inputs:

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: npm registry URL.
     default: 'https://npm.pkg.github.com/'
     required: false
-  npm-auth-token:
+  node-auth-token:
     description: Authentication token for the npm registry.
     default: ''
     required: false
@@ -52,7 +52,7 @@ runs:
       uses: actions/setup-node@v4
       env:
         NODE_OPTIONS: ${{ inputs.node-options }}
-        NODE_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+        NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
       with:
         node-version: ${{ inputs.node-version-file && '' || inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,79 @@
+name: Setup Node
+description: Set up Node.js with cache detection and dependency installation.
+
+inputs:
+  node-version:
+    description: Node.js version to set up.
+    default: '18'
+    required: false
+  node-version-file:
+    description: Path to a file containing the Node version (takes precedence over node-version).
+    default: ''
+    required: false
+  registry-url:
+    description: npm registry URL.
+    default: 'https://npm.pkg.github.com/'
+    required: false
+  npm-auth-token:
+    description: Authentication token for the npm registry.
+    default: ''
+    required: false
+  node-options:
+    description: Space-separated list of command-line Node options.
+    default: ''
+    required: false
+  package-manager:
+    description: "Package manager to use (npm or yarn). Deprecated: yarn support will be removed in a future version."
+    default: 'npm'
+    required: false
+  install-dependencies:
+    description: Whether to install dependencies ('true' or 'false').
+    default: 'true'
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Detect cache mode
+      id: cache-detection
+      shell: bash
+      run: |
+        CACHE_MODE=""
+        if [ "${{ inputs.package-manager }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
+          CACHE_MODE="npm"
+        elif [ "${{ inputs.package-manager }}" == 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ]; then
+          CACHE_MODE="yarn"
+        else
+          echo "No lock files found for ${{ inputs.package-manager }}"
+        fi
+        echo "cache-mode=$CACHE_MODE" >> "$GITHUB_OUTPUT"
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      env:
+        NODE_OPTIONS: ${{ inputs.node-options }}
+        NODE_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
+      with:
+        node-version: ${{ inputs.node-version-file && '' || inputs.node-version }}
+        node-version-file: ${{ inputs.node-version-file }}
+        registry-url: ${{ inputs.registry-url }}
+        cache: ${{ steps.cache-detection.outputs.cache-mode }}
+
+    - name: Install dependencies
+      if: ${{ inputs.install-dependencies == 'true' }}
+      shell: bash
+      run: |
+        CACHE_MODE="${{ steps.cache-detection.outputs.cache-mode }}"
+        if [ "${{ inputs.package-manager }}" == 'yarn' ]; then
+          if [ "$CACHE_MODE" == 'yarn' ]; then
+            yarn --frozen-lockfile
+          else
+            yarn install
+          fi
+        else
+          if [ "$CACHE_MODE" == 'npm' ]; then
+            npm ci
+          else
+            npm install
+          fi
+        fi

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -34,6 +34,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Package manager deprecation warning
+      if: ${{ inputs.package-manager != 'npm' }}
+      shell: bash
+      run: |
+        echo "::warning::The package-manager input is deprecated and will be removed soon. Please update your workflow to use npm."
+
     - name: Detect cache mode
       id: cache-detection
       shell: bash

--- a/.github/actions/setup-php/README.md
+++ b/.github/actions/setup-php/README.md
@@ -24,6 +24,3 @@ steps:
 | `composer-options`   | `'--prefer-dist'` | Arguments passed to Composer install.                                                     |
 | `composer-auth-json` | `''`              | Authentication for privately hosted packages and repositories as a JSON formatted object. |
 
-## Notes
-
-- When `composer-install` is `'true'`, `composer validate` runs automatically before installing dependencies. This ensures that `composer.json` and `composer.lock` are consistent.

--- a/.github/actions/setup-php/README.md
+++ b/.github/actions/setup-php/README.md
@@ -1,0 +1,29 @@
+# Setup PHP
+
+This composite action sets up PHP using [shivammathur/setup-php](https://github.com/shivammathur/setup-php), validates `composer.json`/`composer.lock`, and installs Composer dependencies via [ramsey/composer-install](https://github.com/ramsey/composer-install).
+
+## Simple usage example
+
+```yml
+steps:
+  - uses: actions/checkout@v4
+  - uses: ./.github/actions/setup-php
+    with:
+      composer-auth-json: ${{ secrets.COMPOSER_AUTH_JSON }}
+```
+
+## Inputs
+
+| Name                 | Default           | Description                                                                               |
+|----------------------|-------------------|-------------------------------------------------------------------------------------------|
+| `php-version`        | `'8.2'`           | PHP version to set up.                                                                    |
+| `php-extensions`     | `''`              | PHP extensions to install or disable.                                                     |
+| `php-tools`          | `'composer'`      | PHP tools to install (e.g. `composer`, `cs2pr`, `parallel-lint`).                         |
+| `coverage`           | `'none'`          | Code coverage driver (`none`, `xdebug`, `pcov`, or empty for default).                    |
+| `composer-install`   | `'true'`          | Whether to validate and install Composer dependencies (`'true'` or `'false'`).            |
+| `composer-options`   | `'--prefer-dist'` | Arguments passed to Composer install.                                                     |
+| `composer-auth-json` | `''`              | Authentication for privately hosted packages and repositories as a JSON formatted object. |
+
+## Notes
+
+- When `composer-install` is `'true'`, `composer validate` runs automatically before installing dependencies. This ensures that `composer.json` and `composer.lock` are consistent.

--- a/.github/actions/setup-php/README.md
+++ b/.github/actions/setup-php/README.md
@@ -17,7 +17,7 @@ steps:
 | Name                 | Default           | Description                                                                               |
 |----------------------|-------------------|-------------------------------------------------------------------------------------------|
 | `php-version`        | `'8.2'`           | PHP version to set up.                                                                    |
-| `php-extensions`     | `''`              | PHP extensions to install or disable.                                                     |
+| `php-extensions`     | `''`              | PHP extensions to install.                                                                |
 | `php-tools`          | `'composer'`      | PHP tools to install (e.g. `composer`, `cs2pr`, `parallel-lint`).                         |
 | `coverage`           | `'none'`          | Code coverage driver (`none`, `xdebug`, `pcov`, or empty for default).                    |
 | `composer-install`   | `'true'`          | Whether to validate and install Composer dependencies (`'true'` or `'false'`).            |

--- a/.github/actions/setup-php/README.md
+++ b/.github/actions/setup-php/README.md
@@ -1,6 +1,6 @@
 # Set up PHP
 
-This composite action sets up PHP using [shivammathur/setup-php](https://github.com/shivammathur/setup-php), validates `composer.json`/`composer.lock`, and installs Composer dependencies via [ramsey/composer-install](https://github.com/ramsey/composer-install).
+This composite action sets up PHP, validates `composer.json`/`composer.lock`, and installs Composer dependencies.
 
 ## Simple usage example
 

--- a/.github/actions/setup-php/README.md
+++ b/.github/actions/setup-php/README.md
@@ -1,4 +1,4 @@
-# Setup PHP
+# Set up PHP
 
 This composite action sets up PHP using [shivammathur/setup-php](https://github.com/shivammathur/setup-php), validates `composer.json`/`composer.lock`, and installs Composer dependencies via [ramsey/composer-install](https://github.com/ramsey/composer-install).
 

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -1,5 +1,5 @@
 name: Set up PHP
-description: Set up PHP with shivammathur/setup-php, validate and install Composer dependencies.
+description: Set up PHP, validate and install Composer dependencies.
 
 inputs:
   php-version:

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: '8.2'
     required: false
   php-extensions:
-    description: PHP extensions to install or disable.
+    description: PHP extensions to install.
     default: ''
     required: false
   php-tools:

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -1,0 +1,56 @@
+name: Setup PHP
+description: Set up PHP with shivammathur/setup-php, validate and install Composer dependencies.
+
+inputs:
+  php-version:
+    description: PHP version to set up.
+    default: '8.2'
+    required: false
+  php-extensions:
+    description: PHP extensions to install or disable.
+    default: ''
+    required: false
+  php-tools:
+    description: PHP tools to install (e.g. composer, cs2pr, parallel-lint).
+    default: 'composer'
+    required: false
+  coverage:
+    description: Code coverage driver (none, xdebug, pcov, or empty for default).
+    default: 'none'
+    required: false
+  composer-install:
+    description: Whether to validate and install Composer dependencies ('true' or 'false').
+    default: 'true'
+    required: false
+  composer-options:
+    description: Arguments passed to Composer install.
+    default: '--prefer-dist'
+    required: false
+  composer-auth-json:
+    description: Authentication for privately hosted packages and repositories as a JSON formatted object.
+    default: ''
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        extensions: ${{ inputs.php-extensions }}
+        tools: ${{ inputs.php-tools }}
+        coverage: ${{ inputs.coverage }}
+
+    - name: Validate composer.json and composer.lock
+      if: ${{ inputs.composer-install == 'true' }}
+      shell: bash
+      run: composer validate
+
+    - name: Install Composer dependencies
+      if: ${{ inputs.composer-install == 'true' }}
+      uses: ramsey/composer-install@v3
+      env:
+        COMPOSER_AUTH: ${{ inputs.composer-auth-json }}
+      with:
+        composer-options: ${{ inputs.composer-options }}

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -35,7 +35,7 @@ runs:
   using: composite
   steps:
     - name: Set up PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ inputs.php-version }}
         extensions: ${{ inputs.php-extensions }}
@@ -49,7 +49,7 @@ runs:
 
     - name: Install Composer dependencies
       if: ${{ inputs.composer-install == 'true' }}
-      uses: ramsey/composer-install@v3
+      uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
       env:
         COMPOSER_AUTH: ${{ inputs.composer-auth-json }}
       with:

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -1,4 +1,4 @@
-name: Setup PHP
+name: Set up PHP
 description: Set up PHP with shivammathur/setup-php, validate and install Composer dependencies.
 
 inputs:

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -128,10 +128,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_USER_TOKEN != '' && secrets.GITHUB_USER_TOKEN || secrets.GITHUB_TOKEN }}
         run: npx semantic-release
 
-      - name: Delete signing key files
-        env:
-          GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}
-        if: ${{ always() && env.GITHUB_USER_SSH_PUBLIC_KEY != '' }}
-        run: |
-          rm -f "${{ runner.temp }}/signingkey"
-          rm -f "${{ runner.temp }}/signingkey.pub"

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -45,7 +45,7 @@ jobs:
           path: semantic-release-repo
 
       - name: Set up Node
-        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@main
         with:
           node-version-file: semantic-release-repo/package.json
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
@@ -69,7 +69,7 @@ jobs:
           ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Set up Git
-        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@main
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           ssh-public-key: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -44,13 +44,13 @@ jobs:
           sparse-checkout-cone-mode: false
           path: semantic-release-repo
 
-      - name: Set up node
-        uses: actions/setup-node@v4
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      - name: Set up Node
+        uses: ./.github/actions/setup-node
         with:
           node-version-file: semantic-release-repo/package.json
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
+          node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+          install-dependencies: 'false'
 
       - name: Install dependencies
         run: |
@@ -68,25 +68,13 @@ jobs:
           persist-credentials: false
           ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
-      - name: Set up SSH
-        env:
-          GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
-        if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
-        uses: webfactory/ssh-agent@v0.9.1
+      - name: Set up Git
+        uses: ./.github/actions/setup-git
         with:
-          ssh-private-key: ${{ env.GITHUB_USER_SSH_KEY }}
-
-      - name: Set up signing commits
-        env:
-          GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}
-        if: ${{ env.GITHUB_USER_SSH_PUBLIC_KEY != '' }}
-        run: |
-          : # Create empty SSH private key file so Git does not complain.
-          touch "${{ runner.temp }}/signingkey"
-          echo "${{ env.GITHUB_USER_SSH_PUBLIC_KEY }}" > "${{ runner.temp }}/signingkey.pub"
-          git config --global commit.gpgsign true
-          git config --global gpg.format ssh
-          git config --global user.signingkey "${{ runner.temp }}/signingkey.pub"
+          ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
+          ssh-public-key: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}
+          user-email: ${{ secrets.GITHUB_USER_EMAIL }}
+          user-name: ${{ secrets.GITHUB_USER_NAME }}
 
       - name: Check presence of release.config.js
         run: |
@@ -112,16 +100,6 @@ jobs:
         if: ${{ env.HAS_CONFIG == 'false' }}
         run: |
           rm -rf workflow-repo
-
-      - name: Set up release environment variables
-        env:
-          GITHUB_USER_EMAIL: ${{ secrets.GITHUB_USER_EMAIL }}
-          GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
-        run: |
-          ${{ env.GITHUB_USER_EMAIL != '' }} && echo "GIT_AUTHOR_EMAIL=${{ env.GITHUB_USER_EMAIL }}" >> $GITHUB_ENV || true
-          ${{ env.GITHUB_USER_NAME != '' }} && echo "GIT_AUTHOR_NAME=${{ env.GITHUB_USER_NAME }}" >> $GITHUB_ENV || true
-          ${{ env.GITHUB_USER_EMAIL != '' }} && echo "GIT_COMMITTER_EMAIL=${{ env.GITHUB_USER_EMAIL }}" >> $GITHUB_ENV || true
-          ${{ env.GITHUB_USER_NAME != '' }} && echo "GIT_COMMITTER_NAME=${{ env.GITHUB_USER_NAME }}" >> $GITHUB_ENV || true
 
       - name: Release
         env:

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -45,7 +45,7 @@ jobs:
           path: semantic-release-repo
 
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
         with:
           node-version-file: semantic-release-repo/package.json
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
@@ -69,7 +69,7 @@ jobs:
           ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Set up Git
-        uses: ./.github/actions/setup-git
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           ssh-public-key: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -108,7 +108,7 @@ jobs:
           ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Set up Git
-        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@main
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
@@ -258,7 +258,7 @@ jobs:
           composer-options: ${{ inputs.COMPOSER_ARGS }}
 
       - name: Set up Node
-        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@main
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -263,18 +263,13 @@ jobs:
         with:
           composer-options: ${{ inputs.COMPOSER_ARGS }}
 
-      - name: Set up node
-        uses: actions/setup-node@v4
-        env:
-          NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
+          npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+          node-options: ${{ inputs.NODE_OPTIONS }}
 
       - name: Determine package type
         run: |
@@ -386,8 +381,3 @@ jobs:
           include-hidden-files: true
           compression-level: 9
 
-      - name: Delete signing key files
-        if: ${{ always() }}
-        run: |
-          rm -f "${{ runner.temp }}/signingkey"
-          rm -f "${{ runner.temp }}/signingkey.pub"

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -268,7 +268,7 @@ jobs:
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+          node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
           node-options: ${{ inputs.NODE_OPTIONS }}
 
       - name: Determine package type

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -251,7 +251,7 @@ jobs:
         with:
           composer-options: ${{ inputs.COMPOSER_ARGS }}
 
-      - name: Set up Node.js
+      - name: Set up Node
         uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.NODE_VERSION }}

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -101,26 +101,14 @@ jobs:
           fetch-depth: 0
           ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
-      - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.9.0
+      - name: Set up Git
+        uses: ./.github/actions/setup-git
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
-
-      - name: Set up Git
-        run: |
-          git config --global user.email "${{ secrets.GITHUB_USER_EMAIL }}"
-          git config --global user.name "${{ secrets.GITHUB_USER_NAME }}"
-          git config --global advice.addIgnoredFile false
-          git config --global push.autoSetupRemote true
-
-      - name: Set up signing commits
-        run: |
-          : # Create empty SSH private key file so Git does not complain.
-          touch "${{ runner.temp }}/signingkey"
-          echo "${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}" > "${{ runner.temp }}/signingkey.pub"
-          git config --global commit.gpgsign true
-          git config --global gpg.format ssh
-          git config --global user.signingkey "${{ runner.temp }}/signingkey.pub"
+          user-email: ${{ secrets.GITHUB_USER_EMAIL }}
+          user-name: ${{ secrets.GITHUB_USER_NAME }}
+          ssh-public-key: ${{ secrets.GITHUB_USER_SSH_PUBLIC_KEY }}
+          automated-commits: 'true'
 
       - name: Set up custom environment variables
         env:

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -102,7 +102,7 @@ jobs:
           ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Set up Git
-        uses: ./.github/actions/setup-git
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
@@ -252,7 +252,7 @@ jobs:
           composer-options: ${{ inputs.COMPOSER_ARGS }}
 
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}

--- a/.github/workflows/coding-standards-php.yml
+++ b/.github/workflows/coding-standards-php.yml
@@ -56,7 +56,7 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
-        uses: ./.github/actions/setup-php
+        uses: inpsyde/reusable-workflows/.github/actions/setup-php@fix/247
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           php-extensions: ${{ inputs.PHP_EXTENSIONS }}

--- a/.github/workflows/coding-standards-php.yml
+++ b/.github/workflows/coding-standards-php.yml
@@ -56,7 +56,7 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
-        uses: inpsyde/reusable-workflows/.github/actions/setup-php@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-php@main
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           php-extensions: ${{ inputs.PHP_EXTENSIONS }}

--- a/.github/workflows/coding-standards-php.yml
+++ b/.github/workflows/coding-standards-php.yml
@@ -56,22 +56,13 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: ./.github/actions/setup-php
         with:
           php-version: ${{ inputs.PHP_VERSION }}
-          extensions: ${{ inputs.PHP_EXTENSIONS }}
-          tools: composer, cs2pr
-          coverage: none
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
-        env:
-          COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
-        with:
+          php-extensions: ${{ inputs.PHP_EXTENSIONS }}
+          php-tools: 'composer, cs2pr'
           composer-options: ${{ inputs.COMPOSER_ARGS }}
+          composer-auth-json: ${{ secrets.COMPOSER_AUTH_JSON }}
 
       - name: Run PHP_CodeSniffer
         run: ./$(composer config bin-dir)/phpcs ${{ inputs.PHPCS_ARGS }}

--- a/.github/workflows/deploy-deployer.yml
+++ b/.github/workflows/deploy-deployer.yml
@@ -73,7 +73,7 @@ jobs:
           ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Set up Git
-        uses: ./.github/actions/setup-git
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
@@ -86,7 +86,7 @@ jobs:
           wireguard-configuration: ${{ secrets.WIREGUARD_CONFIGURATION }}
 
       - name: Set up PHP
-        uses: ./.github/actions/setup-php
+        uses: inpsyde/reusable-workflows/.github/actions/setup-php@fix/247
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           php-extensions: ${{ inputs.PHP_EXTENSIONS }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Set up Node
         if: steps.npm-workspaces.outputs.enabled == 'true'
-        uses: ./.github/actions/setup-node
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}

--- a/.github/workflows/deploy-deployer.yml
+++ b/.github/workflows/deploy-deployer.yml
@@ -63,7 +63,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      NODE_CACHE_MODE: ''
       COMPOSER_NO_DEV: 1
 
     steps:
@@ -73,18 +72,10 @@ jobs:
           fetch-depth: 0
           ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
-      - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.9.1
+      - name: Set up Git
+        uses: ./.github/actions/setup-git
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ inputs.PHP_VERSION }}
-          extensions: ${{ inputs.PHP_EXTENSIONS }}
-          tools: composer, ${{ inputs.PHP_TOOLS }}
-          coverage: none
 
       - name: Set up WireGuard
         uses: inpsyde/actions/setup-wireguard@v1
@@ -94,13 +85,14 @@ jobs:
         with:
           wireguard-configuration: ${{ secrets.WIREGUARD_CONFIGURATION }}
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
-        env:
-          COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
+      - name: Set up PHP
+        uses: ./.github/actions/setup-php
+        with:
+          php-version: ${{ inputs.PHP_VERSION }}
+          php-extensions: ${{ inputs.PHP_EXTENSIONS }}
+          php-tools: 'composer, ${{ inputs.PHP_TOOLS }}'
+          composer-options: ''
+          composer-auth-json: ${{ secrets.COMPOSER_AUTH_JSON }}
 
       - name: Detect npm workspaces
         id: npm-workspaces
@@ -111,27 +103,13 @@ jobs:
             echo "enabled=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Set up node cache mode
-        run: |
-          if [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; then
-            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
-          else
-            echo "No lock files found or unknown package manager"
-          fi
-
-      - name: Set up node
+      - name: Set up Node
         if: steps.npm-workspaces.outputs.enabled == 'true'
-        uses: actions/setup-node@v4
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+        uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          cache: ${{ env.NODE_CACHE_MODE }}
-
-      - name: Install npm dependencies
-        if: steps.npm-workspaces.outputs.enabled == 'true'
-        run: npm ${{ env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
+          node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
 
       - name: Run the build using workspaces
         if: steps.npm-workspaces.outputs.enabled == 'true'

--- a/.github/workflows/deploy-deployer.yml
+++ b/.github/workflows/deploy-deployer.yml
@@ -133,6 +133,7 @@ jobs:
 
       - name: Run Deployer
         env:
+          ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
           DEPLOY_HOSTNAME: ${{ secrets.DEPLOY_HOSTNAME }}
           DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}

--- a/.github/workflows/deploy-deployer.yml
+++ b/.github/workflows/deploy-deployer.yml
@@ -73,7 +73,7 @@ jobs:
           ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
       - name: Set up Git
-        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@main
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
 
@@ -86,7 +86,7 @@ jobs:
           wireguard-configuration: ${{ secrets.WIREGUARD_CONFIGURATION }}
 
       - name: Set up PHP
-        uses: inpsyde/reusable-workflows/.github/actions/setup-php@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-php@main
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           php-extensions: ${{ inputs.PHP_EXTENSIONS }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Set up Node
         if: steps.npm-workspaces.outputs.enabled == 'true'
-        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@main
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -56,7 +56,7 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
-        uses: ./.github/actions/setup-php
+        uses: inpsyde/reusable-workflows/.github/actions/setup-php@fix/247
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           php-extensions: ${{ inputs.PHP_EXTENSIONS }}

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -56,7 +56,7 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
-        uses: inpsyde/reusable-workflows/.github/actions/setup-php@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-php@main
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           php-extensions: ${{ inputs.PHP_EXTENSIONS }}

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -56,20 +56,14 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: ./.github/actions/setup-php
         with:
           php-version: ${{ inputs.PHP_VERSION }}
-          extensions: ${{ inputs.PHP_EXTENSIONS }}
-          tools: cs2pr, parallel-lint
-          coverage: none
-
-      - name: Install Composer dependencies
-        if: ${{ inputs.COMPOSER_DEPS_INSTALL }}
-        uses: ramsey/composer-install@v3
-        env:
-          COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
-        with:
+          php-extensions: ${{ inputs.PHP_EXTENSIONS }}
+          php-tools: 'cs2pr, parallel-lint'
+          composer-install: ${{ inputs.COMPOSER_DEPS_INSTALL }}
           composer-options: ${{ inputs.COMPOSER_ARGS }}
+          composer-auth-json: ${{ secrets.COMPOSER_AUTH_JSON }}
 
       - name: Run PHP lint check
         run: parallel-lint ${{ inputs.LINT_ARGS }} --checkstyle | cs2pr

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Git
         uses: ./.github/actions/setup-git
         with:
-          ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
+          ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           user-name: ${{ secrets.GITHUB_USER_NAME }}
 
@@ -66,7 +66,7 @@ jobs:
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+          node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
           node-options: ${{ inputs.NODE_OPTIONS }}
 
       - name: Run tsc

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -55,14 +55,14 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up Git
-        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@main
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           user-name: ${{ secrets.GITHUB_USER_NAME }}
 
       - name: Set up Node
-        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@main
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -61,7 +61,7 @@ jobs:
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           user-name: ${{ secrets.GITHUB_USER_NAME }}
 
-      - name: Set up Node.js
+      - name: Set up Node
         uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.NODE_VERSION }}

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -39,8 +39,6 @@ jobs:
   static-analysis-js:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    env:
-      NODE_CACHE_MODE: ''
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,45 +54,20 @@ jobs:
               .parse(process.env.ENV_VARS)
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
-      - name: Set up SSH
-        env:
-          GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
-        if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
-        uses: webfactory/ssh-agent@v0.9.1
-        with:
-          ssh-private-key: ${{ env.GITHUB_USER_SSH_KEY }}
-
       - name: Set up Git
-        env:
-          GITHUB_USER_EMAIL: ${{ secrets.GITHUB_USER_EMAIL }}
-          GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
-        if: ${{ env.GITHUB_USER_EMAIL != '' && env.GITHUB_USER_NAME != '' }}
-        run: |
-          git config --global user.email "${{ env.GITHUB_USER_EMAIL }}"
-          git config --global user.name "${{ env.GITHUB_USER_NAME }}"
+        uses: ./.github/actions/setup-git
+        with:
+          ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
+          user-email: ${{ secrets.GITHUB_USER_EMAIL }}
+          user-name: ${{ secrets.GITHUB_USER_NAME }}
 
-      - name: Set up node cache mode
-        run: |
-          if [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; then
-            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
-          else
-            echo "No lock files found"
-          fi
-
-      - name: Set up node
-        uses: actions/setup-node@v4
-        env:
-          NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          cache: ${{ env.NODE_CACHE_MODE }}
-
-      - name: Install dependencies
-        env:
-          ARGS: ${{ env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
-        run: ${{ format('npm {0}', env.ARGS) }}
+          npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+          node-options: ${{ inputs.NODE_OPTIONS }}
 
       - name: Run tsc
         run: ./node_modules/.bin/tsc --noEmit --skipLibCheck --pretty false

--- a/.github/workflows/static-analysis-js.yml
+++ b/.github/workflows/static-analysis-js.yml
@@ -55,14 +55,14 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up Git
-        uses: ./.github/actions/setup-git
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           user-name: ${{ secrets.GITHUB_USER_NAME }}
 
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}

--- a/.github/workflows/static-analysis-php.yml
+++ b/.github/workflows/static-analysis-php.yml
@@ -56,7 +56,7 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
-        uses: ./.github/actions/setup-php
+        uses: inpsyde/reusable-workflows/.github/actions/setup-php@fix/247
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           php-extensions: ${{ inputs.PHP_EXTENSIONS }}

--- a/.github/workflows/static-analysis-php.yml
+++ b/.github/workflows/static-analysis-php.yml
@@ -56,7 +56,7 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
-        uses: inpsyde/reusable-workflows/.github/actions/setup-php@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-php@main
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           php-extensions: ${{ inputs.PHP_EXTENSIONS }}

--- a/.github/workflows/static-analysis-php.yml
+++ b/.github/workflows/static-analysis-php.yml
@@ -56,22 +56,13 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: ./.github/actions/setup-php
         with:
           php-version: ${{ inputs.PHP_VERSION }}
-          extensions: ${{ inputs.PHP_EXTENSIONS }}
-          tools: composer, cs2pr
-          coverage: none
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
-        env:
-          COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
-        with:
+          php-extensions: ${{ inputs.PHP_EXTENSIONS }}
+          php-tools: 'composer, cs2pr'
           composer-options: ${{ inputs.COMPOSER_ARGS }}
+          composer-auth-json: ${{ secrets.COMPOSER_AUTH_JSON }}
 
       - name: Run Psalm
         if: ${{ hashFiles('psalm.xml', 'psalm.xml.dist') != '' }}

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Set up Git
         uses: ./.github/actions/setup-git
         with:
-          ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
+          ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           user-name: ${{ secrets.GITHUB_USER_NAME }}
 
@@ -149,7 +149,7 @@ jobs:
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+          node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
 
       - name: Build assets
         run: npm run build --if-present

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Git
-        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@main
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
@@ -129,14 +129,14 @@ jobs:
 
       - name: Set up PHP
         if: ${{ inputs.COMPOSER_DEPS_INSTALL }}
-        uses: inpsyde/reusable-workflows/.github/actions/setup-php@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-php@main
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           php-extensions: ${{ inputs.PHP_EXTENSIONS }}
           composer-auth-json: ${{ secrets.COMPOSER_AUTH_JSON }}
 
       - name: Set up Node
-        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@main
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -116,35 +116,16 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PHP_CHECK: false
-      NODE_CACHE_MODE: ''
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up SSH
-        env:
-          GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
-        if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
-        uses: webfactory/ssh-agent@v0.9.1
-        with:
-          ssh-private-key: ${{ env.GITHUB_USER_SSH_KEY }}
-
       - name: Set up Git
-        env:
-          GITHUB_USER_EMAIL: ${{ secrets.GITHUB_USER_EMAIL }}
-          GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
-        if: ${{ env.GITHUB_USER_EMAIL != '' && env.GITHUB_USER_NAME != '' }}
-        run: |
-          git config --global user.email "${{ env.GITHUB_USER_EMAIL }}"
-          git config --global user.name "${{ env.GITHUB_USER_NAME }}"
-
-      - name: Set up node cache mode
-        run: |
-          if [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; then
-            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
-          else
-            echo "No lock files found or unknown package manager"
-          fi
+        uses: ./.github/actions/setup-git
+        with:
+          ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
+          user-email: ${{ secrets.GITHUB_USER_EMAIL }}
+          user-name: ${{ secrets.GITHUB_USER_NAME }}
 
       - name: Set up PHP
         if: ${{ inputs.COMPOSER_DEPS_INSTALL }}
@@ -163,17 +144,12 @@ jobs:
         with:
           composer-options: '--prefer-dist'
 
-      - name: Set up node
-        uses: actions/setup-node@v4
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          cache: ${{ env.NODE_CACHE_MODE }}
-
-      - name: Install dependencies
-        run: npm ${{ env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
+          npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
 
       - name: Build assets
         run: npm run build --if-present

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -144,7 +144,7 @@ jobs:
         with:
           composer-options: '--prefer-dist'
 
-      - name: Set up Node.js
+      - name: Set up Node
         uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.NODE_VERSION }}

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -129,20 +129,11 @@ jobs:
 
       - name: Set up PHP
         if: ${{ inputs.COMPOSER_DEPS_INSTALL }}
-        uses: shivammathur/setup-php@v2
+        uses: ./.github/actions/setup-php
         with:
           php-version: ${{ inputs.PHP_VERSION }}
-          extensions: ${{ inputs.PHP_EXTENSIONS }}
-          tools: composer
-          coverage: none
-
-      - name: Install Composer dependencies
-        if: ${{ inputs.COMPOSER_DEPS_INSTALL }}
-        uses: ramsey/composer-install@v3
-        env:
-          COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
-        with:
-          composer-options: '--prefer-dist'
+          php-extensions: ${{ inputs.PHP_EXTENSIONS }}
+          composer-auth-json: ${{ secrets.COMPOSER_AUTH_JSON }}
 
       - name: Set up Node
         uses: ./.github/actions/setup-node

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Git
-        uses: ./.github/actions/setup-git
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
@@ -129,14 +129,14 @@ jobs:
 
       - name: Set up PHP
         if: ${{ inputs.COMPOSER_DEPS_INSTALL }}
-        uses: ./.github/actions/setup-php
+        uses: inpsyde/reusable-workflows/.github/actions/setup-php@fix/247
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           php-extensions: ${{ inputs.PHP_EXTENSIONS }}
           composer-auth-json: ${{ secrets.COMPOSER_AUTH_JSON }}
 
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Git
         uses: ./.github/actions/setup-git
         with:
-          ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
+          ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           user-name: ${{ secrets.GITHUB_USER_NAME }}
 
@@ -85,7 +85,7 @@ jobs:
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+          node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
           node-options: ${{ inputs.NODE_OPTIONS }}
           package-manager: ${{ inputs.PACKAGE_MANAGER }}
 

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -65,14 +65,14 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up Git
-        uses: ./.github/actions/setup-git
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           user-name: ${{ secrets.GITHUB_USER_NAME }}
 
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -50,15 +50,6 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - name: PACKAGE_MANAGER deprecation warning
-        if: ${{ inputs.PACKAGE_MANAGER != '' }}
-        run: |
-          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]; then
-            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please remove it. The workflow already uses npm by default."
-          else
-            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please update your workflow to use npm."          
-          fi
-
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -49,8 +49,6 @@ jobs:
   tests-unit-js:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    env:
-      NODE_CACHE_MODE: ''
     steps:
       - name: PACKAGE_MANAGER deprecation warning
         if: ${{ inputs.PACKAGE_MANAGER != '' }}
@@ -75,47 +73,21 @@ jobs:
               .parse(process.env.ENV_VARS)
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
-      - name: Set up SSH
-        env:
-          GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
-        if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
-        uses: webfactory/ssh-agent@v0.9.1
-        with:
-          ssh-private-key: ${{ env.GITHUB_USER_SSH_KEY }}
-
       - name: Set up Git
-        env:
-          GITHUB_USER_EMAIL: ${{ secrets.GITHUB_USER_EMAIL }}
-          GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
-        if: ${{ env.GITHUB_USER_EMAIL != '' && env.GITHUB_USER_NAME != '' }}
-        run: |
-          git config --global user.email "${{ env.GITHUB_USER_EMAIL }}"
-          git config --global user.name "${{ env.GITHUB_USER_NAME }}"
+        uses: ./.github/actions/setup-git
+        with:
+          ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
+          user-email: ${{ secrets.GITHUB_USER_EMAIL }}
+          user-name: ${{ secrets.GITHUB_USER_NAME }}
 
-      - name: Set up node cache mode
-        run: |
-          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
-            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
-          elif [ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ]; then
-            echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
-          else
-            echo "No lock files found or unknown package manager"
-          fi
-
-      - name: Set up node
-        uses: actions/setup-node@v4
-        env:
-          NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          cache: ${{ env.NODE_CACHE_MODE }}
-
-      - name: Install dependencies
-        env:
-          ARGS: ${{ env.NODE_CACHE_MODE == 'yarn' && '--frozen-lockfile' || env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
-        run: ${{ format('{0} {1}', inputs.PACKAGE_MANAGER, env.ARGS) }}
+          npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+          node-options: ${{ inputs.NODE_OPTIONS }}
+          package-manager: ${{ inputs.PACKAGE_MANAGER }}
 
       - name: Run Jest
         run: ./node_modules/.bin/jest ${{ inputs.JEST_ARGS }}

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -65,14 +65,14 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up Git
-        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@main
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           user-name: ${{ secrets.GITHUB_USER_NAME }}
 
       - name: Set up Node
-        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@main
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}

--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -80,7 +80,7 @@ jobs:
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           user-name: ${{ secrets.GITHUB_USER_NAME }}
 
-      - name: Set up Node.js
+      - name: Set up Node
         uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.NODE_VERSION }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -51,20 +51,17 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: ./.github/actions/setup-php
         with:
           php-version: ${{ inputs.PHP_VERSION }}
-          extensions: ${{ inputs.PHP_EXTENSIONS }}
+          php-extensions: ${{ inputs.PHP_EXTENSIONS }}
+          php-tools: ''
+          coverage: ''
+          composer-options: ${{ inputs.COMPOSER_ARGS }}
+          composer-auth-json: ${{ secrets.COMPOSER_AUTH_JSON }}
 
       - name: Set up problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
-        env:
-          COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
-        with:
-          composer-options: ${{ inputs.COMPOSER_ARGS }}
 
       - name: Run PHPUnit
         run: ./$(composer config bin-dir)/phpunit ${{ inputs.PHPUNIT_ARGS }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -51,7 +51,7 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
-        uses: ./.github/actions/setup-php
+        uses: inpsyde/reusable-workflows/.github/actions/setup-php@fix/247
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           php-extensions: ${{ inputs.PHP_EXTENSIONS }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -51,7 +51,7 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up PHP
-        uses: inpsyde/reusable-workflows/.github/actions/setup-php@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-php@main
         with:
           php-version: ${{ inputs.PHP_VERSION }}
           php-extensions: ${{ inputs.PHP_EXTENSIONS }}

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -70,8 +70,6 @@ jobs:
   static-analysis-assets:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    env:
-      NODE_CACHE_MODE: ''
     steps:
       - name: PACKAGE_MANAGER deprecation warning
         if: ${{ inputs.PACKAGE_MANAGER != '' }}
@@ -96,47 +94,21 @@ jobs:
               .parse(process.env.ENV_VARS)
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
-      - name: Set up SSH
-        env:
-          GITHUB_USER_SSH_KEY: ${{ secrets.GITHUB_USER_SSH_KEY }}
-        if: ${{ env.GITHUB_USER_SSH_KEY != '' }}
-        uses: webfactory/ssh-agent@v0.9.1
-        with:
-          ssh-private-key: ${{ env.GITHUB_USER_SSH_KEY }}
-
       - name: Set up Git
-        env:
-          GITHUB_USER_EMAIL: ${{ secrets.GITHUB_USER_EMAIL }}
-          GITHUB_USER_NAME: ${{ secrets.GITHUB_USER_NAME }}
-        if: ${{ env.GITHUB_USER_EMAIL != '' && env.GITHUB_USER_NAME != '' }}
-        run: |
-          git config --global user.email "${{ env.GITHUB_USER_EMAIL }}"
-          git config --global user.name "${{ env.GITHUB_USER_NAME }}"
+        uses: ./.github/actions/setup-git
+        with:
+          ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
+          user-email: ${{ secrets.GITHUB_USER_EMAIL }}
+          user-name: ${{ secrets.GITHUB_USER_NAME }}
 
-      - name: Set up node cache mode
-        run: |
-          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ] && { [ -f "${GITHUB_WORKSPACE}/package-lock.json" ] || [ -f "${GITHUB_WORKSPACE}/npm-shrinkwrap.json" ]; }; then
-            echo "NODE_CACHE_MODE=npm" >> $GITHUB_ENV
-          elif [ "${{ inputs.PACKAGE_MANAGER }}" == 'yarn' ] && [ -f "${GITHUB_WORKSPACE}/yarn.lock" ]; then
-            echo "NODE_CACHE_MODE=yarn" >> $GITHUB_ENV
-          else
-            echo "No lock files found or unknown package manager"
-          fi
-
-      - name: Set up node
-        uses: actions/setup-node@v4
-        env:
-          NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          cache: ${{ env.NODE_CACHE_MODE }}
-
-      - name: Install dependencies
-        env:
-          ARGS: ${{ env.NODE_CACHE_MODE == 'yarn' && '--frozen-lockfile' || env.NODE_CACHE_MODE == 'npm' && 'ci' || 'install' }}
-        run: ${{ format('{0} {1}', inputs.PACKAGE_MANAGER, env.ARGS) }}
+          npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+          node-options: ${{ inputs.NODE_OPTIONS }}
+          package-manager: ${{ inputs.PACKAGE_MANAGER }}
 
       - name: Lint script files
         if: ${{ contains(fromJSON(inputs.LINT_TOOLS), 'js') }}

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -101,7 +101,7 @@ jobs:
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           user-name: ${{ secrets.GITHUB_USER_NAME }}
 
-      - name: Set up Node.js
+      - name: Set up Node
         uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.NODE_VERSION }}

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -86,14 +86,14 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up Git
-        uses: ./.github/actions/setup-git
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           user-name: ${{ secrets.GITHUB_USER_NAME }}
 
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Git
         uses: ./.github/actions/setup-git
         with:
-          ssh-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
+          ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           user-name: ${{ secrets.GITHUB_USER_NAME }}
 
@@ -106,7 +106,7 @@ jobs:
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          npm-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
+          node-auth-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
           node-options: ${{ inputs.NODE_OPTIONS }}
           package-manager: ${{ inputs.PACKAGE_MANAGER }}
 

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -86,14 +86,14 @@ jobs:
               .forEach(envVar => core.exportVariable(envVar.name, envVar.value));
 
       - name: Set up Git
-        uses: inpsyde/reusable-workflows/.github/actions/setup-git@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-git@main
         with:
           ssh-private-key: ${{ secrets.GITHUB_USER_SSH_KEY }}
           user-email: ${{ secrets.GITHUB_USER_EMAIL }}
           user-name: ${{ secrets.GITHUB_USER_NAME }}
 
       - name: Set up Node
-        uses: inpsyde/reusable-workflows/.github/actions/setup-node@fix/247
+        uses: inpsyde/reusable-workflows/.github/actions/setup-node@main
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}

--- a/.github/workflows/wp-scripts-lint.yml
+++ b/.github/workflows/wp-scripts-lint.yml
@@ -71,15 +71,6 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - name: PACKAGE_MANAGER deprecation warning
-        if: ${{ inputs.PACKAGE_MANAGER != '' }}
-        run: |
-          if [ "${{ inputs.PACKAGE_MANAGER }}" == 'npm' ]; then
-            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please remove it. The workflow already uses npm by default."
-          else
-            echo "::warning::The PACKAGE_MANAGER input is deprecated and will be removed soon. Please update your workflow to use npm."          
-          fi
-
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature

## What is the current behavior? (You can also link to an open issue here)

Fixes #247 
Fixes #183 

## What is the new behavior (if this is a feature change)?

- Extract three composite actions 
- Incorporate `composer validate` on the `setup-php` composite action so that all the workflows calling it can benefit (before only a part of the workflows were validating composer files)
- Incorporate the package manager input in the `setup-node` so that, when we remove Yarn, the logic and the deprecation warning live only in the action
- Use kebab-case for the actions input, following GitHub convention

Out of scope:
- deprecated workflows have not been modified

Bonus:
- removed the "delete signing key" from the workflows doing that step: since I was working to extract the signing key logic, it made sense to me to execute that task as well
- composite actions pin third-party actions by their commit SHA (#248)

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No, the interface of the workflows has not been changed.

## Other information

### Log of the tests

- automatic-release.yml [log](https://github.com/inpsyde/test-plugin/actions/runs/28157043877/job/83388064353) :white_check_mark: 
- build-and-distribute.yml  [log](https://github.com/inpsyde/standex-electronics-core/actions/runs/27419671046) :white_check_mark: 
- coding-standards-php.yml [log](https://github.com/inpsyde/standex-electronics-core/actions/runs/27419470687/job/81040881706?pr=90) :white_check_mark: 
- deploy-deployer.yml [log](https://github.com/inpsyde/translate-inpsyde-website/actions/runs/27350127856/job/80809399081) :white_check_mark: 
- lint-php.yml [log](https://github.com/inpsyde/standex-electronics-core/actions/runs/27419470687/job/81040881502?pr=90) :white_check_mark: 
- static-analysis-js.yml [log](https://github.com/inpsyde/wonolog-tester/actions/runs/28153816048/job/83377476919) :white_check_mark: (the workflow didn't end successfully for other reasons)
- static-analysis-php.yml [log](https://github.com/inpsyde/standex-electronics-core/actions/runs/27419470687/job/81040881506?pr=90) :white_check_mark:  
- test-playwright.yml [log](https://github.com/inpsyde/google-tag-manager/actions/runs/27411133488/job/81012407870) :white_check_mark:
- tests-unit-js.yml [log](https://github.com/inpsyde/standex-electronics-utils/actions/runs/28155196884/job/83381957160) :white_check_mark: 
- tests-unit-php.yml [log](https://github.com/inpsyde/standex-electronics-core/actions/runs/27419470481/job/81040881556?pr=90) :white_check_mark: 
- wp-scripts-lint.yml [log](https://github.com/Inpsyde-Global-Service-Provider/unilux-reports/actions/runs/27408007444/job/81001871629?pr=7) :white_check_mark: 
