### PR TITLE
Fix SVN status missing changes

### DIFF
--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -234,7 +234,9 @@ jobs:
           [ -d "$SVN_REPO_ROOT" ] || { echo "❌ SVN_REPO_ROOT not found"; exit 1; }
           cd "$SVN_REPO_ROOT"
 
-          # No -q here either, same reason as in "Update SVN tracking".
+          # Do not add -q to grep: it exits on the first match, SIGPIPE-ing svn status mid-write;
+          # under pipefail that non-zero exit wins over grep's, which would wrongly report
+          # "No changes in trunk" and abort even when there are real changes to commit.
           svn status trunk | grep '^[ADMR!~]' >/dev/null || { echo "❌ No changes in trunk"; exit 1; }
 
           # WordPress.org SVN doesn't support SSH keys or tokens.

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -209,7 +209,9 @@ jobs:
           svn add . --force
           
           #Only run if there's anything to delete
-          if svn status | grep -q '^!'; then
+          # No -q: it exits on the first match, SIGPIPE-ing svn status mid-write; under
+          # pipefail that non-zero exit wins over grep's, silently hiding real matches.
+          if svn status | grep '^!' >/dev/null; then
             svn status | grep '^!' | cut -c9- | while IFS= read -r file; do
               svn delete "$file@"  # @ suffix handles files with @ in name
             done
@@ -233,7 +235,8 @@ jobs:
           [ -d "$SVN_REPO_ROOT" ] || { echo "❌ SVN_REPO_ROOT not found"; exit 1; }
           cd "$SVN_REPO_ROOT"
 
-          svn status trunk | grep -q '^[ADMR!~]' || { echo "❌ No changes in trunk"; exit 1; }
+          # No -q here either, same reason as in "Update SVN tracking".
+          svn status trunk | grep '^[ADMR!~]' >/dev/null || { echo "❌ No changes in trunk"; exit 1; }
 
           # WordPress.org SVN doesn't support SSH keys or tokens.
           # Keeping credentials as step-level env vars with --no-auth-cache is the best available option.

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -208,11 +208,10 @@ jobs:
           cd "${SVN_REPO_ROOT}/trunk"
           svn add . --force
           
-          # Only run if there's anything to delete.
-          # No -q: it exits on the first match, SIGPIPE-ing svn status mid-write; under
-          # pipefail that non-zero exit wins over grep's, silently hiding real matches.
-          if svn status | grep '^!' >/dev/null; then
-            svn status | grep '^!' | cut -c9- | while IFS= read -r file; do
+          MISSING=$(svn status | grep '^!' | cut -c9- || true)
+
+          if [ -n "$MISSING" ]; then
+            echo "$MISSING" | while IFS= read -r file; do
               svn delete "$file@"  # @ suffix handles files with @ in name
             done
           fi

--- a/.github/workflows/wordpress-org-release.yml
+++ b/.github/workflows/wordpress-org-release.yml
@@ -208,7 +208,7 @@ jobs:
           cd "${SVN_REPO_ROOT}/trunk"
           svn add . --force
           
-          #Only run if there's anything to delete
+          # Only run if there's anything to delete.
           # No -q: it exits on the first match, SIGPIPE-ing svn status mid-write; under
           # pipefail that non-zero exit wins over grep's, silently hiding real matches.
           if svn status | grep '^!' >/dev/null; then


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


---

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix

---

## What is the current behavior? (You can also link to an open issue here)
Two checks piped svn status into grep -q. Since grep -q exits as soon as it finds a match, it can close the pipe while svn status (a separate, still-running process) is mid-write, killing it with SIGPIPE. Under set -o pipefail, that non-zero exit (not grep's own success) becomes the pipeline's result, so the `if`/`||` sees 'no match' even when grep actually found one. This only surfaces when there's something to actually match, which is why it went unnoticed.

In practice this means:
  - In 'Update SVN tracking', the deletion block is silently skipped, so files that should be removed from SVN trunk are never deleted.
 - In 'Commit changes to SVN repository', the 'anything to commit' guard can falsely report 'No changes in trunk' and abort the whole job, even when there are real pending changes.

---

## What is the new behavior (if this is a feature change)?
`-q` option is removed from the grep call, so svn status always finishes writing before grep exits, and the pipeline's exit code correctly reflects whether grep found a match.

This may take a few seconds longer, but correctness is much more important in this case.

---

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

---

## Security impact

None.

---

## Other information
