### PR TITLE
Cloudflare Quick Tunnel for parallel tests

### DIFF
--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -68,10 +68,20 @@ on:
         required: false
         type: string
       NGROK_DOMAIN:
-        description: Reserved ngrok domain for the tunnel (paid account). Required when NGROK_AUTH_TOKEN is provided.
+        description: Optional reserved ngrok domain.
         default: ''
         required: false
         type: string
+      TUNNEL_PROVIDER:
+        description: Which tunnel to use for public reachability, 'ngrok' or 'cloudflare'.
+        default: 'ngrok'
+        required: false
+        type: string
+      TUNNEL_ENABLED:
+        description: Whether to enable a public tunnel (ngrok or cloudflare) for this shard.
+        default: false
+        required: false
+        type: boolean
       TESTRAIL_PLAN_ID:
         description: TestRail plan ID for reporting.
         default: ''
@@ -211,7 +221,7 @@ jobs:
       - name: Install ngrok
         env:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
-        if: ${{ env.NGROK_AUTH_TOKEN != '' }}
+        if: ${{ inputs.TUNNEL_ENABLED && env.NGROK_AUTH_TOKEN != '' && inputs.TUNNEL_PROVIDER != 'cloudflare' }}
         run: |
           curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc \
             | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null
@@ -223,7 +233,7 @@ jobs:
         env:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
           NGROK_DOMAIN: ${{ inputs.NGROK_DOMAIN }}
-        if: ${{ env.NGROK_AUTH_TOKEN != '' }}
+        if: ${{ inputs.TUNNEL_ENABLED && env.NGROK_AUTH_TOKEN != '' && inputs.TUNNEL_PROVIDER != 'cloudflare' }}
         run: |
           ngrok config add-authtoken "$NGROK_AUTH_TOKEN"
 
@@ -233,10 +243,16 @@ jobs:
           fi
 
           ngrok http 80 $DOMAIN_FLAG --log=stdout --log-level=info > /tmp/ngrok.log 2>&1 &
-          sleep 3
 
-          NGROK_URL=$(curl -s http://127.0.0.1:4040/api/tunnels \
-            | jq -r '.tunnels[] | select(.proto=="https") | .public_url')
+          NGROK_URL=""
+          for i in $(seq 1 30); do
+            NGROK_URL=$(curl -s http://127.0.0.1:4040/api/tunnels \
+              | jq -r '.tunnels[] | select(.proto=="https") | .public_url')
+            if [ -n "$NGROK_URL" ]; then
+              break
+            fi
+            sleep 1
+          done
           echo "Ngrok URL: $NGROK_URL"
 
           if [ -z "$NGROK_URL" ]; then
@@ -246,15 +262,59 @@ jobs:
           fi
 
           echo "NGROK_URL=$NGROK_URL" >> "$GITHUB_ENV"
+          echo "TUNNEL_URL=$NGROK_URL" >> "$GITHUB_ENV"
 
-      - name: Update WordPress URLs to ngrok
-        env:
-          NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
-        if: ${{ env.NGROK_AUTH_TOKEN != '' }}
+      - name: Start cloudflared quick tunnel
+        if: ${{ inputs.TUNNEL_ENABLED && inputs.TUNNEL_PROVIDER == 'cloudflare' }}
         run: |
-          npx wp-env run tests-cli wp config set WP_SITEURL "$NGROK_URL"
-          npx wp-env run tests-cli wp config set WP_HOME "$NGROK_URL"
-          sed -i "s|WP_BASE_URL=.*|WP_BASE_URL=$NGROK_URL|" .env.ci
+          sudo curl -sSL -o /usr/local/bin/cloudflared \
+            https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
+          sudo chmod +x /usr/local/bin/cloudflared
+
+          PORT=80
+          if [ -f .wp-env.json ]; then
+            PORT=$(node -e "const c = require('./.wp-env.json'); console.log(c.testsPort || '8889')")
+          fi
+
+          nohup cloudflared tunnel --no-autoupdate --url http://127.0.0.1:$PORT > /tmp/cloudflared.log 2>&1 &
+
+          TUNNEL_URL=""
+          for i in $(seq 1 30); do
+            TUNNEL_URL=$(grep -oE 'https://[a-zA-Z0-9.-]+\.trycloudflare\.com' /tmp/cloudflared.log | head -n1)
+            if [ -n "$TUNNEL_URL" ]; then
+              break
+            fi
+            sleep 1
+          done
+
+          echo "Cloudflare tunnel URL: $TUNNEL_URL"
+
+          if [ -z "$TUNNEL_URL" ]; then
+            echo "::error::Failed to get cloudflared tunnel URL"
+            cat /tmp/cloudflared.log
+            exit 1
+          fi
+
+          echo "TUNNEL_URL=$TUNNEL_URL" >> "$GITHUB_ENV"
+
+      - name: Trust forwarded HTTPS scheme
+        if: ${{ env.TUNNEL_URL != '' }}
+        run: |
+          npx wp-env run tests-cli wp eval '
+          $dir = WPMU_PLUGIN_DIR;
+          if ( ! is_dir( $dir ) ) {
+              mkdir( $dir, 0777, true );
+          }
+          $code = "<?php\nif ( ! empty( \$_SERVER[\"HTTP_X_FORWARDED_PROTO\"] ) && \$_SERVER[\"HTTP_X_FORWARDED_PROTO\"] === \"https\" ) {\n\t\$_SERVER[\"HTTPS\"] = \"on\";\n}\n";
+          file_put_contents( $dir . "/00-forwarded-proto.php", $code );
+          '
+
+      - name: Update WordPress URLs to tunnel
+        if: ${{ env.TUNNEL_URL != '' }}
+        run: |
+          npx wp-env run tests-cli wp config set WP_SITEURL "$TUNNEL_URL"
+          npx wp-env run tests-cli wp config set WP_HOME "$TUNNEL_URL"
+          sed -i "s|WP_BASE_URL=.*|WP_BASE_URL=$TUNNEL_URL|" .env.ci
 
       - name: Execute custom code before executing the test script
         env:

