### PR TITLE
Fix: wordpress.org publishing workflow fails on rsync warning

### DIFF
--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -63,7 +63,6 @@ jobs:
             exit 1
           fi
 
-          echo "VALIDATED_SVN_PLUGIN_SLUG=$SVN_PLUGIN_SLUG" >> "$GITHUB_ENV"
           echo "✅ Valid plugin slug: $SVN_PLUGIN_SLUG"
 
       - name: Validate versions
@@ -144,23 +143,25 @@ jobs:
           echo "✅ Version $VALIDATED_PLUGIN_VERSION is consistent across inputs, plugin file, and readme.txt"
 
       - name: Checkout SVN repository
+        env:
+          SVN_PLUGIN_SLUG: ${{ inputs.SVN_PLUGIN_SLUG }}
         run: |
           set -euo pipefail
 
           # Must stay outside github.workspace: the sync step below rsyncs github.workspace
           # onto this path, and a nested destination causes rsync "vanished" warnings.
           export SVN_REPO_PATH="${RUNNER_TEMP}/svn_repository"
-          export SVN_REPO_ROOT="${RUNNER_TEMP}/svn_repository/${VALIDATED_SVN_PLUGIN_SLUG}"
+          export SVN_REPO_ROOT="${RUNNER_TEMP}/svn_repository/${SVN_PLUGIN_SLUG}"
 
           echo "SVN_REPO_PATH=$SVN_REPO_PATH" >> "$GITHUB_ENV"
           echo "SVN_REPO_ROOT=$SVN_REPO_ROOT" >> "$GITHUB_ENV"
 
           mkdir -p "$SVN_REPO_PATH" && cd "$SVN_REPO_PATH"
-
+          
           # We only do a full checkout of trunk here, leaving other directories empty.
           # Tags directory can take gigabytes for older plugins, and we don't need them for publishing.
-
-          svn checkout "https://plugins.svn.wordpress.org/${VALIDATED_SVN_PLUGIN_SLUG}" --depth immediates
+          
+          svn checkout "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}" --depth immediates
           cd "$SVN_REPO_ROOT" && svn update trunk --set-depth infinity
 
       - name: Verify version doesn't exist in SVN
@@ -173,7 +174,7 @@ jobs:
 
           if [ -d "$VALIDATED_PLUGIN_VERSION" ]; then
             echo "❌ Version $VALIDATED_PLUGIN_VERSION already exists in WordPress.org!"
-            echo "   Check: https://plugins.svn.wordpress.org/${VALIDATED_SVN_PLUGIN_SLUG}/tags/"
+            echo "   Check: https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/tags/"
             exit 1
           fi
 
@@ -248,8 +249,8 @@ jobs:
           echo "🚀 Publishing version ${VALIDATED_PLUGIN_VERSION}"
           
           svn copy \
-            "https://plugins.svn.wordpress.org/${VALIDATED_SVN_PLUGIN_SLUG}/trunk" \
-            "https://plugins.svn.wordpress.org/${VALIDATED_SVN_PLUGIN_SLUG}/tags/${VALIDATED_PLUGIN_VERSION}" \
+            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/trunk" \
+            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/tags/${VALIDATED_PLUGIN_VERSION}" \
             --username "$SVN_USERNAME" \
             --password "$SVN_PASSWORD" \
             --no-auth-cache \
@@ -262,7 +263,7 @@ jobs:
         if: inputs.DRY_RUN == true
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.VALIDATED_SVN_PLUGIN_SLUG }}
+          name: ${{ inputs.SVN_PLUGIN_SLUG }}
           path: ${{ env.SVN_REPO_ROOT }}/trunk
           include-hidden-files: true
           compression-level: 1 #Minimal compression - we don't want to waste resources for this

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -188,6 +188,7 @@ jobs:
           touch .distignore # Ensure file exists so --exclude-from doesn't fail
           
           rsync -rc \
+          --itemize-changes \
           --delete \
           --delete-excluded \
           --exclude='.git' \
@@ -213,6 +214,13 @@ jobs:
               svn delete "$file@"  # @ suffix handles files with @ in name
             done
           fi
+
+      - name: Show SVN status
+        run: |
+          set -euo pipefail
+
+          cd "${SVN_REPO_ROOT}/trunk"
+          svn status
 
       - name: Commit changes to SVN repository
         if: inputs.DRY_RUN != true

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -65,11 +65,6 @@ jobs:
 
           echo "✅ Valid plugin slug: $SVN_PLUGIN_SLUG"
 
