### PR TITLE
Reuse B&D artifact in test-playwright.yml

### DIFF
--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -92,17 +92,12 @@ on:
         default: 'build-and-distribute.yml'
         required: false
         type: string
-      TESTED_ARTIFACT_DIR:
-        description: Directory to download the tested artifact into.
-        default: 'tests/qa/resources/files'
-        required: false
-        type: string
-      TESTED_ARTIFACT_SLUG:
+      ARTIFACT_NAME:
         description: >
-          Plugin slug used to download and repack the tested artifact as a zip for installation.
-          Expects the B&D artifact structure `<slug>-*/` containing `<slug>/` inside.
-          Produces `<slug>.zip` with `<slug>/` at the zip root and cleans up the downloaded directory.
-          Requires TESTED_ARTIFACT_DIR to also be set.
+          Name of the artifact produced by the build workflow to download and repack as a zip for plugin installation.
+          Expects the artifact to contain `<name>/` inside, produces `<name>.zip` with `<name>/` at the zip root.
+          When provided, the workflow resolves the producing run ID from the triggering workflow_run event or
+          the latest successful run of BUILD_WORKFLOW_FILENAME on the current branch.
         default: ''
         required: false
         type: string
@@ -285,9 +280,9 @@ jobs:
           npx wp-env run tests-cli wp config set WP_HOME "$NGROK_URL"
           sed -i "s|WP_BASE_URL=.*|WP_BASE_URL=$NGROK_URL|" .env.ci
 
-      - name: Resolve tested artifact run ID
+      - name: Resolve artifact run ID
         id: resolve-artifact-run-id