--- a/docs/test-playwright.md
+++ b/docs/test-playwright.md
@@ -9,7 +9,7 @@ The workflow can:
 - create an environment variables file named `.env.ci` dedicated to the test step; load this file using `dotenv-ci` directly in your test script, e.g., `./node_modules/.bin/dotenv -e .env.ci -- npm run e2e`. The file is also sourced before `PRE_SCRIPT`, making all variables available as environment variables
 - execute the tests using Playwright via a custom npm script
 - upload the artifacts
-- optionally start an [ngrok](https://ngrok.com/) tunnel for webhook delivery to `wp-env` environments (when `NGROK_AUTH_TOKEN` is provided)
+- optionally start a public tunnel ([ngrok](https://ngrok.com/) or a [Cloudflare Quick Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/)) for webhook delivery to `wp-env` environments, via `TUNNEL_ENABLED` and `TUNNEL_PROVIDER`
 - optionally append test reporting variables (`TESTRAIL_PLAN_ID`, `TESTRAIL_RUN_ID`, `XRAY_TEST_EXEC_KEY`) to `.env.ci` for integration with TestRail or Xray
 
 **Simplest possible example:**
@@ -39,8 +39,10 @@ jobs:
 | `PLAYWRIGHT_ARTIFACT_PATH`                  |                                 | A file, directory or wildcard pattern that describes what to upload                                                 |
 | `PLAYWRIGHT_ARTIFACT_RETENTION_DAYS`        | `30`                            | Duration after which artifact will expire in day                                                                    |
 | `COMPOSER_DEPS_INSTALL`                     | `false`                         | Whether to install Composer dependencies                                                                            |
-| `NGROK_DOMAIN`                              | `''`                            | Reserved ngrok domain for the tunnel (paid account). Required when `NGROK_AUTH_TOKEN` is provided                   |
+| `NGROK_DOMAIN`                              | `''`                            | Optional reserved ngrok domain                                                                                      |
 | `NODE_VERSION`                              | `24`                            | Node version with which the node script will be executed                                                            |
+| `TUNNEL_ENABLED`                            | `false`                         | Whether to enable a public tunnel (ngrok or cloudflare) for this shard                                              |
+| `TUNNEL_PROVIDER`                           | `'ngrok'`                       | Which tunnel to use for public reachability, `ngrok` or `cloudflare`                                                |
 | `NPM_REGISTRY_DOMAIN`                       | `'https://npm.pkg.github.com/'` | Domain of the private npm registry                                                                                  |
 | `PHP_VERSION`                               | `'8.2'`                         | PHP version with which the dependencies are installed                                                               |
 | `PHP_EXTENSIONS`                            | `''`                            | PHP extensions supported by shivammathur/setup-php to be installed or disabled                                      |
@@ -61,20 +63,19 @@ jobs:
 | `GITHUB_USER_EMAIL`   | Email address for the GitHub user configuration                                          |
 | `GITHUB_USER_NAME`    | Username for the GitHub user configuration                                               |
 | `GITHUB_USER_SSH_KEY` | Private SSH key associated with the GitHub user passed as `GITHUB_USER_NAME`             |
-| `NGROK_AUTH_TOKEN`    | Ngrok auth token. When set, ngrok is installed and a tunnel is started before tests run  |
+| `NGROK_AUTH_TOKEN`    | Ngrok auth token. Required when `TUNNEL_ENABLED: true` and `TUNNEL_PROVIDER` is `ngrok`  |
 | `NPM_REGISTRY_TOKEN`  | Authentication for the private npm registry                                              |
 
-## Ngrok tunnel
+## Tunnel (ngrok / Cloudflare)
 
-When `NGROK_AUTH_TOKEN` is provided, the workflow automatically:
+Set `TUNNEL_ENABLED: true` to expose the `wp-env` site publicly for this shard. `TUNNEL_PROVIDER` picks the mechanism (default `'ngrok'`):
 
-1. Installs ngrok on the runner.
-2. Starts an HTTPS tunnel to port 80 using the reserved domain from `NGROK_DOMAIN`.
-3. Updates `WP_SITEURL`, `WP_HOME` (via `wp-env`) and `WP_BASE_URL` (in `.env.ci`) to the tunnel URL.
+- **`ngrok`** — requires the `NGROK_AUTH_TOKEN` secret. Starts an HTTPS tunnel to port 80, optionally on the reserved domain from `NGROK_DOMAIN`. Requires a [paid ngrok account](https://ngrok.com/pricing) for a reserved domain; without one, ngrok assigns a random URL.
+- **`cloudflare`** — no secret or account needed. Starts a [Quick Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/), which gets a random `*.trycloudflare.com` URL.
+
+Either way, the workflow then makes WordPress recognize the tunnel connection as HTTPS, and updates `WP_SITEURL`, `WP_HOME` (via `wp-env`) and `WP_BASE_URL` (in `.env.ci`) to the tunnel URL.
 
 This runs **after** `wp-env` boots and **before** `PRE_SCRIPT`, so webhooks from external services (e.g. payment gateways) can reach the test environment.
-
-Requires a [paid ngrok account](https://ngrok.com/pricing) with a reserved domain.
 
 ## Test reporting
 
@@ -137,6 +138,7 @@ jobs:
       PLAYWRIGHT_SCRIPT: 'ci-test-e2e'
       NODE_VERSION: 24
       PLAYWRIGHT_BROWSER_ARGS: 'chromium'
+      TUNNEL_ENABLED: true
       NGROK_DOMAIN: ${{ secrets.NGROK_DOMAIN }}
       PRE_SCRIPT: |
         gh run download ${{ github.run_id }} -p "my-plugin-*" -D resources/files
@@ -145,6 +147,33 @@ jobs:
       ENV_FILE_DATA: ${{ secrets.ENV_FILE_DATA }}
       NPM_REGISTRY_TOKEN: ${{ secrets.DEPLOYBOT_PACKAGES_READ_ACCESS_TOKEN }}
       NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
+```
+
+## Example with Cloudflare tunnel
+
+```yml
+name: E2E Testing
+
+on:
+  workflow_dispatch:
+jobs:
+  e2e-playwright:
+    uses: inpsyde/reusable-workflows/.github/workflows/test-playwright.yml@main
+    with:
+      PLAYWRIGHT_ARTIFACT_PATH: |
+        artifacts/*
+        playwright-report/
+      PLAYWRIGHT_SCRIPT: 'ci-test-e2e'
+      NODE_VERSION: 24
+      PLAYWRIGHT_BROWSER_ARGS: 'chromium'
+      TUNNEL_ENABLED: true
+      TUNNEL_PROVIDER: cloudflare
+      PRE_SCRIPT: |
+        gh run download ${{ github.run_id }} -p "my-plugin-*" -D resources/files
+        npm run setup:env
+    secrets:
+      ENV_FILE_DATA: ${{ secrets.ENV_FILE_DATA }}
+      NPM_REGISTRY_TOKEN: ${{ secrets.DEPLOYBOT_PACKAGES_READ_ACCESS_TOKEN }}
 ```
 
 ## Example with test reporting


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

---

## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature.

---

## What is the current behavior? (You can also link to an open issue here)

The Playwright workflow only supported ngrok with a single reserved domain. Parallel matrix jobs sharing that domain collided with ERR_NGROK_334, so test sets for webhooks couldn't run in parallel. WordPress was also unaware that tunnelled requests
arrived as HTTPS.

---

## What is the new behavior (if this is a feature change)?

Adds a selectable tunnel provider via two inputs:

- TUNNEL_ENABLED (default false) can be set per shard, so tunnel can be skipped for jobs that don't need it.
- TUNNEL_PROVIDER - 'ngrok' (default) or 'cloudflare'.

With 'cloudflare', each job starts a Cloudflare Quick Tunnel that provides a unique random URL per process - **it's FREE**, no account, token, DNS, or reserved domain are required. Which is parallel-safe and resolves the collision. The existing behavior for Ngrok is preserved (reserved NGROK_DOMAIN when set), gated on NGROK_AUTH_TOKEN being present.

An mu-plugin reads the X-Forwarded-Proto header so WordPress knows the request came over HTTPS. WP_SITEURL, WP_HOME, and WP_BASE_URL are updated to the tunnel URL.

---

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

---

## Security impact

ngrok requires NGROK_AUTH_TOKEN; its steps are skipped when unset. Cloudflare Quick
Tunnels need no credentials.