### PR TITLE
Add duplicate run detection to skip redundant builds

### DIFF
--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -146,42 +146,42 @@ jobs:
         run: |
           # Fetch latest public release
           LATEST_RELEASE=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' || echo "")
-          
+
           if [ -z "$LATEST_RELEASE" ]; then
             echo "No releases found, using default version 0.0.0."
             LATEST_RELEASE="0.0.0"
           else
             echo "Latest release found: $LATEST_RELEASE"
           fi
-          
+
           # Get short SHA (first 7 characters)
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           echo "Short SHA: $SHORT_SHA"
-          
+
           # Strip 'dev/' prefix from branch name for version string (if it exists)
           ORIGIN_BRANCH="${{ github.ref_name }}"
           VERSION_BRANCH="${ORIGIN_BRANCH#dev/}"
-          
+
           # Normalize branch name for semver pre-release identifier
           # Replace invalid characters with hyphens and convert to lowercase
           NORMALIZED_BRANCH=$(echo "$VERSION_BRANCH" | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$//g' | tr '[:upper:]' '[:lower:]')
-          
+
           # Construct semver with pre-release identifier using short SHA
           PACKAGE_VERSION="${LATEST_RELEASE}+${NORMALIZED_BRANCH}.${SHORT_SHA}"
           echo "Generated package version: $PACKAGE_VERSION"
-          
+
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
 
       - name: Inspect origin branch and determine build branch
         run: |
           ORIGIN_BRANCH="${{ github.ref_name }}"
           echo "Origin branch: $ORIGIN_BRANCH"
-          
+
           # Branch scheme:
           # dev/main -> main (stable production code with assets, where releases are created)
           # dev/ABC-123 -> ABC-123 (feature branch with compiled assets)
           # dev/xyz -> xyz (any other branch)
-          
+
           # Determine the build branch name
           if [ -n "${{ inputs.BUILT_BRANCH_NAME }}" ]; then
             BUILD_BRANCH="${{ inputs.BUILT_BRANCH_NAME }}"
@@ -189,14 +189,14 @@ jobs:
             # Strip 'dev/' prefix from origin branch to get build branch (if it exists)
             BUILD_BRANCH="${ORIGIN_BRANCH#dev/}"
           fi
-          
+
           echo "Build branch: $BUILD_BRANCH"
           echo "BUILT_BRANCH_NAME=$BUILD_BRANCH" >> $GITHUB_ENV
 
       - name: Validate branch strategy
         run: |
           ORIGIN_BRANCH="${{ github.ref_name }}"
-          
+
           # Check if we would commit to the same branch as the origin
           if [ "$ORIGIN_BRANCH" = "${{ env.BUILT_BRANCH_NAME }}" ]; then
             echo "❌ ERROR: Build artifacts would be committed to the same branch as the source code!"
@@ -215,74 +215,59 @@ jobs:
             echo ""
             exit 1
           fi
-          
+
           echo "✅ Branch strategy validated:"
           echo "  Source branch: $ORIGIN_BRANCH"
           echo "  Build branch: ${{ env.BUILT_BRANCH_NAME }}"
 
+      - name: Check if already built for this SHA
+        run: |
+          SHA="${{ github.sha }}"
+          BUILD_BRANCH="${{ env.BUILT_BRANCH_NAME }}"
+
+          if git show-ref -q "refs/remotes/origin/$BUILD_BRANCH"; then
+            if git show "origin/$BUILD_BRANCH:style.css" 2>/dev/null | grep -qF "SHA: $SHA"; then
+              echo "Already built (theme): SHA $SHA found in build branch."
+              echo "SKIP_BUILD=true" >> $GITHUB_ENV
+            elif git grep -q "SHA: $SHA" "origin/$BUILD_BRANCH" -- "*.php" 2>/dev/null; then
+              echo "Already built (plugin): SHA $SHA found in build branch."
+              echo "SKIP_BUILD=true" >> $GITHUB_ENV
+            else
+              echo "No existing build found for SHA $SHA — proceeding with build."
+            fi
+          else
+            echo "Build branch does not exist yet — proceeding with build."
+          fi
+
       - name: Checkout the build branch with clean slate
         run: |
-          # Check if build branch exists remotely
-          if git show-ref -q refs/remotes/origin/${{ env.BUILT_BRANCH_NAME }}; then
-            echo "Build branch exists, checking out and cleaning..."
-            git checkout ${{ env.BUILT_BRANCH_NAME }}
-          
-            # Clean everything except .git directory for a fresh start
-            git rm -rf . || true
-            git clean -fxd
-            echo "✅ Cleaned existing build branch for fresh build"
+          if [ "${{ env.SKIP_BUILD }}" = "true" ]; then
+            # Build already completed for this SHA — check out existing compiled build branch for artifact generation.
+            git checkout "${{ env.BUILT_BRANCH_NAME }}"
+            echo "✅ Checked out existing build branch (skipping rebuild)."
           else
-            echo "Build branch doesn't exist, creating new branch..."
-            git checkout -b ${{ env.BUILT_BRANCH_NAME }}
-            echo "✅ Created new build branch"
+            # Check if build branch exists remotely
+            if git show-ref -q refs/remotes/origin/${{ env.BUILT_BRANCH_NAME }}; then
+              echo "Build branch exists, checking out and cleaning..."
+              git checkout ${{ env.BUILT_BRANCH_NAME }}
+
+              # Clean everything except .git directory for a fresh start
+              git rm -rf . || true
+              git clean -fxd
+              echo "✅ Cleaned existing build branch for fresh build"
+            else
+              echo "Build branch doesn't exist, creating new branch..."
+              git checkout -b ${{ env.BUILT_BRANCH_NAME }}
+              echo "✅ Created new build branch"
+            fi
+
+            # Copy all files from source branch
+            git checkout ${{ github.ref_name }} -- .
+            echo "✅ Copied source files to build branch"
           fi
-          
-          # Copy all files from source branch
-          git checkout ${{ github.ref_name }} -- .
-          echo "✅ Copied source files to build branch"
-
-      - name: Check for composer.json
-        id: check-composer
-        run: |
-          if [ -f "composer.json" ]; then
-            echo "Composer project detected (composer.json exists)"
-            echo "HAS_COMPOSER=true" >> $GITHUB_ENV
-          else
-            echo "No composer.json found - skipping PHP-related steps"
-            echo "HAS_COMPOSER=false" >> $GITHUB_ENV
-          fi
-
-      - name: Set up PHP
-        if: ${{ env.HAS_COMPOSER == 'true' }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ inputs.PHP_VERSION }}
-          extensions: ${{ inputs.PHP_EXTENSIONS }}
-          tools: php-scoper, sniccowp/php-scoper-wordpress-excludes, composer/installers, inpsyde/wp-translation-downloader, ${{ inputs.PHP_TOOLS }}
-          coverage: none
-
-      - name: Install Composer dependencies
-        if: ${{ env.HAS_COMPOSER == 'true' }}
-        uses: ramsey/composer-install@v3
-        env:
-          COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
-        with:
-          composer-options: ${{ inputs.COMPOSER_ARGS }}
-
-      - name: Set up node
-        uses: actions/setup-node@v4
-        env:
-          NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
-        with:
-          node-version: ${{ inputs.NODE_VERSION }}
-          registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
 
       - name: Determine package type
