### PR TITLE
Fix logic that inserts the commit hash into the plugin file.

### DIFF
--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -289,11 +289,16 @@ jobs:
         if: ${{ env.SKIP_BUILD != 'true' && env.PACKAGE_FILE != '' }}
         run: |
           echo "Updating ${{ env.PACKAGE_FILE }}..."
-          sed -Ei "s/Version: .*/Version: ${{ env.PACKAGE_VERSION }}/g" "${{ env.PACKAGE_FILE }}"
           if grep -q "SHA:" "${{ env.PACKAGE_FILE }}"; then
+            sed -Ei "s/Version: .*/Version: ${{ env.PACKAGE_VERSION }}/g" "${{ env.PACKAGE_FILE }}"
             sed -Ei "s/SHA: .*/SHA: ${{ github.sha }}/g" "${{ env.PACKAGE_FILE }}"
           else
-            sed -Ei "/Version: /a SHA: ${{ github.sha }}" "${{ env.PACKAGE_FILE }}"
+            # Insert the SHA line right after Version in one pass, reusing its
+            # exact prefix (e.g. " * " in a PHPDoc block) via a capture group so
+            # the new line matches the surrounding header format. Using sed's `a`
+            # command here would strip that leading whitespace, so the line is
+            # built with a `\n` in the replacement instead.
+            sed -Ei "s/^(.*)Version: .*/\1Version: ${{ env.PACKAGE_VERSION }}\n\1SHA: ${{ github.sha }}/" "${{ env.PACKAGE_FILE }}"
           fi
 
       - name: Check for composer.json


### PR DESCRIPTION
Previously this was added without the comment prefix which looked off and may have caused issues with run-time plugin header extraction.

## Please check if the PR fulfills these requirements
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


---

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

**Malformed header (SHA: line missing comment prefix)**

Where: step Prepare package in `.github/workflows/build-and-distribute.yml:288-297`.

Root cause: when the package file has no existing SHA: line, the workflow inserts one with plain `sed -Ei "/Version: /a SHA: <sha>"`. The `a` (append) command inserts the literal text with no indentation/comment marker, whereas every other header line is prefixed (e.g.  `* Version: 1.0.0` in a PHPDoc block for plugins, or unprefixed in a `style.css` theme header — the prefix format varies by project type). The literal insert breaks the docblock for PHP plugin headers, which is what produced the malformed header shown in the issue's screenshots.

This regressed in PR #253 (Add duplicate run detection to skip redundant builds), which introduced the "insert SHA: line if missing" code path.

Fix: derive the new line's prefix from the actual `Version:` line already present in the file. This is format-agnostic (works for both PHPDoc-style plugin headers and plain-style theme headers).

---


## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

We may have to manually fix build artifacts in affected projects.

---

## Security impact

none

---

## Other information
Fixes #259 