### PR TITLE
Cache Playwright browsers in test-playwright workflow

### DIFF
--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -155,23 +155,31 @@ jobs:
           sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
           rsync -av ./build/ . && rm -rf ./build/
 
+      # Strip --with-deps from caller-supplied args so it's not duplicated on install
+      # and doesn't get passed to install-deps, which doesn't accept it.
+      - name: Normalize Playwright browser args
+        id: playwright-args
+        run: |
+          ARGS=$(echo '${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}' | sed 's/--with-deps//g' | xargs)
+          echo "args=$ARGS" >> "$GITHUB_OUTPUT"
+
       # Key = lockfile hash (Playwright version proxy) + browser args.
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json', 'npm-shrinkwrap.json') }}-${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json', 'npm-shrinkwrap.json') }}-${{ steps.playwright-args.outputs.args }}
 
       - name: Cache miss; install Playwright dependencies
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
         run: |
-          npx playwright install ${{ inputs.PLAYWRIGHT_BROWSER_ARGS }} --with-deps
+          npx playwright install ${{ steps.playwright-args.outputs.args }} --with-deps
 
       - name: Cache hit; install only OS dependencies for Playwright browsers
         if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}
         run: |
-          npx playwright install-deps ${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}
+          npx playwright install-deps ${{ steps.playwright-args.outputs.args }}
 
       - name: Create environment file
         env:

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -54,7 +54,7 @@ on:
         type: string
       PLAYWRIGHT_BROWSER_ARGS:
         description: Set of arguments passed to `npx playwright install`.
-        default: '--with-deps'
+        default: ''
         required: false
         type: string
       PRE_SCRIPT:
@@ -163,18 +163,15 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json', 'npm-shrinkwrap.json') }}-${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}
 
-      # Miss: download browsers + libs.
-      - name: Install Playwright dependencies
+      - name: Cache miss; install Playwright dependencies
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
         run: |
-          npx playwright install ${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}
+          npx playwright install ${{ inputs.PLAYWRIGHT_BROWSER_ARGS }} --with-deps
 
-      # Hit: binaries restored; apt libs aren't cached, so reinstall libs only.
-      - name: Install OS dependencies for Playwright browsers
+      - name: Cache hit; install only OS dependencies for Playwright browsers
         if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}
         run: |
-          DEPS_ARGS=$(echo '${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}' | sed 's/--with-deps//g' | xargs)
-          npx playwright install-deps $DEPS_ARGS
+          npx playwright install-deps ${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}
 
       - name: Create environment file
         env:

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -155,9 +155,26 @@ jobs:
           sed -i "s/'__composer_autoload_files'/\'__composer_autoload_files_${{ github.sha }}'/g" "build/vendor/composer/autoload_real.php"
           rsync -av ./build/ . && rm -rf ./build/
 
+      # Key = lockfile hash (Playwright version proxy) + browser args.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json', 'npm-shrinkwrap.json') }}-${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}
+
+      # Miss: download browsers + libs.
       - name: Install Playwright dependencies
+        if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
         run: |
           npx playwright install ${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}
+
+      # Hit: binaries restored; apt libs aren't cached, so reinstall libs only.
+      - name: Install OS dependencies for Playwright browsers
+        if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}
+        run: |
+          DEPS_ARGS=$(echo '${{ inputs.PLAYWRIGHT_BROWSER_ARGS }}' | sed 's/--with-deps//g' | xargs)
+          npx playwright install-deps $DEPS_ARGS
 
       - name: Create environment file
         env:
@@ -267,3 +284,4 @@ jobs:
         run: |
           echo "Tests failed! Check the artifacts for details."
           exit 1
+          

--- a/docs/test-playwright.md
+++ b/docs/test-playwright.md
@@ -6,7 +6,6 @@ The workflow can:
 
 - execute a building step, both for node and PHP environments (if the PHP version is provided and a `composer.json` file is present)
 - compile frontend assets via `npm run build` (skipped gracefully if no `build` script is defined in `package.json`)