+        if: ${{ env.SKIP_BUILD != 'true' }}
         run: |
           # Check for WordPress theme (style.css with Theme Name header)
           if [ -f "style.css" ] && grep -q "Theme Name:" style.css; then
@@ -305,64 +290,120 @@ jobs:
           fi
 
       - name: Prepare WordPress Plugin
-        if: ${{ env.PACKAGE_TYPE == 'wordpress-plugin' }}
+        if: ${{ env.SKIP_BUILD != 'true' && env.PACKAGE_TYPE == 'wordpress-plugin' }}
         run: |
           PLUGIN_FILE="${{ env.PLUGIN_MAIN_FILE }}"
           echo "Updating plugin file: $PLUGIN_FILE"
           sed -Ei "s/Version: .*/Version: ${{ env.PACKAGE_VERSION }}/g" "$PLUGIN_FILE"
-          sed -Ei "s/SHA: .*/SHA: ${{ github.sha }}/g" "$PLUGIN_FILE"
+          if grep -q "SHA:" "$PLUGIN_FILE"; then
+            sed -Ei "s/SHA: .*/SHA: ${{ github.sha }}/g" "$PLUGIN_FILE"
+          else
+            sed -Ei "/Version: /a SHA: ${{ github.sha }}" "$PLUGIN_FILE"
+          fi
 
       - name: Prepare WordPress Theme