-          # Must stay outside github.workspace: the sync step below rsyncs github.workspace
-          # onto this path, and a nested destination causes rsync "vanished" warnings.
-          echo "SVN_REPO_PATH=${RUNNER_TEMP}/svn_repository" >> "$GITHUB_ENV"
-          echo "SVN_REPO_ROOT=${RUNNER_TEMP}/svn_repository/${SVN_PLUGIN_SLUG}" >> "$GITHUB_ENV"
-
       - name: Validate versions
         env:
           PLUGIN_VERSION: ${{ inputs.PLUGIN_VERSION }}
@@ -148,8 +143,19 @@ jobs:
           echo "✅ Version $VALIDATED_PLUGIN_VERSION is consistent across inputs, plugin file, and readme.txt"
 
       - name: Checkout SVN repository
+        env:
+          SVN_PLUGIN_SLUG: ${{ inputs.SVN_PLUGIN_SLUG }}
         run: |
           set -euo pipefail
+
+          # Must stay outside github.workspace: the sync step below rsyncs github.workspace
+          # onto this path, and a nested destination causes rsync "vanished" warnings.
+          export SVN_REPO_PATH="${RUNNER_TEMP}/svn_repository"
+          export SVN_REPO_ROOT="${RUNNER_TEMP}/svn_repository/${SVN_PLUGIN_SLUG}"
+
+          echo "SVN_REPO_PATH=$SVN_REPO_PATH" >> "$GITHUB_ENV"
+          echo "SVN_REPO_ROOT=$SVN_REPO_ROOT" >> "$GITHUB_ENV"
+
           mkdir -p "$SVN_REPO_PATH" && cd "$SVN_REPO_PATH"
           
           # We only do a full checkout of trunk here, leaving other directories empty.

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -44,9 +44,6 @@ on:
 
 jobs:
   update_svn_from_git:
-    env:
-      SVN_REPO_PATH: "${{ github.workspace }}/svn_repository"
-      SVN_REPO_ROOT: "${{ github.workspace }}/svn_repository/${{ inputs.SVN_PLUGIN_SLUG }}"
     runs-on: ubuntu-latest
     steps:
       - name: Install required tools
@@ -67,6 +64,11 @@ jobs:
           fi
 
           echo "✅ Valid plugin slug: $SVN_PLUGIN_SLUG"
+
+          # Must stay outside github.workspace: the sync step below rsyncs github.workspace
+          # onto this path, and a nested destination causes rsync "vanished" warnings.
+          echo "SVN_REPO_PATH=${RUNNER_TEMP}/svn_repository" >> "$GITHUB_ENV"
+          echo "SVN_REPO_ROOT=${RUNNER_TEMP}/svn_repository/${SVN_PLUGIN_SLUG}" >> "$GITHUB_ENV"
 
       - name: Validate versions
         env:

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -63,6 +63,7 @@ jobs:
             exit 1
           fi
 
+          echo "VALIDATED_SVN_PLUGIN_SLUG=$SVN_PLUGIN_SLUG" >> "$GITHUB_ENV"
           echo "✅ Valid plugin slug: $SVN_PLUGIN_SLUG"
 
       - name: Validate versions
@@ -143,25 +144,23 @@ jobs:
           echo "✅ Version $VALIDATED_PLUGIN_VERSION is consistent across inputs, plugin file, and readme.txt"
 
       - name: Checkout SVN repository
-        env:
-          SVN_PLUGIN_SLUG: ${{ inputs.SVN_PLUGIN_SLUG }}
         run: |
           set -euo pipefail
 
           # Must stay outside github.workspace: the sync step below rsyncs github.workspace
           # onto this path, and a nested destination causes rsync "vanished" warnings.
           export SVN_REPO_PATH="${RUNNER_TEMP}/svn_repository"
-          export SVN_REPO_ROOT="${RUNNER_TEMP}/svn_repository/${SVN_PLUGIN_SLUG}"
+          export SVN_REPO_ROOT="${RUNNER_TEMP}/svn_repository/${VALIDATED_SVN_PLUGIN_SLUG}"
 
           echo "SVN_REPO_PATH=$SVN_REPO_PATH" >> "$GITHUB_ENV"
           echo "SVN_REPO_ROOT=$SVN_REPO_ROOT" >> "$GITHUB_ENV"
 
           mkdir -p "$SVN_REPO_PATH" && cd "$SVN_REPO_PATH"
-          
+
           # We only do a full checkout of trunk here, leaving other directories empty.
           # Tags directory can take gigabytes for older plugins, and we don't need them for publishing.
