### PR TITLE
Fix release lookup auth and make build-skip version-aware

### DIFF
--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -78,7 +78,7 @@ on:
         description: Public SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`.
         required: true
       GITHUB_USER_TOKEN:
-        description: Authentication token with write permission needed by the release bot (falls back to `GITHUB_TOKEN`).
+        description: Authentication token with read permission needed by the release bot (falls back to `GITHUB_TOKEN`).
         required: false
       ENV_VARS:
         description: Additional environment variables as a JSON formatted object.

--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -77,6 +77,9 @@ on:
       GITHUB_USER_SSH_PUBLIC_KEY:
         description: Public SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`.
         required: true
+      GITHUB_USER_TOKEN:
+        description: Authentication token with write permission needed by the release bot (falls back to `GITHUB_TOKEN`).
+        required: false
       ENV_VARS:
         description: Additional environment variables as a JSON formatted object.
         required: false
@@ -136,7 +139,7 @@ jobs:
       - name: Determine package version
         if: ${{ !inputs.PACKAGE_VERSION }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_USER_SSH_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_USER_TOKEN != '' && secrets.GITHUB_USER_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           # Fetch latest public release
           LATEST_RELEASE=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' || echo "")
@@ -244,11 +247,15 @@ jobs:
             echo "No package file (library) — proceeding with build..."
           elif ! git show-ref -q "refs/remotes/origin/$BUILD_BRANCH"; then
             echo "Build branch does not exist yet — proceeding with build..."
-          elif git show "origin/$BUILD_BRANCH:$PACKAGE_FILE" 2>/dev/null | grep -qF "SHA: $SHA"; then
-            echo "Already built: SHA $SHA found in $PACKAGE_FILE on build branch $BUILD_BRANCH."
-            echo "SKIP_BUILD=true" >> $GITHUB_ENV
           else
-            echo "No existing build found for SHA $SHA — proceeding with build..."
+            COMMITTED="$(git show "origin/$BUILD_BRANCH:$PACKAGE_FILE" 2>/dev/null || echo "")"
+            if echo "$COMMITTED" | grep -qF "SHA: $SHA" \
+               && echo "$COMMITTED" | grep -qF "Version: ${{ env.PACKAGE_VERSION }}"; then
+              echo "Already built: SHA $SHA at version ${{ env.PACKAGE_VERSION }} — reusing."
+              echo "SKIP_BUILD=true" >> $GITHUB_ENV
+            else
+              echo "SHA or version differs from committed build — rebuilding..."
+            fi
           fi
 
       - name: Checkout the build branch with clean slate


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


---

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix.

---

## What is the current behavior? (You can also link to an open issue here)

The "Determine package version" step sets `GITHUB_TOKEN` to an SSH private key (`secrets.GITHUB_USER_SSH_KEY`) and uses it for `gh release list`. An SSH key is a multi-line PEM blob, which can't be used as an HTTP Authorization header, so `gh` fails.

Separately, the "Check if already built for this SHA" step keys the build-skip cache on the commit SHA only. If a SHA was already built (e.g. with the wrong 0.0.0 version), a re-run, including one with a corrected or manually specified PACKAGE_VERSION, is skipped and the stale artifact is re-served, so the correct version never gets applied.

---

## What is the new behavior (if this is a feature change)?

1 .The version-lookup step now authenticates `gh` with a real API token instead of the SSH key: an optional `GITHUB_USER_TOKEN` secret, falling back to the automatic `GITHUB_TOKEN` when not provided.
2. The "Check if already built for this SHA" step now compares both the committed SHA and the version. The build is only skipped when both match, a changed or manually specified `PACKAGE_VERSION` triggers a rebuild so the correct version is applied. This also self-fixes any artifact previously committed with the wrong version.

---

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

---

## Security impact

<!-- 
  Required if this PR touches: auth, authorization, payments, external data,
  file uploads, direct DB queries, or privileged operations.
  If none: write "none" and delete the fields below.
-->

**What changed (security perspective):**

**Testing done:**

**Residual risk (link Jira if any):**


---

## Other information