-        if: ${{ env.PACKAGE_TYPE == 'wordpress-theme' }}
+        if: ${{ env.SKIP_BUILD != 'true' && env.PACKAGE_TYPE == 'wordpress-theme' }}
         run: |
           # Update theme style.css file
           echo "Updating theme style.css."
           sed -Ei "s/Version: .*/Version: ${{ env.PACKAGE_VERSION }}/g" style.css
-          sed -Ei "s/SHA: .*/SHA: ${{ github.sha }}/g" style.css
+          if grep -q "SHA:" style.css; then
+            sed -Ei "s/SHA: .*/SHA: ${{ github.sha }}/g" style.css
+          else
+            sed -Ei "/Version: /a SHA: ${{ github.sha }}" style.css
+          fi
+
+      - name: Check for composer.json
+        id: check-composer
+        if: ${{ env.SKIP_BUILD != 'true' }}
+        run: |
+          if [ -f "composer.json" ]; then
+            echo "Composer project detected (composer.json exists)"
+            echo "HAS_COMPOSER=true" >> $GITHUB_ENV
+          else
+            echo "No composer.json found - skipping PHP-related steps"
+            echo "HAS_COMPOSER=false" >> $GITHUB_ENV
+          fi
+
+      - name: Set up PHP
+        if: ${{ env.SKIP_BUILD != 'true' && env.HAS_COMPOSER == 'true' }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.PHP_VERSION }}
+          extensions: ${{ inputs.PHP_EXTENSIONS }}
+          tools: php-scoper, sniccowp/php-scoper-wordpress-excludes, composer/installers, inpsyde/wp-translation-downloader, ${{ inputs.PHP_TOOLS }}
+          coverage: none
+
+      - name: Install Composer dependencies
+        if: ${{ env.SKIP_BUILD != 'true' && env.HAS_COMPOSER == 'true' }}
+        uses: ramsey/composer-install@v3
+        env:
+          COMPOSER_AUTH: '${{ secrets.COMPOSER_AUTH_JSON }}'
+        with:
+          composer-options: ${{ inputs.COMPOSER_ARGS }}
+
+      - name: Set up node
+        if: ${{ env.SKIP_BUILD != 'true' }}
+        uses: actions/setup-node@v4
+        env:
+          NODE_OPTIONS: ${{ inputs.NODE_OPTIONS }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+        with:
+          node-version: ${{ inputs.NODE_VERSION }}
+          registry-url: ${{ inputs.NPM_REGISTRY_DOMAIN }}
+          cache: npm
+
+      - name: Install dependencies
+        if: ${{ env.SKIP_BUILD != 'true' }}
+        run: npm ci
 
       - name: Update version in package.json
+        if: ${{ env.SKIP_BUILD != 'true' }}
         run: npm version ${{ env.PACKAGE_VERSION }} --no-git-tag-version --allow-same-version
 
       - name: Update version in composer.json
-        if: ${{ env.HAS_COMPOSER == 'true' }}
+        if: ${{ env.SKIP_BUILD != 'true' && env.HAS_COMPOSER == 'true' }}
         run: |
           echo "Updating composer.json version to ${{ env.PACKAGE_VERSION }}."
           jq --arg version "${{ env.PACKAGE_VERSION }}" '.version = $version' composer.json > composer.json.tmp && mv composer.json.tmp composer.json
           echo "✅ Updated composer.json version field."
 
       - name: Execute custom code before archive creation
+        if: ${{ env.SKIP_BUILD != 'true' }}
         run: |
           ${{ inputs.PRE_SCRIPT }}
 
       - name: Compile assets
+        if: ${{ env.SKIP_BUILD != 'true' }}
         run: npm run build
 
       - name: Run WordPress Translation Downloader
-        if: ${{ env.HAS_COMPOSER == 'true' }}
+        if: ${{ env.SKIP_BUILD != 'true' && env.HAS_COMPOSER == 'true' }}
         run: composer wp-translation-downloader:download
 
       - name: Run PHP-Scoper
-        if: ${{ env.HAS_COMPOSER == 'true' && hashFiles('scoper.inc.php') != '' }}
+        if: ${{ env.SKIP_BUILD != 'true' && env.HAS_COMPOSER == 'true' && hashFiles('scoper.inc.php') != '' }}
         # The sed call appends the Git commit SHA to the Composer autoload cache key to ensure unique identification for prefixed files.
         # This prevents Composer from skipping autoloaded files due to hash collisions based on relative paths.
         run: |
           php-scoper add-prefix --force --output-dir=build
           composer --working-dir=build dump-autoload -o
-          sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"    
+          sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
           rsync -av ./build/ . && rm -rf ./build/
 
       - name: Apply .distignore file
-        if: ${{ hashFiles('.distignore') != '' }}
+        if: ${{ env.SKIP_BUILD != 'true' && hashFiles('.distignore') != '' }}
         # Configure git to (gracefully) use .distignore file during packaging instead of the regular .gitignore file.
         # Then clean up all files possibly mentioned in .distignore (e.g., source files).
         run: |
           find . -name ".gitignore" -delete
-          git config core.excludesFile .distignore 
+          git config core.excludesFile .distignore
           git rm -rf --cached .
           git add .
-          git clean -Xdf 
+          git clean -Xdf
 
       - name: Git add, commit, and push
+        if: ${{ env.SKIP_BUILD != 'true' }}
         run: |
           git add -A
           git commit -m "[BOT] Add build artifact from ${{ github.ref_name }} -> ${{ env.BUILT_BRANCH_NAME }}." --no-verify || ((echo "HAS_GIT_CHANGES=yes" >> $GITHUB_ENV) && (echo "No changes to commit."))
@@ -376,10 +417,10 @@ jobs:
         run: |
           # Create package directory for artifact
           mkdir -p "./artifact-staging/${{ env.PACKAGE_NAME }}"
-          
+
           # Copy all files to the package directory (excluding .git)
           rsync -av --exclude='.git' --exclude='./artifact-staging' ./ "./artifact-staging/${{ env.PACKAGE_NAME }}/"
-          
+
           echo "✅ Prepared artifact with package structure:"
           echo "  Package name: ${{ env.PACKAGE_NAME }}"
           echo "  Artifact structure: artifact-staging/${{ env.PACKAGE_NAME }}/"

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -251,7 +251,7 @@ jobs:
           elif ! git show-ref -q "refs/remotes/origin/$BUILD_BRANCH"; then
             echo "Build branch does not exist yet — proceeding with build..."
           elif git show "origin/$BUILD_BRANCH:$PACKAGE_FILE" 2>/dev/null | grep -qF "SHA: $SHA"; then
-            echo "Already built: SHA $SHA found in $PACKAGE_FILE on build branch."
+            echo "Already built: SHA $SHA found in $PACKAGE_FILE on build branch $BUILD_BRANCH."
             echo "SKIP_BUILD=true" >> $GITHUB_ENV
           else
             echo "No existing build found for SHA $SHA — proceeding with build..."

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -87,6 +87,12 @@ on:
 
 jobs:
   build-and-distribute:
+    # Serialize concurrent builds targeting the same SHA + branch.
+    # cancel-in-progress: false queues the second run; it will then detect
+    # the already-built SHA and resolve transparently via artifact generation.
+    concurrency:
+      group: build-and-distribute-${{ github.sha }}-${{ inputs.BUILT_BRANCH_NAME || github.ref_name }}
+      cancel-in-progress: false
     timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -220,23 +220,41 @@ jobs:
           echo "  Source branch: $ORIGIN_BRANCH"
           echo "  Build branch: ${{ env.BUILT_BRANCH_NAME }}"
 
+      - name: Determine package type
+        run: |
+          # Check for WordPress theme
+          if [ -f "style.css" ] && grep -q "Theme Name:" style.css; then
+            echo "Package type: WordPress Theme"
+            echo "PACKAGE_FILE=style.css" >> $GITHUB_ENV
+          # Check for WordPress plugin
+          else
+            # Find the first PHP file with "Plugin Name" header
+            PLUGIN_FILE=$(grep -rl --include "*.php" "Plugin Name:" . 2>/dev/null | head -n1)
+            if [ -n "$PLUGIN_FILE" ]; then
+              echo "Package type: WordPress Plugin"
+              echo "Plugin file found: $PLUGIN_FILE"
+              echo "PACKAGE_FILE=$PLUGIN_FILE" >> $GITHUB_ENV
+            # Nothing to do for generic library
+            else
+              echo "Package type: Library"
+            fi
+          fi
+
       - name: Check if already built for this SHA
         run: |
           SHA="${{ github.sha }}"
           BUILD_BRANCH="${{ env.BUILT_BRANCH_NAME }}"
+          PACKAGE_FILE="${{ env.PACKAGE_FILE }}"
 
-          if git show-ref -q "refs/remotes/origin/$BUILD_BRANCH"; then
-            if git show "origin/$BUILD_BRANCH:style.css" 2>/dev/null | grep -qF "SHA: $SHA"; then
-              echo "Already built (theme): SHA $SHA found in build branch."
-              echo "SKIP_BUILD=true" >> $GITHUB_ENV
-            elif git grep -q "SHA: $SHA" "origin/$BUILD_BRANCH" -- "*.php" 2>/dev/null; then
-              echo "Already built (plugin): SHA $SHA found in build branch."
-              echo "SKIP_BUILD=true" >> $GITHUB_ENV
-            else
-              echo "No existing build found for SHA $SHA — proceeding with build."
-            fi
+          if [ -z "$PACKAGE_FILE" ]; then
+            echo "No package file (library) — proceeding with build..."
+          elif ! git show-ref -q "refs/remotes/origin/$BUILD_BRANCH"; then
+            echo "Build branch does not exist yet — proceeding with build..."
+          elif git show "origin/$BUILD_BRANCH:$PACKAGE_FILE" 2>/dev/null | grep -qF "SHA: $SHA"; then
+            echo "Already built: SHA $SHA found in $PACKAGE_FILE on build branch."
+            echo "SKIP_BUILD=true" >> $GITHUB_ENV
           else
-            echo "Build branch does not exist yet — proceeding with build."
+            echo "No existing build found for SHA $SHA — proceeding with build..."
           fi
 
       - name: Checkout the build branch with clean slate
@@ -264,27 +282,6 @@ jobs:
             # Copy all files from source branch
             git checkout ${{ github.ref_name }} -- .
             echo "✅ Copied source files to build branch"
-          fi
-
-      - name: Determine package type
-        if: ${{ env.SKIP_BUILD != 'true' }}
-        run: |
-          # Check for WordPress theme (style.css with Theme Name header)
-          if [ -f "style.css" ] && grep -q "Theme Name:" style.css; then
-            echo "Package type: WordPress Theme"
-            echo "PACKAGE_FILE=style.css" >> $GITHUB_ENV
-          # Check for WordPress plugin (PHP file with Plugin Name header)
-          else
-            # Find the first PHP file with "Plugin Name:" header
-            PLUGIN_FILE=$(grep -rl --include "*.php" "Plugin Name:" . 2>/dev/null | head -n1)
-            if [ -n "$PLUGIN_FILE" ]; then
-              echo "Package type: WordPress Plugin"
-              echo "Plugin file found: $PLUGIN_FILE"
-              echo "PACKAGE_FILE=$PLUGIN_FILE" >> $GITHUB_ENV
-            # Nothing to do for generic library
-            else
-              echo "Package type: Library"
-            fi
           fi
 
       - name: Prepare package

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -272,7 +272,7 @@ jobs:
           # Check for WordPress theme (style.css with Theme Name header)
           if [ -f "style.css" ] && grep -q "Theme Name:" style.css; then
             echo "Package type: WordPress Theme"
-            echo "PACKAGE_TYPE=wordpress-theme" >> $GITHUB_ENV
+            echo "PACKAGE_FILE=style.css" >> $GITHUB_ENV
           # Check for WordPress plugin (PHP file with Plugin Name header)
           else
             # Find the first PHP file with "Plugin Name:" header
@@ -280,37 +280,22 @@ jobs:
             if [ -n "$PLUGIN_FILE" ]; then
               echo "Package type: WordPress Plugin"
               echo "Plugin file found: $PLUGIN_FILE"
-              echo "PACKAGE_TYPE=wordpress-plugin" >> $GITHUB_ENV
-              echo "PLUGIN_MAIN_FILE=$PLUGIN_FILE" >> $GITHUB_ENV
-            # Fallback to generic library
+              echo "PACKAGE_FILE=$PLUGIN_FILE" >> $GITHUB_ENV
+            # Nothing to do for generic library
             else
               echo "Package type: Library"
-              echo "PACKAGE_TYPE=library" >> $GITHUB_ENV
             fi
           fi
 
-      - name: Prepare WordPress Plugin
-        if: ${{ env.SKIP_BUILD != 'true' && env.PACKAGE_TYPE == 'wordpress-plugin' }}
+      - name: Prepare package
+        if: ${{ env.SKIP_BUILD != 'true' && env.PACKAGE_FILE != '' }}
         run: |
-          PLUGIN_FILE="${{ env.PLUGIN_MAIN_FILE }}"
-          echo "Updating plugin file: $PLUGIN_FILE"
-          sed -Ei "s/Version: .*/Version: ${{ env.PACKAGE_VERSION }}/g" "$PLUGIN_FILE"
-          if grep -q "SHA:" "$PLUGIN_FILE"; then
-            sed -Ei "s/SHA: .*/SHA: ${{ github.sha }}/g" "$PLUGIN_FILE"
+          echo "Updating ${{ env.PACKAGE_FILE }}..."
+          sed -Ei "s/Version: .*/Version: ${{ env.PACKAGE_VERSION }}/g" "${{ env.PACKAGE_FILE }}"
+          if grep -q "SHA:" "${{ env.PACKAGE_FILE }}"; then
+            sed -Ei "s/SHA: .*/SHA: ${{ github.sha }}/g" "${{ env.PACKAGE_FILE }}"
           else
-            sed -Ei "/Version: /a SHA: ${{ github.sha }}" "$PLUGIN_FILE"
-          fi
-
-      - name: Prepare WordPress Theme
-        if: ${{ env.SKIP_BUILD != 'true' && env.PACKAGE_TYPE == 'wordpress-theme' }}
-        run: |
-          # Update theme style.css file
-          echo "Updating theme style.css."
-          sed -Ei "s/Version: .*/Version: ${{ env.PACKAGE_VERSION }}/g" style.css
-          if grep -q "SHA:" style.css; then
-            sed -Ei "s/SHA: .*/SHA: ${{ github.sha }}/g" style.css
-          else
-            sed -Ei "/Version: /a SHA: ${{ github.sha }}" style.css
+            sed -Ei "/Version: /a SHA: ${{ github.sha }}" "${{ env.PACKAGE_FILE }}"
           fi
 
       - name: Check for composer.json

--- a/docs/build-and-distribute.md
+++ b/docs/build-and-distribute.md
@@ -178,7 +178,7 @@ By default, the workflow strips the `dev/` prefix from the origin branch to dete
 - Ensure your `package.json` includes a `build` script for asset compilation
 - Use `.distignore` to exclude development files from the final build
 - Consider using [path filters](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths) to avoid unnecessary builds when only documentation changes
-- Use [concurrency settings](https://docs.github.com/en/actions/using-jobs/using-concurrency) to prevent conflicts when multiple pushes occur rapidly
+- Use [concurrency settings](https://docs.github.com/en/actions/using-jobs/using-concurrency) to prevent conflicts when multiple pushes occur rapidly — the workflow serializes concurrent builds for the same SHA internally, so a queued second run will skip the actual build and resolve via the pre-built artifact
 
 ```yml
 name: Build and push assets
@@ -202,7 +202,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build-and-distribute:

--- a/docs/build-and-distribute.md
+++ b/docs/build-and-distribute.md
@@ -5,14 +5,15 @@ This action can be used to build plugin and theme archives and push them to corr
 To achieve that, the reusable workflow:
 
 1. Inspects the origin branch and determines the correlating build branch (strips `dev/` prefix)
-2. Installs dependencies (including dev-dependencies) defined in `composer.json`
-3. Installs Node.js dependencies and compiles assets via `npm run build`
-4. Updates version information in plugin/theme headers and `package.json`
-5. Executes [WordPress Translation Downloader](https://github.com/inpsyde/wp-translation-downloader) if configured by the package
-6. Executes [PHP-Scoper](https://github.com/humbug/php-scoper) if configured by the package
-7. Applies `.distignore` file filtering if present
-8. Commits and pushes the build artifact to the determined build branch
-9. Uploads the build as a GitHub Actions artifact for download
+2. Checks whether the build branch already contains the current commit SHA — if so, skips steps 3–8 entirely (see [Duplicate run detection](#duplicate-run-detection))
+3. Installs dependencies (including dev-dependencies) defined in `composer.json`
+4. Installs Node.js dependencies and compiles assets via `npm run build`
+5. Updates version and SHA information in plugin/theme headers and `package.json`
+6. Executes [WordPress Translation Downloader](https://github.com/inpsyde/wp-translation-downloader) if configured by the package
+7. Executes [PHP-Scoper](https://github.com/humbug/php-scoper) if configured by the package
+8. Applies `.distignore` file filtering if present
+9. Commits and pushes the build artifact to the determined build branch
+10. Uploads the build as a GitHub Actions artifact for download
 
 ## Branch naming convention
 
@@ -249,7 +250,7 @@ This makes the workflow flexible enough to handle both full-stack WordPress proj
 The workflow handles version information for both plugins and themes:
 
 - Updates `Version:` header in the main plugin file
-- Updates `SHA:` header with the current commit hash
+- Upserts `SHA:` header with the current commit hash — replaces the existing value if the field is present, or inserts a new line after `Version:` if it is absent
 - Updates version in `package.json` and `composer.json`
 
 ### Asset Compilation
@@ -271,6 +272,16 @@ If a `scoper.inc.php` file is present, the workflow will:
 1. Run PHP-Scoper to prefix all PHP dependencies
 2. Rebuild the autoloader for the scoped dependencies
 3. Ensure unique autoload cache keys to prevent conflicts
+
+### Duplicate run detection
+
+The workflow detects when the build branch already contains a build for the current commit SHA and skips the entire compilation pipeline in that case.
+
+After each successful build, the commit SHA is written into the `SHA:` header of `style.css` (themes) or the main plugin PHP file (plugins). On subsequent runs for the same commit, the workflow reads that field from the remote build branch _before_ any toolchain setup. If the SHA matches, all build and compile steps are skipped and the workflow proceeds directly to packaging the existing build branch content and uploading the artifact.
+
+This is transparent to downstream jobs: the `artifact` output is always populated, whether the build was freshly compiled or reused.
+
+**Applies to WordPress plugins and themes only.** Library projects do not embed a `SHA:` field, so they always rebuild.
 
 ### Distignore Support
 


### PR DESCRIPTION
# Skip redundant builds in `build-and-distribute` when SHA is already compiled

Skip the entire compilation pipeline when the build branch already contains a build for the current commit SHA, saving several minutes of Node/PHP setup on duplicate workflow runs (re-runs, race conditions between concurrent triggers, or any other scenario where the same SHA is built more than once).

## Rationale

The intent of _build&distribute_ was always to maintain the build branch as the stable source of truth. It gives us a traceable, clean artifact that is not buried in a million GHA executions and it does not expire after 90 days.

**What we see in practice though** is that the coupling between `dev/foo`(<- the source branch) and `foo` (<- the build branch) is a surprisingly annoying obstacle to overcome when building reliable CI pipelines.
So there has always been an incentive to keep workflow artifacts around as a side-channel to the build-branch-commit (also because it offers a stable plugin/theme subfolder which we do not have on feature branches).

- On push to `dev/foo`, we cannot call e2e tests that require a built package since we push to the dev branch
- We cannot call e2e tests on `foo` because that has no direct connection to the dev branch: It will execute, but failures will not show up on the PR, so they'd be an costly, easy-to-miss optional signal that does not actually help QA efforts
- We do not want every build consumer to produce their own _build&distribute_ run because this is wasteful and redundant.
- However, we cannot properly decouple build & distribute from e2e tests and still chain them so that e2e only runs when we know that a build has completed. While it is possible to use a (completed) `workflow_run` trigger, the handover of the build branch checkout is still not trivial



A **clean solution** would be that indeed every consumer runs _build&distribute_ and then uses the artifact it produces. But as I said this is redundant and wasteful.
This PR attempts to make it less wasteful and thereby enable this as a clean pattern.

Ideally, it would turn a ~5min execution into a <1min execution that does not add any noise to the actual build branch, so it would be safe to call it repeatedly.


## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What kind of change does this PR introduce?

Feature / optimization

## What is the current behavior?

Every workflow run performs a full build regardless of whether the build branch already contains compiled assets for the triggering commit. Two runs for the same SHA produce identical output but consume identical runner time.

## What is the new behavior?

### Duplicate run detection

A new "Check if already built for this SHA" step runs immediately before the build branch is checked out. It reads the remote build branch without checking it out and looks for the current commit SHA in:

- `SHA:` header in `style.css` — WordPress themes
- `SHA:` header in the main plugin PHP file — WordPress plugins

If the SHA is found, `SKIP_BUILD=true` is set and all compilation steps are skipped. The workflow then checks out the existing build branch (without wiping it) and proceeds directly to artifact packaging and upload, so the `artifact` output is always populated for downstream jobs.

Library projects (no theme or plugin header) are unaffected and always rebuild.

### SHA upsert

The `SHA:` field is now written into plugin/theme headers even when it is absent from the source file. Previously the `sed` substitution was a no-op if the field did not exist, which would prevent the skip gate from ever firing. The new behaviour inserts `SHA: <hash>` after the `Version:` line on the first build, enabling duplicate detection for all subsequent runs.

### Earlier preparation steps

"Determine package type" and "Prepare WordPress Plugin/Theme" have been moved to immediately after the source checkout, before any PHP or Node toolchain setup. This means a skip-gate hit now short-circuits the run before the most expensive steps (PHP setup, Composer install, Node setup, `npm ci`, `npm run build`) are even reached.

## Does this PR introduce a breaking change?

No. The `artifact` output and build branch push behaviour are unchanged for normal (non-duplicate) runs.

## Changes

- **`.github/workflows/build-and-distribute.yml`**:
  - Added "Check if already built for this SHA" step (after branch validation, before checkout)
  - Modified "Checkout the build branch with clean slate" to use a fast path when `SKIP_BUILD=true`: checks out the existing build branch without wiping it
  - Moved "Determine package type", "Prepare WordPress Plugin", "Prepare WordPress Theme" to immediately after checkout (before toolchain setup); all three now have `if: SKIP_BUILD != 'true'`
  - Updated SHA `sed` in both Prepare steps to upsert: replaces existing `SHA:` line or inserts after `Version:` if absent
  - Added `if: ${{ env.SKIP_BUILD != 'true' }}` to every build/compile step from "Check for composer.json" through "Git add, commit, and push"; artifact steps are left unconditional
- **`docs/build-and-distribute.md`**:
  - Updated intro step list to reflect the new skip check (step 2) and SHA upsert
  - Added "Duplicate run detection" subsection under "Build process details" explaining the gate, its scope, and the library limitation
  - Clarified `SHA:` behaviour in "Version Management" subsection
