### PR TITLE
Feature: Show SVN status before committing

### DIFF
--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -188,6 +188,7 @@ jobs:
           touch .distignore # Ensure file exists so --exclude-from doesn't fail
           
           rsync -rc \
+          --itemize-changes \
           --delete \
           --delete-excluded \
           --exclude='.git' \

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -214,6 +214,13 @@ jobs:
             done
           fi
 
+      - name: Show SVN status
+        run: |
+          set -euo pipefail
+
+          cd "${SVN_REPO_ROOT}/trunk"
+          svn status
+
       - name: Commit changes to SVN repository
         if: inputs.DRY_RUN != true
         env:

--- a/docs/wordpress-org-release.md
+++ b/docs/wordpress-org-release.md
@@ -9,7 +9,7 @@ To achieve that, this workflow:
 3. Verifies that the version in the plugin file header and `readme.txt` `Stable tag` both match `PLUGIN_VERSION`
 4. Checks out the WordPress.org SVN repository (trunk is fully checked out; tag contents are never fetched — only tag names are listed when needed for the version check)
 5. Verifies the version does not already exist as an SVN tag (skipped when `UPDATE_TRUNK_ONLY=true`)
-6. Synchronizes the Git working directory to SVN trunk via `rsync`, respecting `.distignore` and excluding sensitive files like `auth.json`, `.env`, and `.npmrc`
+6. Synchronizes the Git working directory to SVN trunk via `rsync` (reporting every added, deleted, or changed file via `--itemize-changes`), respecting `.distignore` and excluding sensitive files like `auth.json`, `.env`, and `.npmrc`
 7. Prints the full `svn status` of trunk, so the exact set of additions, deletions, and modifications is visible before anything is committed
 8. Commits trunk to SVN (or uploads it as an artifact in `DRY_RUN` mode)
 9. Creates an SVN tag from trunk (skipped when `UPDATE_TRUNK_ONLY=true` or `DRY_RUN=true`)

--- a/docs/wordpress-org-release.md
+++ b/docs/wordpress-org-release.md
@@ -10,8 +10,9 @@ To achieve that, this workflow:
 4. Checks out the WordPress.org SVN repository (trunk is fully checked out; tag contents are never fetched — only tag names are listed when needed for the version check)
 5. Verifies the version does not already exist as an SVN tag (skipped when `UPDATE_TRUNK_ONLY=true`)
 6. Synchronizes the Git working directory to SVN trunk via `rsync`, respecting `.distignore` and excluding sensitive files like `auth.json`, `.env`, and `.npmrc`
-7. Commits trunk to SVN (or uploads it as an artifact in `DRY_RUN` mode)
-8. Creates an SVN tag from trunk (skipped when `UPDATE_TRUNK_ONLY=true` or `DRY_RUN=true`)
+7. Prints the full `svn status` of trunk, so the exact set of additions, deletions, and modifications is visible before anything is committed
+8. Commits trunk to SVN (or uploads it as an artifact in `DRY_RUN` mode)
+9. Creates an SVN tag from trunk (skipped when `UPDATE_TRUNK_ONLY=true` or `DRY_RUN=true`)
 
 > [!NOTE]
 > This workflow intentionally fails if the version already exists as an SVN tag. There is no amendment flow.


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


---

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature

---

### What is the current behavior? (You can also link to an open issue here)
There is no `svn status` output after copying files from Git to SVN directory.

---

### What is the new behavior (if this is a feature change)?
Showing `svn status` after copying files and before committing or creating an archive.

---

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

---

### Security impact

None.


---

### Other information
Closes #266.