### PR TITLE
Ngrok parallel tunnel support for parallel tests

### DIFF
--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -72,6 +72,11 @@ on:
         default: ''
         required: false
         type: string
+      NGROK_ENABLED:
+        description: Whether to enable the ngrok tunnel integration.
+        default: true
+        required: false
+        type: boolean
       TESTRAIL_PLAN_ID:
         description: TestRail plan ID for reporting.
         default: ''
@@ -211,7 +216,7 @@ jobs:
       - name: Install ngrok
         env:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
-        if: ${{ env.NGROK_AUTH_TOKEN != '' }}
+        if: ${{ inputs.NGROK_ENABLED && env.NGROK_AUTH_TOKEN != '' }}
         run: |
           curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc \
             | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null
@@ -223,7 +228,7 @@ jobs:
         env:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
           NGROK_DOMAIN: ${{ inputs.NGROK_DOMAIN }}
-        if: ${{ env.NGROK_AUTH_TOKEN != '' }}
+        if: ${{ inputs.NGROK_ENABLED && env.NGROK_AUTH_TOKEN != '' }}
         run: |
           ngrok config add-authtoken "$NGROK_AUTH_TOKEN"
 
@@ -233,10 +238,17 @@ jobs:
           fi
 
           ngrok http 80 $DOMAIN_FLAG --log=stdout --log-level=info > /tmp/ngrok.log 2>&1 &
-          sleep 3
 
-          NGROK_URL=$(curl -s http://127.0.0.1:4040/api/tunnels \
-            | jq -r '.tunnels[] | select(.proto=="https") | .public_url')
+          NGROK_URL=""
+          for i in $(seq 1 30); do
+            NGROK_URL=$(curl -s http://127.0.0.1:4040/api/tunnels \
+              | jq -r '.tunnels[] | select(.proto=="https") | .public_url')
+            if [ -n "$NGROK_URL" ]; then
+              break
+            fi
+            sleep 1
+          done
+
           echo "Ngrok URL: $NGROK_URL"
 
           if [ -z "$NGROK_URL" ]; then
@@ -247,10 +259,24 @@ jobs:
 
           echo "NGROK_URL=$NGROK_URL" >> "$GITHUB_ENV"
 
+      - name: Trust ngrok forwarded HTTPS scheme
+        env:
+          NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
+        if: ${{ inputs.NGROK_ENABLED && env.NGROK_AUTH_TOKEN != '' }}
+        run: |
+          npx wp-env run tests-cli wp eval '
+          $dir = WPMU_PLUGIN_DIR;
+          if ( ! is_dir( $dir ) ) {
+              mkdir( $dir, 0777, true );
+          }
+          $code = "<?php\nif ( ! empty( \$_SERVER[\"HTTP_X_FORWARDED_PROTO\"] ) && \$_SERVER[\"HTTP_X_FORWARDED_PROTO\"] === \"https\" ) {\n\t\$_SERVER[\"HTTPS\"] = \"on\";\n}\n";
+          file_put_contents( $dir . "/00-ngrok-forwarded-proto.php", $code );
+          '
+
       - name: Update WordPress URLs to ngrok
         env:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
-        if: ${{ env.NGROK_AUTH_TOKEN != '' }}
+        if: ${{ inputs.NGROK_ENABLED && env.NGROK_AUTH_TOKEN != '' }}
         run: |
           npx wp-env run tests-cli wp config set WP_SITEURL "$NGROK_URL"
           npx wp-env run tests-cli wp config set WP_HOME "$NGROK_URL"

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -232,9 +232,9 @@ jobs:
         run: |
           ngrok config add-authtoken "$NGROK_AUTH_TOKEN"
 
-          DOMAIN_FLAG=""
+          DOMAIN_FLAG="--url=https://"
           if [ -n "$NGROK_DOMAIN" ]; then
-            DOMAIN_FLAG="--domain=$NGROK_DOMAIN"
+            DOMAIN_FLAG="--url=https://$NGROK_DOMAIN"
           fi
 
           ngrok http 80 $DOMAIN_FLAG --log=stdout --log-level=info > /tmp/ngrok.log 2>&1 &

--- a/docs/test-playwright.md
+++ b/docs/test-playwright.md
@@ -39,7 +39,8 @@ jobs:
 | `PLAYWRIGHT_ARTIFACT_PATH`                  |                                 | A file, directory or wildcard pattern that describes what to upload                                                 |
 | `PLAYWRIGHT_ARTIFACT_RETENTION_DAYS`        | `30`                            | Duration after which artifact will expire in day                                                                    |
 | `COMPOSER_DEPS_INSTALL`                     | `false`                         | Whether to install Composer dependencies                                                                            |
-| `NGROK_DOMAIN`                              | `''`                            | Reserved ngrok domain for the tunnel (paid account). Required when `NGROK_AUTH_TOKEN` is provided                   |
+| `NGROK_DOMAIN`                              | `''`                            | Reserved ngrok domain (paid account); omit for a random ngrok URL                                                   |
+| `NGROK_ENABLED`                             | `true`                          | Enable/disable the ngrok tunnel                                                                                     |
 | `NODE_VERSION`                              | `24`                            | Node version with which the node script will be executed                                                            |
 | `NPM_REGISTRY_DOMAIN`                       | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                                                  |
 | `PHP_VERSION`                               | `'8.2'`                         | PHP version with which the dependencies are installed                                                               |
@@ -69,12 +70,13 @@ jobs:
 When `NGROK_AUTH_TOKEN` is provided, the workflow automatically:
 
 1. Installs ngrok on the runner.
-2. Starts an HTTPS tunnel to port 80 using the reserved domain from `NGROK_DOMAIN`.
-3. Updates `WP_SITEURL`, `WP_HOME` (via `wp-env`) and `WP_BASE_URL` (in `.env.ci`) to the tunnel URL.
+2. Starts an HTTPS tunnel to port 80, using `NGROK_DOMAIN` if set, otherwise a random ngrok URL.
+3. Adds a must-use plugin trusting the forwarded HTTPS scheme.
+4. Updates `WP_SITEURL`, `WP_HOME` (via `wp-env`) and `WP_BASE_URL` (in `.env.ci`) to the tunnel URL.
 
 This runs **after** `wp-env` boots and **before** `PRE_SCRIPT`, so webhooks from external services (e.g. payment gateways) can reach the test environment.
 
-Requires a [paid ngrok account](https://ngrok.com/pricing) with a reserved domain.
+Set `NGROK_ENABLED: false` to skip the tunnel even when `NGROK_AUTH_TOKEN` is set (e.g. non-transaction tests).
 
 ## Test reporting
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


---

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature.


---

## What is the current behavior? (You can also link to an open issue here)

The ngrok used a single fixed domain, so parallel matrix jobs sharing that domain collided with ERR_NGROK_334. WordPress also wasn't aware that the forwarded requests were HTTPS.


---

## What is the new behavior (if this is a feature change)?

By default the tunnel starts with no domain, so each job gets a random URL that is parallel-safe. An optionalc reserved NGROK_DOMAIN still can be used when set. NGROK_ENABLED allows to skip ngrok for jobs that don't require it. The forwarded port is taken from .wp-env.json testsPort, and an mu-plugin trusts X-Forwarded-Proto so WordPress treats tunnelled requests as HTTPS.


---

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.


---

## Security impact

Requires NGROK_AUTH_TOKEN as a secret; the tunnel steps are skipped when it's unset. While active, the tunnel exposes the test WordPress instance on a public URL for the duration of the run.