-- cache the Playwright browser binaries across runs, keyed on the lockfile and the requested browser set, so browsers are downloaded only when the Playwright version changes
 - create an environment variables file named `.env.ci` dedicated to the test step; load this file using `dotenv-ci` directly in your test script, e.g., `./node_modules/.bin/dotenv -e .env.ci -- npm run e2e`. The file is also sourced before `PRE_SCRIPT`, making all variables available as environment variables
 - execute the tests using Playwright via a custom npm script
 - upload the artifacts
@@ -45,7 +44,7 @@ jobs:
 | `NPM_REGISTRY_DOMAIN`                       | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                                                  |
 | `PHP_VERSION`                               | `'8.2'`                         | PHP version with which the dependencies are installed                                                               |
 | `PHP_EXTENSIONS`                            | `''`                            | PHP extensions supported by shivammathur/setup-php to be installed or disabled                                      |
-| `PLAYWRIGHT_BROWSER_ARGS`                   | `'--with-deps'`                 | Set of arguments passed to `npx playwright install`. Must include `--with-deps`; see [Browser caching](#browser-caching) |
+| `PLAYWRIGHT_BROWSER_ARGS`                   | `''`                            | Set of arguments passed to `npx playwright install`                                                                 |
 | `PRE_SCRIPT`                                | `''`                            | Run custom shell code before executing the test script. `GH_TOKEN` and all `ENV_FILE_DATA` variables are available  |
 | `PLAYWRIGHT_SCRIPT`                         | `''`                            | The name of a custom npm script to run the tests                                                                    |
 | `TESTRAIL_PLAN_ID`                          | `''`                            | TestRail plan ID for reporting. When set, appended to `.env.ci`                                                     |
@@ -65,18 +64,6 @@ jobs:
 | `NGROK_AUTH_TOKEN`    | Ngrok auth token. When set, ngrok is installed and a tunnel is started before tests run  |
 | `NPM_REGISTRY_TOKEN`  | Authentication for the private npm registry                                              |
 
-## Browser caching
-
-The workflow caches the Playwright browser binaries (`~/.cache/ms-playwright`) between runs so they are downloaded only when they actually change, rather than on every push.
-
-- **Cache key.** The key combines the runner OS, a hash of the lockfile (`package-lock.json` / `npm-shrinkwrap.json`), and the value of `PLAYWRIGHT_BROWSER_ARGS`. The lockfile acts as a proxy for the Playwright version, so the cache turns over automatically when Playwright is upgraded. Including the browser args means callers requesting different browser sets (e.g. `chromium` vs. the full set) never share the same entry.
-- **Cache miss.** `npx playwright install <PLAYWRIGHT_BROWSER_ARGS>` runs, downloading the browser binaries and their system libraries together, and populates the cache.
-- **Cache hit.** The binaries are restored from cache, but the system libraries - installed via `apt`, so they never land in `~/.cache/ms-playwright` - still have to be installed on each fresh runner. The workflow runs `npx playwright install-deps <browser>` (system libraries only, no download) for this. The browser name is parsed out of `PLAYWRIGHT_BROWSER_ARGS` by stripping `--with-deps`; if nothing remains, dependencies for all browsers are installed.
-
-Because the system-library step keys off `--with-deps`, **`PLAYWRIGHT_BROWSER_ARGS` should always include `--with-deps`** (as the default does). On a cache miss it ensures the libraries are downloaded alongside the browsers; on a hit it is stripped so only `install-deps` runs.
-
-The caching is fully internal - there are no additional inputs to set, and callers do not need to change anything. It assumes standard `apt` mirror access, which GitHub-hosted runners provide; on a restricted-network or self-hosted runner, confirm that access first.
-
 ## Ngrok tunnel
 
 When `NGROK_AUTH_TOKEN` is provided, the workflow automatically:
@@ -93,9 +80,9 @@ Requires a [paid ngrok account](https://ngrok.com/pricing) with a reserved domai
 
 The workflow supports optional integration with TestRail and Xray. When any of the following inputs are provided, they are appended to `.env.ci` with the same name, making them available to your test runner and reporters:
 
-- `TESTRAIL_PLAN_ID` - TestRail plan ID
-- `TESTRAIL_RUN_ID` - TestRail run ID
-- `XRAY_TEST_EXEC_KEY` - Xray test execution key
+- `TESTRAIL_PLAN_ID` — TestRail plan ID
+- `TESTRAIL_RUN_ID` — TestRail run ID
+- `XRAY_TEST_EXEC_KEY` — Xray test execution key
 
 These are regular workflow inputs (not secrets), so they can be passed directly from `workflow_dispatch` inputs for on-demand runs.
 
@@ -121,7 +108,7 @@ jobs:
       COMPOSER_DEPS_INSTALL: true
       PHP_VERSION: ${{ matrix.php }}
       NODE_VERSION: 20
-      PLAYWRIGHT_BROWSER_ARGS: 'chromium --with-deps'
+      PLAYWRIGHT_BROWSER_ARGS: 'chromium'
       PRE_SCRIPT: |
         echo "Starting custom logic..."
     secrets:
@@ -149,7 +136,7 @@ jobs:
         playwright-report/
       PLAYWRIGHT_SCRIPT: 'ci-test-e2e'
       NODE_VERSION: 24
-      PLAYWRIGHT_BROWSER_ARGS: 'chromium --with-deps'
+      PLAYWRIGHT_BROWSER_ARGS: 'chromium'
       NGROK_DOMAIN: ${{ secrets.NGROK_DOMAIN }}
       PRE_SCRIPT: |
         gh run download ${{ github.run_id }} -p "my-plugin-*" -D resources/files
@@ -224,7 +211,7 @@ jobs:
         tests/qa/playwright-report/
       PLAYWRIGHT_SCRIPT: ${{ inputs.TEST_SUITE }}
       NODE_VERSION: 22
-      PLAYWRIGHT_BROWSER_ARGS: 'chromium --with-deps'
+      PLAYWRIGHT_BROWSER_ARGS: 'chromium'
       PRE_SCRIPT: |
         gh run download ${{ github.run_id }} -p "my-plugin-*" -D resources/files
         npm run setup:env

--- a/docs/test-playwright.md
+++ b/docs/test-playwright.md
@@ -6,6 +6,7 @@ The workflow can:
 
 - execute a building step, both for node and PHP environments (if the PHP version is provided and a `composer.json` file is present)
 - compile frontend assets via `npm run build` (skipped gracefully if no `build` script is defined in `package.json`)
+- cache the Playwright browser binaries across runs, keyed on the lockfile and the requested browser set, so browsers are downloaded only when the Playwright version changes
 - create an environment variables file named `.env.ci` dedicated to the test step; load this file using `dotenv-ci` directly in your test script, e.g., `./node_modules/.bin/dotenv -e .env.ci -- npm run e2e`. The file is also sourced before `PRE_SCRIPT`, making all variables available as environment variables
 - execute the tests using Playwright via a custom npm script
 - upload the artifacts
@@ -44,7 +45,7 @@ jobs:
 | `NPM_REGISTRY_DOMAIN`                       | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                                                  |
 | `PHP_VERSION`                               | `'8.2'`                         | PHP version with which the dependencies are installed                                                               |
 | `PHP_EXTENSIONS`                            | `''`                            | PHP extensions supported by shivammathur/setup-php to be installed or disabled                                      |
-| `PLAYWRIGHT_BROWSER_ARGS`                   | `'--with-deps'`                 | Set of arguments passed to `npx playwright install`                                                                 |
+| `PLAYWRIGHT_BROWSER_ARGS`                   | `'--with-deps'`                 | Set of arguments passed to `npx playwright install`. Must include `--with-deps`; see [Browser caching](#browser-caching) |
 | `PRE_SCRIPT`                                | `''`                            | Run custom shell code before executing the test script. `GH_TOKEN` and all `ENV_FILE_DATA` variables are available  |
 | `PLAYWRIGHT_SCRIPT`                         | `''`                            | The name of a custom npm script to run the tests                                                                    |
 | `TESTRAIL_PLAN_ID`                          | `''`                            | TestRail plan ID for reporting. When set, appended to `.env.ci`                                                     |
@@ -64,6 +65,18 @@ jobs:
 | `NGROK_AUTH_TOKEN`    | Ngrok auth token. When set, ngrok is installed and a tunnel is started before tests run  |
 | `NPM_REGISTRY_TOKEN`  | Authentication for the private npm registry                                              |
 
+## Browser caching
+
+The workflow caches the Playwright browser binaries (`~/.cache/ms-playwright`) between runs so they are downloaded only when they actually change, rather than on every push.
+
+- **Cache key.** The key combines the runner OS, a hash of the lockfile (`package-lock.json` / `npm-shrinkwrap.json`), and the value of `PLAYWRIGHT_BROWSER_ARGS`. The lockfile acts as a proxy for the Playwright version, so the cache turns over automatically when Playwright is upgraded. Including the browser args means callers requesting different browser sets (e.g. `chromium` vs. the full set) never share the same entry.
+- **Cache miss.** `npx playwright install <PLAYWRIGHT_BROWSER_ARGS>` runs, downloading the browser binaries and their system libraries together, and populates the cache.
+- **Cache hit.** The binaries are restored from cache, but the system libraries - installed via `apt`, so they never land in `~/.cache/ms-playwright` - still have to be installed on each fresh runner. The workflow runs `npx playwright install-deps <browser>` (system libraries only, no download) for this. The browser name is parsed out of `PLAYWRIGHT_BROWSER_ARGS` by stripping `--with-deps`; if nothing remains, dependencies for all browsers are installed.
+
+Because the system-library step keys off `--with-deps`, **`PLAYWRIGHT_BROWSER_ARGS` should always include `--with-deps`** (as the default does). On a cache miss it ensures the libraries are downloaded alongside the browsers; on a hit it is stripped so only `install-deps` runs.
+
+The caching is fully internal - there are no additional inputs to set, and callers do not need to change anything. It assumes standard `apt` mirror access, which GitHub-hosted runners provide; on a restricted-network or self-hosted runner, confirm that access first.
+
 ## Ngrok tunnel
 
 When `NGROK_AUTH_TOKEN` is provided, the workflow automatically:
@@ -80,9 +93,9 @@ Requires a [paid ngrok account](https://ngrok.com/pricing) with a reserved domai
 
 The workflow supports optional integration with TestRail and Xray. When any of the following inputs are provided, they are appended to `.env.ci` with the same name, making them available to your test runner and reporters:
 
-- `TESTRAIL_PLAN_ID` — TestRail plan ID
-- `TESTRAIL_RUN_ID` — TestRail run ID
-- `XRAY_TEST_EXEC_KEY` — Xray test execution key
+- `TESTRAIL_PLAN_ID` - TestRail plan ID
+- `TESTRAIL_RUN_ID` - TestRail run ID
+- `XRAY_TEST_EXEC_KEY` - Xray test execution key
 
 These are regular workflow inputs (not secrets), so they can be passed directly from `workflow_dispatch` inputs for on-demand runs.
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


---

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature: CI performance improvement + docs.


---

## What is the current behavior? (You can also link to an open issue here)

`test-playwright.yml` re-downloads Playwright browsers on every run. For example: across the 9-shard E2E matrix that's 9 full downloads per run.


---

## What is the new behavior (if this is a feature change)?

Browser binaries (`~/.cache/ms-playwright`) are cached, keyed on the resolved Playwright version + browser args. Cache miss downloads browsers + libs; cache hit restores binaries and reinstalls only the apt system libs (not cached). No new inputs. Doc updated with a Browser caching section.


---

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.


---

## Security impact

none


---

## Other information

`PLAYWRIGHT_BROWSER_ARGS` must include `--with-deps` (default already does) for the hit-branch lib install to work.