-          
-          svn checkout "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}" --depth immediates
+
+          svn checkout "https://plugins.svn.wordpress.org/${VALIDATED_SVN_PLUGIN_SLUG}" --depth immediates
           cd "$SVN_REPO_ROOT" && svn update trunk --set-depth infinity
 
       - name: Verify version doesn't exist in SVN
@@ -174,7 +173,7 @@ jobs:
 
           if [ -d "$VALIDATED_PLUGIN_VERSION" ]; then
             echo "❌ Version $VALIDATED_PLUGIN_VERSION already exists in WordPress.org!"
-            echo "   Check: https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/tags/"
+            echo "   Check: https://plugins.svn.wordpress.org/${VALIDATED_SVN_PLUGIN_SLUG}/tags/"
             exit 1
           fi
 
@@ -249,8 +248,8 @@ jobs:
           echo "🚀 Publishing version ${VALIDATED_PLUGIN_VERSION}"
           
           svn copy \
-            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/trunk" \
-            "https://plugins.svn.wordpress.org/${{ inputs.SVN_PLUGIN_SLUG }}/tags/${VALIDATED_PLUGIN_VERSION}" \
+            "https://plugins.svn.wordpress.org/${VALIDATED_SVN_PLUGIN_SLUG}/trunk" \
+            "https://plugins.svn.wordpress.org/${VALIDATED_SVN_PLUGIN_SLUG}/tags/${VALIDATED_PLUGIN_VERSION}" \
             --username "$SVN_USERNAME" \
             --password "$SVN_PASSWORD" \
             --no-auth-cache \
@@ -263,7 +262,7 @@ jobs:
         if: inputs.DRY_RUN == true
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.SVN_PLUGIN_SLUG }}
+          name: ${{ env.VALIDATED_SVN_PLUGIN_SLUG }}
           path: ${{ env.SVN_REPO_ROOT }}/trunk
           include-hidden-files: true
           compression-level: 1 #Minimal compression - we don't want to waste resources for this

--- a/docs/wordpress-org-release.md
+++ b/docs/wordpress-org-release.md
@@ -9,9 +9,10 @@ To achieve that, this workflow:
 3. Verifies that the version in the plugin file header and `readme.txt` `Stable tag` both match `PLUGIN_VERSION`
 4. Checks out the WordPress.org SVN repository (trunk is fully checked out; tag contents are never fetched — only tag names are listed when needed for the version check)
 5. Verifies the version does not already exist as an SVN tag (skipped when `UPDATE_TRUNK_ONLY=true`)
-6. Synchronizes the Git working directory to SVN trunk via `rsync`, respecting `.distignore` and excluding sensitive files like `auth.json`, `.env`, and `.npmrc`
-7. Commits trunk to SVN (or uploads it as an artifact in `DRY_RUN` mode)
-8. Creates an SVN tag from trunk (skipped when `UPDATE_TRUNK_ONLY=true` or `DRY_RUN=true`)
+6. Synchronizes the Git working directory to SVN trunk via `rsync` (reporting every added, deleted, or changed file via `--itemize-changes`), respecting `.distignore` and excluding sensitive files like `auth.json`, `.env`, and `.npmrc`
+7. Prints the full `svn status` of trunk, so the exact set of additions, deletions, and modifications is visible before anything is committed
+8. Commits trunk to SVN (or uploads it as an artifact in `DRY_RUN` mode)
+9. Creates an SVN tag from trunk (skipped when `UPDATE_TRUNK_ONLY=true` or `DRY_RUN=true`)
 
 > [!NOTE]
 > This workflow intentionally fails if the version already exists as an SVN tag. There is no amendment flow.


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


---

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix (and a bit of refactoring).

---

### What is the current behavior? (You can also link to an open issue here)
The GitHub Action using this workflow fails because of `rsync` warnings:
```shell
file has vanished: "/home/runner/work/paypal-point-of-sale/paypal-point-of-sale/svn_repository/zettle-pos-integration/trunk/vendor/container-interop/service-provider/puli.json"
file has vanished: "/home/runner/work/paypal-point-of-sale/paypal-point-of-sale/svn_repository/zettle-pos-integration/trunk/vendor/container-interop/service-provider/src/ServiceProviderInterface.php"
```

---

### What is the new behavior (if this is a feature change)?
No warnings from `rsync`.

Additionally, the `VALIDATED_SVN_PLUGIN_SLUG` variable is introduced instead of reading raw input every time. This adds clarity and consistency with the `VALIDATED_PLUGIN_VERSION` var we are using already.

---

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

---

### Security impact
None.

---

### Other information
Closes #264.