### PR TITLE
Fix: verify VPN egress IP via a tunnel-routed probe

### DIFF
--- a/.github/actions/setup-openvpn/action.yml
+++ b/.github/actions/setup-openvpn/action.yml
@@ -43,7 +43,7 @@ runs:
       env:
         GATEWAY_IP: ${{ inputs.ovpn-gateway-ip }}
       run: |
-        IP=$(curl -s https://api.ipify.org)
+        IP=$(dig +short @1.1.1.1 whoami.cloudflare ch txt | tr -d '"')
         echo "Egress IP: $IP"
         [[ "$IP" == "$GATEWAY_IP" ]] || { echo "Unexpected egress IP: $IP"; exit 1; }
       shell: bash

--- a/.github/workflows/deploy-deployer.yml
+++ b/.github/workflows/deploy-deployer.yml
@@ -99,7 +99,7 @@ jobs:
           wireguard-configuration: ${{ secrets.WIREGUARD_CONFIGURATION }}
 
       - name: Set up OpenVPN
-        uses: inpsyde/reusable-workflows/.github/actions/setup-openvpn@fix/setup-openvpn-verify-egress-ip
+        uses: inpsyde/reusable-workflows/.github/actions/setup-openvpn@main
         env:
           OVPN_CONFIG: ${{ secrets.OVPN_CONFIG }}
           OVPN_USERNAME: ${{ secrets.OVPN_USERNAME }}

--- a/.github/workflows/deploy-deployer.yml
+++ b/.github/workflows/deploy-deployer.yml
@@ -99,7 +99,7 @@ jobs:
           wireguard-configuration: ${{ secrets.WIREGUARD_CONFIGURATION }}
 
       - name: Set up OpenVPN
-        uses: inpsyde/reusable-workflows/.github/actions/setup-openvpn@main
+        uses: inpsyde/reusable-workflows/.github/actions/setup-openvpn@fix/setup-openvpn-verify-egress-ip
         env:
           OVPN_CONFIG: ${{ secrets.OVPN_CONFIG }}
           OVPN_USERNAME: ${{ secrets.OVPN_USERNAME }}


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (for bug fixes/features)
* [ ] Docs have been added/updated (for bug fixes/features)

---

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Bug fix

---

## What is the current behavior? (You can also link to an open issue here)

**Workflows using `setup-openvpn` fail during the `Verify VPN egress IP` step.**

The verification step currently determines the workflow runner's public IP by calling a third-party HTTPS IP-echo service and comparing the returned address with the expected VPN gateway IP.

This works only when the VPN routes **all outbound traffic** through the tunnel.

Some VPN profiles use split tunneling and route only specific destinations through the VPN while leaving the runner's default route unchanged. In that case, requests to arbitrary internet hosts — including the IP-echo service — bypass the VPN and use the runner's normal network interface.

As a result, the verification step reports the runner's public IP instead of the VPN gateway IP and fails, even though the VPN tunnel itself has been established successfully and the configured destinations are correctly routed through it.

One possible workaround would be to add the IP-echo service to the VPN destinations list. However, this is unreliable for services hosted behind Cloudflare because their IP addresses may change and cannot be safely hard-coded.

---

## What is the new behavior (if this is a feature change)?
Replaced the IP detection logic with a simpler approach.

The verification step now determines the public IP using Cloudflare's DNS-based IP echo service:

```bash
IP=$(dig +short @1.1.1.1 whoami.cloudflare CH TXT | tr -d '"')
```

This allows the egress IP check to work without depending on the dynamically resolved IP addresses of an external HTTPS service.

**Note:** `1.1.1.1` must still be included in the VPN destinations list so that this DNS request is routed through the tunnel.

`dnsutils` is already installed on the runner image, so no additional installation step is required.

No inputs or existing interfaces were changed, so callers are unaffected.

---

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

---

## Security impact

<!-- 
  Required if this PR touches: auth, authorization, payments, external data,
  file uploads, direct DB queries, or privileged operations.
  If none: write "none" and delete the fields below.
-->

None.

---

## Other information
