### PR TITLE
Expose artifact name as workflow output

### DIFF
--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -80,11 +80,17 @@ on:
       ENV_VARS:
         description: Additional environment variables as a JSON formatted object.
         required: false
+    outputs:
+      artifact:
+        description: The name of the generated release artifact
+        value: ${{ jobs.build-and-distribute.outputs.artifact }}
 
 jobs:
   build-and-distribute:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    outputs:
+      artifact: ${{ steps.set-artifact-name.outputs.artifact }}
     # Used to check whether there are changes to commit
     env:
       HAS_GIT_CHANGES: ''
@@ -378,10 +384,17 @@ jobs:
           echo "  Package name: ${{ env.PACKAGE_NAME }}"
           echo "  Artifact structure: artifact-staging/${{ env.PACKAGE_NAME }}/"
 
+      - name: Set artifact name
+        id: set-artifact-name
+        run: |
+          ARTIFACT_NAME="${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}"
+          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+          echo "artifact=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: ./artifact-staging/
           include-hidden-files: true
           compression-level: 9

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -82,7 +82,7 @@ on:
         required: false
     outputs:
       artifact:
-        description: The name of the generated release artifact
+        description: The name of the generated release artifact.
         value: ${{ jobs.build-and-distribute.outputs.artifact }}
 
 jobs:

--- a/docs/build-and-distribute.md
+++ b/docs/build-and-distribute.md
@@ -262,6 +262,27 @@ The workflow produces two outputs:
 1. **Build Branch**: The compiled code pushed to the build branch (e.g., `dev/main` → `main`)
 2. **GitHub Artifact**: A downloadable archive named `{package-name}-{version}` containing the build (without `.git` folder)
 
+### Workflow output
+
+The artifact name is also exposed as a workflow output called `artifact`, so downstream jobs in the calling workflow can reference it without having to reconstruct the name themselves:
+
+```yml
+jobs:
+  build-and-distribute:
+    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@main
+    secrets: inherit
+    with:
+      PACKAGE_VERSION: ${{ inputs.PACKAGE_VERSION }}
+
+  deploy:
+    needs: build-and-distribute
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-and-distribute.outputs.artifact }}
+```
+
 ## Migration from previous workflows
 
 If you're migrating from a previous build workflow, consider these changes:


### PR DESCRIPTION
# Expose artifact name as workflow output in `build-and-distribute`

Add an `artifact` output to the build-and-distribute workflow so calling workflows can reference the generated artifact name without reconstructing it manually.

A dedicated step captures the artifact name into both GITHUB_ENV and GITHUB_OUTPUT, making it available to the upload step and to any downstream jobs via `needs.<job>.outputs.artifact`.

## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


`build-plugin-archive` already exposes the generated archive name as a `workflow_call` output (`artifact`). This PR brings the same behaviour to `build-and-distribute`.

## Changes

- **`build-and-distribute.yml`**: Added a `Set artifact name` step that writes the artifact name (`PACKAGE_NAME-PACKAGE_VERSION`) to both `$GITHUB_ENV` and `$GITHUB_OUTPUT`, ensuring a single computed value is used everywhere. Wired that step output up through job-level and workflow-level `outputs` blocks so callers can reference it via `needs.<job>.outputs.artifact`.
- **`docs/build-and-distribute.md`**: Added a "Workflow output" subsection under "Artifact Output" documenting the new output and showing how a downstream job can consume it with `actions/download-artifact`.