-        if: ${{ inputs.TESTED_ARTIFACT_SLUG != '' }}
+        if: ${{ inputs.ARTIFACT_NAME != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -311,24 +306,23 @@ jobs:
           fi
           echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
 
-      - name: Download tested artifact
-        if: ${{ inputs.TESTED_ARTIFACT_SLUG != '' }}
+      - name: Download artifact
+        if: ${{ inputs.ARTIFACT_NAME != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh run download ${{ steps.resolve-artifact-run-id.outputs.run_id }} \
-            -p "${{ inputs.TESTED_ARTIFACT_SLUG }}-*" \
-            -D "${{ inputs.TESTED_ARTIFACT_DIR }}"
+            -p "${{ inputs.ARTIFACT_NAME }}-*" \
+            -D "tests/qa/resources/files"
 
-      - name: Zip tested artifact
-        if: ${{ inputs.TESTED_ARTIFACT_SLUG != '' }}
-        working-directory: ${{ inputs.TESTED_ARTIFACT_DIR }}
+      - name: Zip artifact
+        if: ${{ inputs.ARTIFACT_NAME != '' }}
+        working-directory: tests/qa/resources/files
         run: |
-          SLUG="${{ inputs.TESTED_ARTIFACT_SLUG }}"
-          cd "${SLUG}-"*/
-          zip -rq "../${SLUG}.zip" "${SLUG}"
+          cd "${{ inputs.ARTIFACT_NAME }}-"*/
+          zip -rq "../${{ inputs.ARTIFACT_NAME }}.zip" "${{ inputs.ARTIFACT_NAME }}"
           cd ..
-          rm -rf "${SLUG}-"*/
+          rm -rf "${{ inputs.ARTIFACT_NAME }}-"*/
 
       - name: Execute custom code before executing the test script
         env:

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -330,13 +330,6 @@ jobs:
           cd ..
           rm -rf "${SLUG}-"*/
 
-      - name: Debug zip structure
-        if: ${{ inputs.TESTED_ARTIFACT_SLUG != '' }}
-        working-directory: ${{ inputs.TESTED_ARTIFACT_DIR }}
-        run: |
-          SLUG="${{ inputs.TESTED_ARTIFACT_SLUG }}"
-          unzip -l "${SLUG}.zip" | head -20
-
       - name: Execute custom code before executing the test script
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -87,6 +87,24 @@ on:
         default: ''
         required: false
         type: string
+      BUILD_WORKFLOW_FILENAME:
+        description: Workflow filename to resolve the build run ID from when triggered outside of a workflow_run event.
+        default: 'build-and-distribute.yml'
+        required: false
+        type: string
+      TESTED_ARTIFACT_DIR:
+        description: Directory to download the tested artifact into.
+        default: 'tests/qa/resources/files'
+        required: false
+        type: string
+      TESTED_ARTIFACT_SLUG:
+        description: >
+          Plugin slug used to download and rename the tested artifact.
+          Downloads the B&D artifact matching `<slug>-*` and renames it to `<slug>.zip`
+          in TESTED_ARTIFACT_DIR, ready for plugin installation.
+        default: ''
+        required: false
+        type: string
     secrets:
       ENV_FILE_DATA:
         description: Additional environment variables for the tests.
@@ -189,8 +207,7 @@ jobs:
           rsync -av ./build/ . && rm -rf ./build/
 
       - name: Install Playwright dependencies
-        run: |
-          npx playwright install ${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}
+        run: npx playwright install ${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}
 
       - name: Create environment file
         env:
@@ -266,6 +283,48 @@ jobs:
           npx wp-env run tests-cli wp config set WP_SITEURL "$NGROK_URL"
           npx wp-env run tests-cli wp config set WP_HOME "$NGROK_URL"
           sed -i "s|WP_BASE_URL=.*|WP_BASE_URL=$NGROK_URL|" .env.ci
+
+      - name: Resolve tested artifact run ID
+        id: resolve-artifact-run-id
+        if: ${{ inputs.TESTED_ARTIFACT_SLUG != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            RUN_ID="${{ github.event.workflow_run.id }}"
+            echo "Using workflow_run event run ID: $RUN_ID"
+          else
+            RUN_ID=$(gh run list \
+              --repo "${{ github.repository }}" \
+              --workflow="${{ inputs.BUILD_WORKFLOW_FILENAME }}" \
+              --branch="${{ github.ref_name }}" \
+              --status=success \
+              --limit=1 \
+              --json databaseId \
+              -q '.[0].databaseId')
+            if [ -z "$RUN_ID" ]; then
+              echo "::error::No successful ${{ inputs.BUILD_WORKFLOW_FILENAME }} run found on branch ${{ github.ref_name }}"
+              exit 1
+            fi
+            echo "Resolved run ID from gh run list: $RUN_ID"
+          fi
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Download tested artifact
+        if: ${{ inputs.TESTED_ARTIFACT_SLUG != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run download ${{ steps.resolve-artifact-run-id.outputs.run_id }} \
+            -p "${{ inputs.TESTED_ARTIFACT_SLUG }}-*" \
+            -D "${{ inputs.TESTED_ARTIFACT_DIR }}"
+
+      - name: Rename tested artifact
+        if: ${{ inputs.TESTED_ARTIFACT_SLUG != '' }}
+        working-directory: ${{ inputs.TESTED_ARTIFACT_DIR }}
+        run: |
+          SLUG="${{ inputs.TESTED_ARTIFACT_SLUG }}"
+          mv "${SLUG}-"*.zip "${SLUG}.zip"
 
       - name: Execute custom code before executing the test script
         env:

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -325,8 +325,17 @@ jobs:
         working-directory: ${{ inputs.TESTED_ARTIFACT_DIR }}
         run: |
           SLUG="${{ inputs.TESTED_ARTIFACT_SLUG }}"
-          zip -rq "${SLUG}.zip" "${SLUG}-"*/"${SLUG}"
+          cd "${SLUG}-"*/
+          zip -rq "../${SLUG}.zip" "${SLUG}"
+          cd ..
           rm -rf "${SLUG}-"*/
+
+      - name: Debug zip structure
+        if: ${{ inputs.TESTED_ARTIFACT_SLUG != '' }}
+        working-directory: ${{ inputs.TESTED_ARTIFACT_DIR }}
+        run: |
+          SLUG="${{ inputs.TESTED_ARTIFACT_SLUG }}"
+          unzip -l "${SLUG}.zip" | head -20
 
       - name: Execute custom code before executing the test script
         env:

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -99,9 +99,10 @@ on:
         type: string
       TESTED_ARTIFACT_SLUG:
         description: >
-          Plugin slug used to download and rename the tested artifact.
-          Downloads the B&D artifact matching `<slug>-*` and renames it to `<slug>.zip`
-          in TESTED_ARTIFACT_DIR, ready for plugin installation.
+          Plugin slug used to download and repack the tested artifact as a zip for installation.
+          Expects the B&D artifact structure `<slug>-*/` containing `<slug>/` inside.
+          Produces `<slug>.zip` with `<slug>/` at the zip root and cleans up the downloaded directory.
+          Requires TESTED_ARTIFACT_DIR to also be set.
         default: ''
         required: false
         type: string
@@ -319,12 +320,13 @@ jobs:
             -p "${{ inputs.TESTED_ARTIFACT_SLUG }}-*" \
             -D "${{ inputs.TESTED_ARTIFACT_DIR }}"
 
-      - name: Rename tested artifact
+      - name: Zip tested artifact
         if: ${{ inputs.TESTED_ARTIFACT_SLUG != '' }}
         working-directory: ${{ inputs.TESTED_ARTIFACT_DIR }}
         run: |
           SLUG="${{ inputs.TESTED_ARTIFACT_SLUG }}"
-          mv "${SLUG}-"*.zip "${SLUG}.zip"
+          zip -rq "${SLUG}.zip" "${SLUG}-"*/"${SLUG}"
+          rm -rf "${SLUG}-"*/
 
       - name: Execute custom code before executing the test script
         env:


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature


## What is the current behavior? (You can also link to an open issue here)
Steps for retreiving B&D artifacts are missing.


## What is the new behavior (if this is a feature change)?
If TESTED_ARTIFACT_SLUG is provided, the workflow will download the artifact built by B&D and place it as a ready-to-install .zip in TESTED_ARTIFACT_DIR.

- Add inputs
    - BUILD_WORKFLOW_FILENAME (build-and-distribute.yml by default)
    - TESTED_ARTIFACT_DIR (`tests/qa/resources/files` by default)
    - TESTED_ARTIFACT_SLUG
- Add steps
    - Resolve tested artifact run ID (uses the triggering run ID when invoked via workflow_run, otherwise finds the latest successful B&D run on the current branch via gh run list)
    - Download tested artifact (downloads the artifact matching <slug>-* from the resolved run)
    - Rename tested artifact (strips the version suffix to normalize .zip filename to TESTED_ARTIFACT_SLUG for further usage in tests)

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No